### PR TITLE
Using PolicyVersion in VendorList version

### DIFF
--- a/src/main/domain/consent/LoadConsentService.js
+++ b/src/main/domain/consent/LoadConsentService.js
@@ -35,6 +35,10 @@ export class LoadConsentService {
 
     const newVendorList = await this._vendorListRepository.getVendorList()
 
+    if (newVendorList.policyVersion !== existingConsent.policyVersion) {
+      return this._consentFactory.createEmptyConsent()
+    }
+
     const result = await this._isValidAndSaveNewConsent({
       newVendorList,
       consent: existingConsent

--- a/src/main/domain/vendorlist/VendorList.js
+++ b/src/main/domain/vendorlist/VendorList.js
@@ -1,6 +1,7 @@
 class VendorList {
-  constructor({version, language, value}) {
+  constructor({version, policyVersion, language, value}) {
     this._version = version
+    this._policyVersion = policyVersion
     this._language = language
     this._value = value
   }
@@ -11,6 +12,10 @@ class VendorList {
 
   get language() {
     return this._language
+  }
+
+  get policyVersion() {
+    return this._policyVersion
   }
 
   get value() {

--- a/src/main/infrastructure/repository/iab/IABVendorListRepository.js
+++ b/src/main/infrastructure/repository/iab/IABVendorListRepository.js
@@ -14,6 +14,7 @@ export class IABVendorListRepository extends VendorListRepository {
     await gvl.readyPromise
     const vendorListJson = gvl.getJson()
     return new VendorList({
+      policyVersion: vendorListJson.tcfPolicyVersion,
       version: vendorListJson.vendorListVersion,
       value: vendorListJson
     })

--- a/src/main/infrastructure/service/IABConsentDecoderService.js
+++ b/src/main/infrastructure/service/IABConsentDecoderService.js
@@ -18,8 +18,11 @@ class IABConsentDecoderService extends ConsentDecoderService {
     }
 
     const tcModel = TCString.decode(encodedConsent)
+    //   console.log('tcModel ' + JSON.stringify(tcModel))
 
     const model = {
+      vendorListVersion: tcModel.vendorListVersion,
+      policyVersion: tcModel.policyVersion,
       vendor: {
         consents: mapToModel(tcModel.vendorConsents),
         legitimateInterests: mapToModel(tcModel.vendorLegitimateInterests)
@@ -43,7 +46,6 @@ class IABConsentDecoderService extends ConsentDecoderService {
     }
 
     return {
-      vendorListVersion: tcModel.vendorListVersion,
       ...model
     }
   }

--- a/src/main/infrastructure/service/IABConsentDecoderService.js
+++ b/src/main/infrastructure/service/IABConsentDecoderService.js
@@ -18,7 +18,6 @@ class IABConsentDecoderService extends ConsentDecoderService {
     }
 
     const tcModel = TCString.decode(encodedConsent)
-    //   console.log('tcModel ' + JSON.stringify(tcModel))
 
     const model = {
       vendorListVersion: tcModel.vendorListVersion,

--- a/src/test/application/BorosTcfTest.js
+++ b/src/test/application/BorosTcfTest.js
@@ -201,6 +201,7 @@ describe('BorosTcf', () => {
         }
       }
       const givenVendorList = {
+        policyVersion: 2,
         vendors: {
           1: {},
           2: {},
@@ -241,6 +242,7 @@ describe('BorosTcf', () => {
         }
       }
       const givenVendorList = {
+        policyVersion: 2,
         vendors: {
           1: {},
           2: {},
@@ -265,7 +267,7 @@ describe('BorosTcf', () => {
       expect(consentModel.vendor.consents).to.be.deep.equal({})
       expect(consentModel.vendor.legitimateInterests).to.be.deep.equal({})
     })
-    it('should return no valid and NOT  new consent is merged and new venders are set to true,  when  user had fine-granularity (the UI should be shown)', async () => {
+    it('should return no valid and a new consent is merged and new vendors are set to false,  when  user had fine-granularity (the UI should be shown)', async () => {
       const givenVendorAllDenied = {
         consents: {
           1: false,
@@ -277,6 +279,7 @@ describe('BorosTcf', () => {
         }
       }
       const givenVendorList = {
+        policyVersion: 2,
         vendors: {
           1: {},
           2: {},
@@ -291,7 +294,7 @@ describe('BorosTcf', () => {
         .mock(CookieStorage, cookieStorageMock)
         .mock(VendorListRepository, vendorListRepository)
         .init()
-      // save consent wit consent for all vendors
+      // save consent with consent for all vendors
       await borosTcf.saveUserConsent({
         purpose: givenAcceptedAllPurpose,
         vendor: givenVendorAllDenied
@@ -307,6 +310,7 @@ describe('BorosTcf', () => {
     })
     it('should return valid if vendor list version are the same', async () => {
       const givenVendorList = {
+        policyVersion: 2,
         version: 36,
         noMattersIfThereIsNoVendorObject: {}
       }
@@ -314,6 +318,10 @@ describe('BorosTcf', () => {
         getVendorList: () => givenVendorList
       }
 
+      cookieStorageMock.save({
+        data:
+          'CO1wTaiO1wTaiCBADAENAkCAAAAAAAAAAAAAABEAAiAA.IF7NX2T5OI2vjq2ZdF7BEaYwfZxyigMgShhQIsS8NwIeFbBoGP2AgHBG4JCQAGBAkkACBAQIsHGBcCQABgIgRiRCMQEmMjzNKBJJAggkbM0FACDVmnsHS3ZCY70--u__bMAA'
+      })
       const borosTcf = TestableTcfApiInitializer.create()
         .mock(CookieStorage, cookieStorageMock)
         .mock(VendorListRepository, vendorListRepository)
@@ -326,6 +334,33 @@ describe('BorosTcf', () => {
 
       const consent = await borosTcf.loadUserConsent()
       expect(consent.valid).to.be.true
+    })
+    it('should return no valid if tcfPolicyVersion version are the different and create a new empty consent', async () => {
+      const givenVendorList = {
+        tcfPolicyVersion: 3,
+        version: 36,
+        noMattersIfThereIsNoVendorObject: {}
+      }
+      const vendorListRepository = {
+        getVendorList: () => givenVendorList
+      }
+
+      cookieStorageMock.save({
+        data:
+          'CO1wTaiO1wTaiCBADAENAkCAAAAAAAAAAAAAABEAAiAA.IF7NX2T5OI2vjq2ZdF7BEaYwfZxyigMgShhQIsS8NwIeFbBoGP2AgHBG4JCQAGBAkkACBAQIsHGBcCQABgIgRiRCMQEmMjzNKBJJAggkbM0FACDVmnsHS3ZCY70--u__bMAA'
+      })
+      const borosTcf = TestableTcfApiInitializer.create()
+        .mock(CookieStorage, cookieStorageMock)
+        .mock(VendorListRepository, vendorListRepository)
+        .init()
+
+      await borosTcf.saveUserConsent({
+        purpose: givenPurpose,
+        vendor: givenVendor
+      })
+
+      const consent = await borosTcf.loadUserConsent()
+      expect(consent.valid).to.be.false
     })
   })
   describe('uiVisible', () => {

--- a/src/test/application/BorosTcfTest.js
+++ b/src/test/application/BorosTcfTest.js
@@ -335,9 +335,9 @@ describe('BorosTcf', () => {
       const consent = await borosTcf.loadUserConsent()
       expect(consent.valid).to.be.true
     })
-    it('should return no valid if tcfPolicyVersion version are the different and create a new empty consent', async () => {
+    it('should return no valid consent if tcfPolicyVersion version are the different and create a new empty consent', async () => {
       const givenVendorList = {
-        tcfPolicyVersion: 3,
+        policyVersion: 3,
         version: 36,
         noMattersIfThereIsNoVendorObject: {}
       }
@@ -361,6 +361,10 @@ describe('BorosTcf', () => {
 
       const consent = await borosTcf.loadUserConsent()
       expect(consent.valid).to.be.false
+      expect(consent.vendor.consents).to.be.deep.equal({})
+      expect(consent.vendor.legitimateInterests).to.be.deep.equal({})
+      expect(consent.purpose.consents).to.be.deep.equal({})
+      expect(consent.purpose.legitimateInterests).to.be.deep.equal({})
     })
   })
   describe('uiVisible', () => {

--- a/src/test/application/BorosTcfTest.js
+++ b/src/test/application/BorosTcfTest.js
@@ -230,7 +230,7 @@ describe('BorosTcf', () => {
       expect(consentModel.vendor.consents[3]).to.be.true
       expect(consentModel.vendor.legitimateInterests[3]).to.be.true
     })
-    it('should return valid and save new consent, when user had denied for all partners (new partners are automatically denied)', async () => {
+    it('should return valid and save a new consent, when user had denied for all partners (new partners are automatically denied)', async () => {
       const givenVendorAllDenied = {
         consents: {
           1: false,
@@ -257,7 +257,7 @@ describe('BorosTcf', () => {
         .mock(CookieStorage, cookieStorageMock)
         .mock(VendorListRepository, vendorListRepository)
         .init()
-      // save consent wit consent for all vendors
+
       await borosTcf.saveUserConsent({
         purpose: givenAcceptedAllPurpose,
         vendor: givenVendorAllDenied
@@ -268,7 +268,7 @@ describe('BorosTcf', () => {
       expect(consentModel.vendor.legitimateInterests).to.be.deep.equal({})
     })
     it('should return no valid and a new consent is merged and new vendors are set to false,  when  user had fine-granularity (the UI should be shown)', async () => {
-      const givenVendorAllDenied = {
+      const givenVendorWithFineGranularity = {
         consents: {
           1: false,
           2: true
@@ -294,10 +294,10 @@ describe('BorosTcf', () => {
         .mock(CookieStorage, cookieStorageMock)
         .mock(VendorListRepository, vendorListRepository)
         .init()
-      // save consent with consent for all vendors
+
       await borosTcf.saveUserConsent({
         purpose: givenAcceptedAllPurpose,
-        vendor: givenVendorAllDenied
+        vendor: givenVendorWithFineGranularity
       })
       const consentModel = await borosTcf.loadUserConsent()
       expect(consentModel.valid).to.be.false

--- a/src/test/application/BorosTcfTest.js
+++ b/src/test/application/BorosTcfTest.js
@@ -335,7 +335,7 @@ describe('BorosTcf', () => {
       const consent = await borosTcf.loadUserConsent()
       expect(consent.valid).to.be.true
     })
-    it('should return no valid consent if tcfPolicyVersion version are the different and create a new empty consent', async () => {
+    it('should return no valid consent if tcfPolicyVersion version are different and return a new empty consent', async () => {
       const givenVendorList = {
         policyVersion: 3,
         version: 36,

--- a/src/test/domain/consent/LoadConsentServiceTest.js
+++ b/src/test/domain/consent/LoadConsentServiceTest.js
@@ -57,7 +57,11 @@ describe('LoadConsentService Should', () => {
     })
 
     it('when retrieved vendor list have the same version we return valid consent and a copy of existing consent', async () => {
-      const vendorList = new VendorList({version: 43, value: {}})
+      const vendorList = new VendorList({
+        version: 43,
+        policyVersion: 2,
+        value: {}
+      })
       const vendorListRepositoryWithTheSameVersion = {
         getVendorList: () => vendorList
       }

--- a/src/test/infrastructure/service/IABConsentDecoderServiceTest.js
+++ b/src/test/infrastructure/service/IABConsentDecoderServiceTest.js
@@ -9,7 +9,9 @@ describe('IABConsentDecoderService Should', () => {
     const encodedConsent =
       'CLcVDxRMWfGmWAVAHCENAXCkAKDAADnAABRgA5mdfCKZuYJez-NQm0TBMYA4oCAAGQYIAAAAAAEAIAEgAA.argAC0gAAAAAAAAAAAA'
     const consent = iabConsentDecoderService.decode({encodedConsent})
+
     expect(consent.vendorListVersion).equal(23)
+    expect(consent.policyVersion).equal(2)
     expect(consent.vendor.consents).exist
     expect(consent.vendor.legitimateInterests).exist
     expect(consent.purpose.consents).exist

--- a/src/test/infrastructure/service/IABConsentEncoderServiceTest.js
+++ b/src/test/infrastructure/service/IABConsentEncoderServiceTest.js
@@ -42,6 +42,6 @@ describe('IABConsentEncoderService Should', () => {
     expect(consent.purpose.legitimateInterests).to.be.deep.equal(
       decoded.purpose.legitimateInterests
     )
-    expect(consent.policyVersion).to.be.deep.equal(decoded.policyVersion)
+    expect(consent.policyVersion).equal(decoded.policyVersion)
   })
 })

--- a/src/test/infrastructure/service/IABConsentEncoderServiceTest.js
+++ b/src/test/infrastructure/service/IABConsentEncoderServiceTest.js
@@ -9,6 +9,7 @@ describe('IABConsentEncoderService Should', () => {
       gvlFactory: new GVLFactory()
     })
     const consent = {
+      policyVersion: 2,
       vendor: {
         consents: {
           1: true,
@@ -41,5 +42,6 @@ describe('IABConsentEncoderService Should', () => {
     expect(consent.purpose.legitimateInterests).to.be.deep.equal(
       decoded.purpose.legitimateInterests
     )
+    expect(consent.policyVersion).to.be.deep.equal(decoded.policyVersion)
   })
 })

--- a/src/test/tcfv2/AddEventListenerCommandTest.js
+++ b/src/test/tcfv2/AddEventListenerCommandTest.js
@@ -117,7 +117,8 @@ describe('AddEventListenerCommand Should', () => {
       }
     }
     const givenVendorList = {
-      version: 44
+      version: 44,
+      policyVersion: 2
     }
     const vendorListRepository = {
       getVendorList: () => givenVendorList
@@ -184,6 +185,7 @@ describe('AddEventListenerCommand Should', () => {
         }
       }
       const givenVendorList = {
+        policyVersion: 2,
         vendors: {
           1: {},
           2: {},


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->
- When  PolicyVersion in stored consent, is different from the PolicyVersion from the retrieved GVL, loadUserConsent should return a  not valid consent and an empty consent
## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->
https://jira.scmspain.com/browse/PSP-3285
## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->
- Return a no valid consent  when PolicyVersion is different
## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/26FKXOovtGzURT0nm/giphy.gif)