### PR TITLE
Adding version behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "jsdom": "16.2.2",
     "jsdom-global": "3.0.2",
     "mocha": "5.2.0",
-    "mocha-param": "^2.0.1",
+    "mocha-param": "2.0.1",
     "nock": "12.0.3",
     "nyc": "15.0.0",
     "sinon": "9.0.2",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "jsdom": "16.2.2",
     "jsdom-global": "3.0.2",
     "mocha": "5.2.0",
+    "mocha-param": "^2.0.1",
     "nock": "12.0.3",
     "nyc": "15.0.0",
     "sinon": "9.0.2",

--- a/src/main/infrastructure/controller/TcfApiController.js
+++ b/src/main/infrastructure/controller/TcfApiController.js
@@ -7,7 +7,7 @@ class TcfApiController {
   }
 
   process(command, version, callback = () => null, parameter) {
-    if (version !== 2 || !this._tcfApi[command]) {
+    if (!this._isVersionCorrect(version) || !this._tcfApi[command]) {
       this._reject(callback)
     } else {
       try {
@@ -26,6 +26,16 @@ class TcfApiController {
     try {
       callback(null, false)
     } catch (ignored) {}
+  }
+
+  _isVersionCorrect(version) {
+    if (!version) {
+      return true
+    }
+    if (version !== 2) {
+      return false
+    }
+    return true
   }
 }
 

--- a/src/main/infrastructure/controller/TcfApiController.js
+++ b/src/main/infrastructure/controller/TcfApiController.js
@@ -7,7 +7,7 @@ class TcfApiController {
   }
 
   process(command, version, callback = () => null, parameter) {
-    if (!this._isVersionCorrect(version) || !this._tcfApi[command]) {
+    if (!this._isCorrectVersion(version) || !this._tcfApi[command]) {
       this._reject(callback)
     } else {
       try {
@@ -28,14 +28,8 @@ class TcfApiController {
     } catch (ignored) {}
   }
 
-  _isVersionCorrect(version) {
-    if (!version) {
-      return true
-    }
-    if (version !== 2) {
-      return false
-    }
-    return true
+  _isCorrectVersion(version) {
+    return !(version && version !== 2)
   }
 }
 

--- a/src/test/infrastructure/controller/TcfApiControllerTest.js
+++ b/src/test/infrastructure/controller/TcfApiControllerTest.js
@@ -16,7 +16,7 @@ describe('TcfApiController should', () => {
     )
 
     itParam(
-      'for command ${name} If the version is 2, callback shall be invoked with  true for the success parameter and TC data parameter should be returned',
+      'for command ${value} If the version is 2, callback shall be invoked with  true for the success parameter and TC data parameter should be returned',
       commandListOk,
       async value => {
         TestableTcfApiInitializer.create().init()

--- a/src/test/infrastructure/controller/TcfApiControllerTest.js
+++ b/src/test/infrastructure/controller/TcfApiControllerTest.js
@@ -1,6 +1,8 @@
+/* eslint-disable no-template-curly-in-string */
 import {TestableTcfApiInitializer} from '../../testable/infrastructure/bootstrap/TestableTcfApiInitializer'
 import {expect} from 'chai'
 import itParam from 'mocha-param'
+
 describe('TcfApiController should', () => {
   describe('version behaviour', () => {
     const commandList = [
@@ -14,90 +16,90 @@ describe('TcfApiController should', () => {
     )
 
     itParam(
-      'If the version is 2, callback shall be invoked with  true for the success parameter and TC data parameter should be returned',
+      'for command ${name} If the version is 2, callback shall be invoked with  true for the success parameter and TC data parameter should be returned',
       commandListOk,
-      async name => {
+      async value => {
         TestableTcfApiInitializer.create().init()
         const {tcData, success} = await new Promise(resolve =>
-          window.__tcfapi(name, 2, (tcData, success) => {
+          window.__tcfapi(value, 2, (tcData, success) => {
             resolve({tcData, success})
           })
         )
         expect(tcData.tcfPolicyVersion).equal(2)
         expect(success).equal(
           true,
-          'Success should be true for command: ' + name
+          'Success should be true for command: ' + value
         )
       }
     )
     itParam(
-      'If the version is 1, callback shall be invoked with  false for the success parameter and a null argument for TC data parameter',
+      'for command ${value}, If the version is 1, callback shall be invoked with  false for the success parameter and a null argument for TC data parameter',
       commandList,
-      async name => {
+      async value => {
         TestableTcfApiInitializer.create().init()
         const {tcData, success} = await new Promise(resolve =>
-          window.__tcfapi(name, 1, (tcData, success) => {
+          window.__tcfapi(value, 1, (tcData, success) => {
             resolve({tcData, success})
           })
         )
         expect(tcData).equal(null)
         expect(success).equal(
           false,
-          'Success should be false for command: ' + name
+          'Success should be false for command: ' + value
         )
       }
     )
     itParam(
-      'If the argument is 0 (Zero), shall return the information for the latest (highest) version available',
+      'for command ${value}, If the argument is 0 (Zero), shall return the information for the latest (highest) version available',
       commandListOk,
-      async name => {
+      async value => {
         TestableTcfApiInitializer.create().init()
         const {tcData, success} = await new Promise(resolve =>
-          window.__tcfapi(name, 0, (tcData, success) => {
+          window.__tcfapi(value, 0, (tcData, success) => {
             resolve({tcData, success})
           })
         )
         expect(tcData.tcfPolicyVersion).equal(
           2,
-          'version  should be 2 for command: ' + name
+          'version  should be 2 for command: ' + value
         )
         expect(success).equal(
           true,
-          'Success should be true for command: ' + name
+          'Success should be true for command: ' + value
         )
       }
     )
     itParam(
-      'If the argument is null, shall return the information for the latest (highest) version available',
+      'for command ${value}, If the argument is null, shall return the information for the latest (highest) version available',
       commandListOk,
-      async name => {
+      async value => {
         TestableTcfApiInitializer.create().init()
         const {tcData, success} = await new Promise(resolve =>
-          window.__tcfapi(name, null, (tcData, success) => {
+          window.__tcfapi(value, null, (tcData, success) => {
             resolve({tcData, success})
           })
         )
         expect(tcData.tcfPolicyVersion).equal(2)
         expect(success).equal(
           true,
-          'Success should be true for command: ' + name
+          'Success should be true for command: ' + value
         )
       }
     )
     itParam(
-      'If the argument undefined shall return the information for the latest (highest) version available',
+      'for command ${value}, If the argument undefined shall return the information for the latest (highest) version available',
       commandListOk,
-      async name => {
+      async value => {
         TestableTcfApiInitializer.create().init()
         const {tcData, success} = await new Promise(resolve =>
-          window.__tcfapi(name, undefined, (tcData, success) => {
+          window.__tcfapi(value, undefined, (tcData, success) => {
             resolve({tcData, success})
           })
         )
         expect(tcData.tcfPolicyVersion).equal(2)
         expect(success).equal(
           true,
-          'Success should be true for command: ' + name
+          'Success should be true for command: ' + value
         )
       }
     )

--- a/src/test/infrastructure/controller/TcfApiControllerTest.js
+++ b/src/test/infrastructure/controller/TcfApiControllerTest.js
@@ -1,57 +1,105 @@
 import {TestableTcfApiInitializer} from '../../testable/infrastructure/bootstrap/TestableTcfApiInitializer'
 import {expect} from 'chai'
+import itParam from 'mocha-param'
 describe('TcfApiController should', () => {
   describe('version behaviour', () => {
-    const command = 'addEventListener'
-    it('If the version is 2, callback shall be invoked with  true for the success parameter and TC data parameter should be returned', async () => {
-      TestableTcfApiInitializer.create().init()
-      const {tcData, success} = await new Promise(resolve =>
-        window.__tcfapi(command, 2, (tcData, success) => {
-          resolve({tcData, success})
-        })
-      )
-      expect(tcData).exist
-      expect(success).equal(true)
-    })
-    it('If the version is 1, callback shall be invoked with  false for the success parameter and a null argument for TC data parameter', async () => {
-      TestableTcfApiInitializer.create().init()
-      const {tcData, success} = await new Promise(resolve =>
-        window.__tcfapi(command, 1, (tcData, success) => {
-          resolve({tcData, success})
-        })
-      )
-      expect(tcData).equal(null)
-      expect(success).equal(false)
-    })
-    it('If the argument is 0 (Zero), shall return the information for the latest (highest) version available', async () => {
-      TestableTcfApiInitializer.create().init()
-      const {tcData, success} = await new Promise(resolve =>
-        window.__tcfapi(command, 0, (tcData, success) => {
-          resolve({tcData, success})
-        })
-      )
-      expect(tcData).exist
-      expect(success).equal(true)
-    })
-    it('If the argument is null, shall return the information for the latest (highest) version available', async () => {
-      TestableTcfApiInitializer.create().init()
-      const {tcData, success} = await new Promise(resolve =>
-        window.__tcfapi(command, null, (tcData, success) => {
-          resolve({tcData, success})
-        })
-      )
-      expect(tcData).exist
-      expect(success).equal(true)
-    })
-    it('If the argument undefined shall return the information for the latest (highest) version available', async () => {
-      TestableTcfApiInitializer.create().init()
-      const {tcData, success} = await new Promise(resolve =>
-        window.__tcfapi(command, undefined, (tcData, success) => {
-          resolve({tcData, success})
-        })
-      )
-      expect(tcData).exist
-      expect(success).equal(true)
-    })
+    const commandList = [
+      'addEventListener',
+      'removeEventListener',
+      'getTCData',
+      'getVendorList'
+    ]
+    const commandListOk = commandList.filter(
+      item => item !== 'removeEventListener'
+    )
+
+    itParam(
+      'If the version is 2, callback shall be invoked with  true for the success parameter and TC data parameter should be returned',
+      commandListOk,
+      async name => {
+        TestableTcfApiInitializer.create().init()
+        const {tcData, success} = await new Promise(resolve =>
+          window.__tcfapi(name, 2, (tcData, success) => {
+            resolve({tcData, success})
+          })
+        )
+        expect(tcData.tcfPolicyVersion).equal(2)
+        expect(success).equal(
+          true,
+          'Success should be true for command: ' + name
+        )
+      }
+    )
+    itParam(
+      'If the version is 1, callback shall be invoked with  false for the success parameter and a null argument for TC data parameter',
+      commandList,
+      async name => {
+        TestableTcfApiInitializer.create().init()
+        const {tcData, success} = await new Promise(resolve =>
+          window.__tcfapi(name, 1, (tcData, success) => {
+            resolve({tcData, success})
+          })
+        )
+        expect(tcData).equal(null)
+        expect(success).equal(
+          false,
+          'Success should be false for command: ' + name
+        )
+      }
+    )
+    itParam(
+      'If the argument is 0 (Zero), shall return the information for the latest (highest) version available',
+      commandListOk,
+      async name => {
+        TestableTcfApiInitializer.create().init()
+        const {tcData, success} = await new Promise(resolve =>
+          window.__tcfapi(name, 0, (tcData, success) => {
+            resolve({tcData, success})
+          })
+        )
+        expect(tcData.tcfPolicyVersion).equal(
+          2,
+          'version  should be 2 for command: ' + name
+        )
+        expect(success).equal(
+          true,
+          'Success should be true for command: ' + name
+        )
+      }
+    )
+    itParam(
+      'If the argument is null, shall return the information for the latest (highest) version available',
+      commandListOk,
+      async name => {
+        TestableTcfApiInitializer.create().init()
+        const {tcData, success} = await new Promise(resolve =>
+          window.__tcfapi(name, null, (tcData, success) => {
+            resolve({tcData, success})
+          })
+        )
+        expect(tcData.tcfPolicyVersion).equal(2)
+        expect(success).equal(
+          true,
+          'Success should be true for command: ' + name
+        )
+      }
+    )
+    itParam(
+      'If the argument undefined shall return the information for the latest (highest) version available',
+      commandListOk,
+      async name => {
+        TestableTcfApiInitializer.create().init()
+        const {tcData, success} = await new Promise(resolve =>
+          window.__tcfapi(name, undefined, (tcData, success) => {
+            resolve({tcData, success})
+          })
+        )
+        expect(tcData.tcfPolicyVersion).equal(2)
+        expect(success).equal(
+          true,
+          'Success should be true for command: ' + name
+        )
+      }
+    )
   })
 })

--- a/src/test/infrastructure/controller/TcfApiControllerTest.js
+++ b/src/test/infrastructure/controller/TcfApiControllerTest.js
@@ -1,0 +1,57 @@
+import {TestableTcfApiInitializer} from '../../testable/infrastructure/bootstrap/TestableTcfApiInitializer'
+import {expect} from 'chai'
+describe('TcfApiController should', () => {
+  describe('version behaviour', () => {
+    const command = 'addEventListener'
+    it('If the version is 2, callback shall be invoked with  true for the success parameter and TC data parameter should be returned', async () => {
+      TestableTcfApiInitializer.create().init()
+      const {tcData, success} = await new Promise(resolve =>
+        window.__tcfapi(command, 2, (tcData, success) => {
+          resolve({tcData, success})
+        })
+      )
+      expect(tcData).exist
+      expect(success).equal(true)
+    })
+    it('If the version is 1, callback shall be invoked with  false for the success parameter and a null argument for TC data parameter', async () => {
+      TestableTcfApiInitializer.create().init()
+      const {tcData, success} = await new Promise(resolve =>
+        window.__tcfapi(command, 1, (tcData, success) => {
+          resolve({tcData, success})
+        })
+      )
+      expect(tcData).equal(null)
+      expect(success).equal(false)
+    })
+    it('If the argument is 0 (Zero), shall return the information for the latest (highest) version available', async () => {
+      TestableTcfApiInitializer.create().init()
+      const {tcData, success} = await new Promise(resolve =>
+        window.__tcfapi(command, 0, (tcData, success) => {
+          resolve({tcData, success})
+        })
+      )
+      expect(tcData).exist
+      expect(success).equal(true)
+    })
+    it('If the argument is null, shall return the information for the latest (highest) version available', async () => {
+      TestableTcfApiInitializer.create().init()
+      const {tcData, success} = await new Promise(resolve =>
+        window.__tcfapi(command, null, (tcData, success) => {
+          resolve({tcData, success})
+        })
+      )
+      expect(tcData).exist
+      expect(success).equal(true)
+    })
+    it('If the argument undefined shall return the information for the latest (highest) version available', async () => {
+      TestableTcfApiInitializer.create().init()
+      const {tcData, success} = await new Promise(resolve =>
+        window.__tcfapi(command, undefined, (tcData, success) => {
+          resolve({tcData, success})
+        })
+      )
+      expect(tcData).exist
+      expect(success).equal(true)
+    })
+  })
+})


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->
- When any command is called we should handle version parameter as is specified in [documentation](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#how-does-the-version-parameter-work)
## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->
https://jira.scmspain.com/browse/PSP-3318
## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->
- Return null for TCData and false for success when version is not correct
## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->
- Try __tcfapi('addEventListener', 0, console.log)
- null and false should be returned

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/a7oVsf3WTOaoE/giphy.gif)