### PR TITLE
initialization with stub options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 
 ## Features
 
+* Initialization with Stub, [see details here](https://github.com/scm-spain/boros-tcf-stub)
+ 
 ## Technical features
 
 ## Usage

--- a/src/main/application/TcfApiV2.js
+++ b/src/main/application/TcfApiV2.js
@@ -1,3 +1,4 @@
+/* eslint-disable standard/no-callback-literal */
 /**
  * TCF Api Facade for the Version 2
  */

--- a/src/main/infrastructure/bootstrap/TcfApiInitializer.js
+++ b/src/main/infrastructure/bootstrap/TcfApiInitializer.js
@@ -30,15 +30,15 @@ import {ChangeUiVisibleUseCase} from '../../application/services/ui/ChangeUiVisi
 import {RemoveEventListenerUseCase} from '../../application/services/event/RemoveEventListenerUseCase'
 import {ObservableEventStatus} from '../../domain/service/ObservableEventStatus'
 import {EventStatusService} from '../../domain/service/EventStatusService'
+import {TcfApiV2} from '../../application/TcfApiV2'
 
 class TcfApiInitializer {
   static init() {
     iocModule({
       module: IOC_MODULE,
       initializer: ({singleton}) => {
-        singleton('window', () => window)
-
         singleton(TcfApiController, () => new TcfApiController())
+        singleton(TcfApiV2, () => new TcfApiV2())
 
         singleton(CmpStatusRepository, () => new InMemoryCmpStatusRepository())
         singleton(
@@ -78,7 +78,9 @@ class TcfApiInitializer {
       }
     })
 
-    TcfApiRegistryService.start()
+    const registryService = new TcfApiRegistryService()
+    registryService.register()
+
     return new BorosTcf()
   }
 }

--- a/src/main/infrastructure/controller/TcfApiController.js
+++ b/src/main/infrastructure/controller/TcfApiController.js
@@ -1,32 +1,31 @@
 import {TcfApiV2} from '../../application/TcfApiV2'
+import {inject} from '../../core/ioc/ioc'
 
 class TcfApiController {
-  constructor() {
-    this._tcfApi = undefined
+  constructor({tcfApi = inject(TcfApiV2)} = {}) {
+    this._tcfApi = tcfApi
   }
 
-  process(command, version, callback, parameter) {
-    // TODO just a prototype
-    if (version !== 2) {
-      console.log('TcfApiController: unaccepted version')
-      return
+  process(command, version, callback = () => null, parameter) {
+    if (version !== 2 || !this._tcfApi[command]) {
+      this._reject(callback)
+    } else {
+      try {
+        return this._tcfApi[command](callback, parameter)
+      } catch (error) {
+        this._reject(callback)
+      }
     }
-    if (typeof callback !== 'function') {
-      console.log('TcfApiController: callback must be a function')
-      return
-    }
-    // initialize the TcfApiV2 if not initialized yet,
-    // this initializes all the dependencies only when called at the first time
-    this._tcfApi = this._tcfApi || new TcfApiV2()
-    if (!this._tcfApi[command]) {
-      callback(null, false)
-    }
+  }
+
+  get api() {
+    return this._tcfApi
+  }
+
+  _reject(callback) {
     try {
-      this._tcfApi[command](callback, parameter)
-    } catch (error) {
-      console.log(`TcfApiController: error processing [${command}]`, error)
       callback(null, false)
-    }
+    } catch (ignored) {}
   }
 }
 

--- a/src/test/infrastructure/bootstrap/TcfApiInitializerTest.js
+++ b/src/test/infrastructure/bootstrap/TcfApiInitializerTest.js
@@ -1,27 +1,36 @@
-import 'jsdom-global/register'
+import jsdom from 'jsdom-global'
 import {expect} from 'chai'
 import {TcfApiInitializer} from '../../../main/infrastructure/bootstrap/TcfApiInitializer'
-import {waitCondition} from '../../../main/core/service/waitCondition'
 import {BorosTcf} from '../../../main/application/BorosTcf'
+import {TcfApiV2} from '../../../main/application/TcfApiV2'
 
 describe('TcfApiInitializer', () => {
+  beforeEach(() => jsdom())
+
   it('should return instance of BorosTcf with the methods', () => {
     const borosTcf = TcfApiInitializer.init()
     expect(borosTcf instanceof BorosTcf).to.be.true
-    expect(typeof borosTcf.getVendorList === 'function').to.be.true
-    expect(typeof borosTcf.saveUserConsent === 'function').to.be.true
-    expect(typeof borosTcf.loadUserConsent === 'function').to.be.true
-    expect(typeof borosTcf.saveUserConsent === 'function').to.be.true
   })
   it('should register the window.__tcfapi command consumer', () => {
     TcfApiInitializer.init()
     const tcfapi = window.__tcfapi
     expect(tcfapi).to.be.a('function')
   })
-  it('should register the __tcfapiLocator iframe', () => {
+  it('should process pending commands', done => {
+    const pending = [() => done()]
+    window.__tcfapi = command => {
+      if (command === 'pending') return pending
+    }
     TcfApiInitializer.init()
-    return waitCondition({
-      condition: () => window.frames.__tcfapiLocator
-    })
+  })
+  it('should process the onReady callback', done => {
+    const onReady = api => {
+      expect(api instanceof TcfApiV2).to.be.true
+      done()
+    }
+    window.__tcfapi = command => {
+      if (command === 'onReady') return onReady
+    }
+    TcfApiInitializer.init()
   })
 })


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

This changes the Boros TCF `window.__tcfapi` initialization according to the [Boros TCF] Stub(https://github.com/scm-spain/boros-tcf-stub) options

## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3286

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

* If any `window.__tcfapi` call is performed before initialization and saved as pending call in the stub, it will be processed after registering the real `window.__tcfapi` implementation

* If the stub has an `onReady` callback registered, it will be processed after registering the real `window.__tcfapi` implementation but before processing any pending command

## Further considerations
<!--- If applies, add information of breaking changes, agreed deploy timings, ...  -->

* boros-tcf is no more registering the `__tfcapiLocator` frame according to IAB specifications for the Stub's responsability 

* see https://github.com/scm-spain/boros-tcf-stub/pull/2

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/jU2m0JwzJti3Yoylc5/giphy.gif)