### PR TITLE
accept nully version calls

### DIFF
--- a/src/main/infrastructure/controller/TcfApiController.js
+++ b/src/main/infrastructure/controller/TcfApiController.js
@@ -1,13 +1,19 @@
 import {TcfApiV2} from '../../application/TcfApiV2'
 import {inject} from '../../core/ioc/ioc'
+import {TCF_API_VERSION} from '../../core/constants'
 
 class TcfApiController {
   constructor({tcfApi = inject(TcfApiV2)} = {}) {
     this._tcfApi = tcfApi
   }
 
-  process(command, version, callback = () => null, parameter) {
-    if (version !== 2 || !this._tcfApi[command]) {
+  process(
+    command,
+    version = TCF_API_VERSION,
+    callback = () => null,
+    parameter
+  ) {
+    if (version === 1 || !this._tcfApi[command]) {
       this._reject(callback)
     } else {
       try {

--- a/src/test/infrastructure/controller/TcfApiControllerTest.js
+++ b/src/test/infrastructure/controller/TcfApiControllerTest.js
@@ -1,0 +1,33 @@
+import {expect} from 'chai'
+import sinon from 'sinon'
+import {TcfApiController} from '../../../main/infrastructure/controller/TcfApiController'
+
+describe('TcfApiController', () => {
+  const tcfApi = {ping: f => f({}, true)}
+  const pingSpy = sinon.spy(tcfApi, 'ping')
+  beforeEach(() => {
+    pingSpy.resetHistory()
+  })
+
+  it('should reject v1 calls', () => {
+    const controller = new TcfApiController({tcfApi})
+    controller.process('ping', 1, (value, success) => {
+      expect(success).to.be.false
+      expect(pingSpy.called).to.be.false
+    })
+  })
+  it('should reject unexisting method calls', () => {
+    const controller = new TcfApiController({tcfApi})
+    controller.process('invent', 2, (value, success) => {
+      expect(success).to.be.false
+      expect(pingSpy.called).to.be.false
+    })
+  })
+  it('should accept undefined version parameter', () => {
+    const controller = new TcfApiController({tcfApi})
+    controller.process('ping', undefined, (value, success) => {
+      expect(success).to.be.true
+      expect(pingSpy.called).to.be.true
+    })
+  })
+})


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->


![image](https://user-images.githubusercontent.com/20399660/86804178-ffe39400-c076-11ea-83e0-ea940dd86977.png)

We must accept nully version parameter, to be the latest version accepted by Boros TCF (actually version 2)

For example, Xandr is not using the version parameter and so, it's not retrieving the consent string

![image](https://user-images.githubusercontent.com/20399660/86803906-b85d0800-c076-11ea-9ae3-bb51ea6d1797.png)

## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3341

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

`window.__tcfapi('a command', undefined, () => null)` is accepted 

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/H4JGIeSDYHUWc/giphy.gif)