### PR TITLE
Feature/protect on load consent error

### DIFF
--- a/src/main/application/services/vendorconsent/LoadUserConsentUseCase.js
+++ b/src/main/application/services/vendorconsent/LoadUserConsentUseCase.js
@@ -1,23 +1,31 @@
 import {inject} from '../../../core/ioc/ioc'
 import {LoadConsentService} from '../../../domain/consent/LoadConsentService'
 import {EventStatusService} from '../../../domain/service/EventStatusService'
+import {ConsentFactory} from '../../../domain/consent/ConsentFactory'
 
 class LoadUserConsentUseCase {
   constructor({
     loadConsentService = inject(LoadConsentService),
-    eventStatusService = inject(EventStatusService)
+    eventStatusService = inject(EventStatusService),
+    consentFactory = inject(ConsentFactory)
   } = {}) {
     this._loadConsentService = loadConsentService
     this._eventStatusService = eventStatusService
+    this._consentFactory = consentFactory
   }
 
   async execute({notify = false} = {}) {
-    const consent = await this._loadConsentService.loadConsent()
-    const consentDto = consent.toJSON()
-    if (consentDto.valid) {
-      this._eventStatusService.updateTCLoaded({notify})
+    try {
+      const consent = await this._loadConsentService.loadConsent()
+      const consentDto = consent.toJSON()
+      if (consentDto.valid) {
+        this._eventStatusService.updateTCLoaded({notify})
+      }
+      return consentDto
+    } catch (error) {
+      const consent = this._consentFactory.createEmpty()
+      return consent.toJSON()
     }
-    return consentDto
   }
 }
 

--- a/src/main/domain/consent/ConsentFactory.js
+++ b/src/main/domain/consent/ConsentFactory.js
@@ -32,6 +32,6 @@ export class ConsentFactory {
       purpose: emptyVendorPurpose(),
       specialFeatures: {},
       valid: false,
-      isNew: false
+      isNew: true
     })
 }

--- a/src/test/application/BorosTcfTest.js
+++ b/src/test/application/BorosTcfTest.js
@@ -406,6 +406,21 @@ describe('BorosTcf', () => {
       expect(consent.purpose.consents).to.be.deep.equal({})
       expect(consent.purpose.legitimateInterests).to.be.deep.equal({})
     })
+
+    it('should return empty consent if decoding old consent fails with an error', async () => {
+      const throwableCookieStorage = {
+        load: () => {
+          throw new Error('Error loading cookie')
+        }
+      }
+      const borosTcf = TestableTcfApiInitializer.create()
+        .mock(CookieStorage, throwableCookieStorage)
+        .init()
+
+      const consent = await borosTcf.loadUserConsent()
+      expect(consent.isNew).to.be.true
+      expect(consent.cmpId).to.equal(BOROS_TCF_ID)
+    })
   })
   describe('uiVisible', () => {
     let borosTcf


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

This PR adds a try/catch over the consent loading use case to avoid errors decoding old consent, and if errors happen, mark the returned consent as empty (so it's invalid for the UI and marked as new)

## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3386

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

If an error occurs, an empty consent is returned 

## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->

* validated forcing an error in a test

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/1RkDDoIVs3ntm/giphy.gif)