### PR TITLE
Adding isNew for helping UI

### DIFF
--- a/src/main/domain/consent/Consent.js
+++ b/src/main/domain/consent/Consent.js
@@ -1,9 +1,16 @@
 export class Consent {
-  constructor({vendor, purpose, specialFeatures, valid = false}) {
+  constructor({
+    vendor,
+    purpose,
+    specialFeatures,
+    valid = false,
+    isNew = false
+  }) {
     this._vendor = vendor
     this._purpose = purpose
     this._specialFeatures = specialFeatures
     this._valid = valid
+    this._isNew = isNew
   }
 
   get vendor() {
@@ -18,12 +25,21 @@ export class Consent {
     return this._specialFeatures
   }
 
+  get isNew() {
+    return this._isNew
+  }
+
+  get valid() {
+    return this._valid
+  }
+
   toJSON() {
     return {
       vendor: this._vendor,
       purpose: this._purpose,
       specialFeatures: this._specialFeatures,
-      valid: this._valid
+      valid: this._valid,
+      isNew: this._isNew
     }
   }
 }

--- a/src/main/domain/consent/ConsentFactory.js
+++ b/src/main/domain/consent/ConsentFactory.js
@@ -14,9 +14,10 @@ export class ConsentFactory {
 
   async createEmptyConsent() {
     const encodedValue = await this._consentEncoderService.encode()
-    return new Consent(
-      this._consentDecoderService.decode({encodedConsent: encodedValue})
-    )
+    const decodedValue = this._consentDecoderService.decode({
+      encodedConsent: encodedValue
+    })
+    return new Consent({...decodedValue, isNew: true})
   }
 
   createConsent({vendor, purpose, specialFeatures, valid}) {

--- a/src/test/application/BorosTcfTest.js
+++ b/src/test/application/BorosTcfTest.js
@@ -182,14 +182,16 @@ describe('BorosTcf', () => {
           expect(consentModel.vendor).to.deep.equal(givenVendor)
           expect(consentModel.purpose).to.deep.equal(givenPurpose)
           expect(consentModel.valid).to.be.true
+          expect(consentModel.isNew).to.be.false
         })
     })
     it('should load an empty consent if there was not saved user consent and is consent should be not valid', async () => {
       const consentModel = await borosTcf.loadUserConsent()
       expect(consentModel).to.not.be.undefined
       expect(consentModel.valid).to.be.false
+      expect(consentModel.isNew).to.be.true
     })
-    it('should return valid  and save new consent, when user had consent for all partners (new partners are automatically accepted)', async () => {
+    it('should return valid  and save new consent(all accepted), when user had consent for all partners (new partners are automatically accepted)', async () => {
       const givenVendorAllAccepted = {
         consents: {
           1: true,
@@ -223,6 +225,7 @@ describe('BorosTcf', () => {
       })
       const consentModel = await borosTcfMocked.loadUserConsent()
       expect(consentModel.valid).to.be.true
+      expect(consentModel.isNew).to.be.false
       expect(consentModel.vendor.consents[1]).to.be.true
       expect(consentModel.vendor.legitimateInterests[1]).to.be.true
       expect(consentModel.vendor.consents[2]).to.be.true
@@ -230,7 +233,7 @@ describe('BorosTcf', () => {
       expect(consentModel.vendor.consents[3]).to.be.true
       expect(consentModel.vendor.legitimateInterests[3]).to.be.true
     })
-    it('should return valid and save a new consent, when user had denied for all partners (new partners are automatically denied)', async () => {
+    it('should return valid and save a new consent(all denied), when user had denied for all partners (new partners are automatically denied)', async () => {
       const givenVendorAllDenied = {
         consents: {
           1: false,
@@ -264,6 +267,7 @@ describe('BorosTcf', () => {
       })
       const consentModel = await borosTcf.loadUserConsent()
       expect(consentModel.valid).to.be.true
+      expect(consentModel.isNew).to.be.false
       expect(consentModel.vendor.consents).to.be.deep.equal({})
       expect(consentModel.vendor.legitimateInterests).to.be.deep.equal({})
     })
@@ -301,6 +305,7 @@ describe('BorosTcf', () => {
       })
       const consentModel = await borosTcf.loadUserConsent()
       expect(consentModel.valid).to.be.false
+      expect(consentModel.isNew).to.be.false
       expect(consentModel.vendor.consents[1]).to.be.false
       expect(consentModel.vendor.legitimateInterests[1]).to.be.false
       expect(consentModel.vendor.consents[2]).to.be.true
@@ -361,6 +366,7 @@ describe('BorosTcf', () => {
 
       const consent = await borosTcf.loadUserConsent()
       expect(consent.valid).to.be.false
+      expect(consent.isNew).to.be.true
       expect(consent.vendor.consents).to.be.deep.equal({})
       expect(consent.vendor.legitimateInterests).to.be.deep.equal({})
       expect(consent.purpose.consents).to.be.deep.equal({})

--- a/src/test/domain/consent/ConsentTest.js
+++ b/src/test/domain/consent/ConsentTest.js
@@ -1,0 +1,15 @@
+import {expect} from 'chai'
+import {Consent} from '../../../main/domain/consent/Consent'
+describe('Consent should', () => {
+  it('Create valid and isNew to default values', () => {
+    const vendor = {}
+    const purpose = {}
+    const specialFeatures = {}
+    const consent = new Consent({vendor, purpose, specialFeatures})
+    expect(consent.isNew).to.be.false
+    expect(consent.valid).to.be.false
+    expect(consent.purpose).to.be.deep.equal(purpose)
+    expect(consent.specialFeatures).to.be.deep.equal(specialFeatures)
+    expect(consent.vendor).to.be.deep.equal(vendor)
+  })
+})


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->
- Adding isNew to consent returned by Boros.  When consent not was stored previously or  has been invalidated by privacy version.
## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->
https://jira.scmspain.com/browse/PSP-3320

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/3otPovknltwgrSHJDO/giphy.gif)