### PR TITLE
Fixing unexisting vendors, and all consents are set to true

### DIFF
--- a/src/main/domain/consent/LoadConsentService.js
+++ b/src/main/domain/consent/LoadConsentService.js
@@ -5,6 +5,7 @@ import {ConsentDecoderService} from '../consent/ConsentDecoderService'
 import {VendorListRepository} from '../vendorlist/VendorListRepository'
 import {ConsentEncoderService} from './ConsentEncoderService'
 import {VendorListHelper} from '../vendorlist/VendorListHelper'
+import {Version} from '../vendorlist/Version'
 
 export class LoadConsentService {
   constructor({
@@ -74,34 +75,43 @@ export class LoadConsentService {
       return true
     }
 
+    const oldVendorList = await this._vendorListRepository.getVendorList({
+      version: new Version(consent.vendorListVersion)
+    })
+
     return (
       (await this._consentHaveConsentsAndLIForAllVendorsWithTheSameValue({
         consent,
         newVendorList,
-        value: true
+        value: true,
+        oldVendorList: oldVendorList.value.vendors
       })) ||
-      this._consentHaveConsentsAndLIForAllVendorsWithTheSameValue({
+      (await this._consentHaveConsentsAndLIForAllVendorsWithTheSameValue({
         consent,
         newVendorList,
-        value: false
-      })
+        value: false,
+        oldVendorList: oldVendorList.value.vendors
+      }))
     )
   }
 
   async _consentHaveConsentsAndLIForAllVendorsWithTheSameValue({
     consent,
     newVendorList,
-    value
+    value,
+    oldVendorList
   }) {
     let isValid = false
     if (
       this._vendorListHelper.haveAllValuesTo({
         object: consent.vendor.consents,
-        valueToVerify: value
+        valueToVerify: value,
+        oldVendorList
       }) &&
       this._vendorListHelper.haveAllValuesTo({
         object: consent.vendor.legitimateInterests,
-        valueToVerify: value
+        valueToVerify: value,
+        oldVendorList
       })
     ) {
       consent.vendor = this._vendorListHelper.setAllVendorsTo({

--- a/src/main/domain/consent/LoadConsentService.js
+++ b/src/main/domain/consent/LoadConsentService.js
@@ -86,12 +86,12 @@ export class LoadConsentService {
         value: true,
         oldVendorList: oldVendorList.value.vendors
       })) ||
-      (await this._consentHaveConsentsAndLIForAllVendorsWithTheSameValue({
+      this._consentHaveConsentsAndLIForAllVendorsWithTheSameValue({
         consent,
         newVendorList,
         value: false,
         oldVendorList: oldVendorList.value.vendors
-      }))
+      })
     )
   }
 

--- a/src/main/domain/vendorlist/VendorListHelper.js
+++ b/src/main/domain/vendorlist/VendorListHelper.js
@@ -1,10 +1,10 @@
 export class VendorListHelper {
-  haveAllValuesTo({object, valueToVerify}) {
+  haveAllValuesTo({object, valueToVerify, oldVendorList}) {
     if (Object.entries(object).length === 0) {
       return valueToVerify === false
     }
-    for (const value of Object.values(object)) {
-      if (valueToVerify !== value) {
+    for (const [key, value] of Object.entries(object)) {
+      if (valueToVerify !== value && oldVendorList && oldVendorList[key]) {
         return false
       }
     }

--- a/src/test/application/BorosTcfTest.js
+++ b/src/test/application/BorosTcfTest.js
@@ -3,6 +3,8 @@ import {expect} from 'chai'
 import {TCString} from '@iabtcf/core'
 import {TestableTcfApiInitializer} from '../testable/infrastructure/bootstrap/TestableTcfApiInitializer'
 import {
+  VendorList45,
+  VendorList46,
   VendorListValueEnglish,
   VendorListValueSpanish
 } from '../fixtures/vendorlist/VendorListValue'
@@ -405,6 +407,32 @@ describe('BorosTcf', () => {
       expect(consent.vendor.legitimateInterests).to.be.deep.equal({})
       expect(consent.purpose.consents).to.be.deep.equal({})
       expect(consent.purpose.legitimateInterests).to.be.deep.equal({})
+    })
+    it('should return valid consent if vendor list version  have changed and user have accepted previously all the vendors, and some vendors does not exist in new vendor list', async () => {
+      const cookieVersion45WithAllVendorsAccepted =
+        'CO2r3W7O2r3W7CBAEAENAtCoAP_AAH_AAAiQGGNX_T5fb2vj-3Z99_tkaYwf95y3p-wzhheMs-8NyYeH7BoGP2MwvBX4JiQKGRgksjKBAQdtHGhcSQgBgIhViTKMYk2MjzNKJLJAilsbe0NYCD9mnsHT3ZCY70-vu__7P3ffwMMav-ny-3tfH9uz77_bI0xg_7zlvT9hnDC8ZZ94bkw8P2DQMfsZheCvwTEgUMjBJZGUCAg7aONC4khADARCrEmUYxJsZHmaUSWSBFLY29oawEH7NPYOnuyEx3p9fd__2fu-_gAA.YAAAAAAAAAAA'
+      cookieStorageMock.save({
+        data: cookieVersion45WithAllVendorsAccepted
+      })
+
+      const mockGVLFactory = new TestableGVLFactory()
+      mockGVLFactory.reset()
+      mockGVLFactory.mockReply({
+        path: '/LATEST?language=es',
+        data: VendorList46.data
+      })
+      mockGVLFactory.mockReply({
+        path: '/45?language=es',
+        data: VendorList45.data
+      })
+      const borosTcf = TestableTcfApiInitializer.create()
+        .mock(CookieStorage, cookieStorageMock)
+        .mock(GVLFactory, mockGVLFactory)
+        .init()
+
+      const consent = await borosTcf.loadUserConsent()
+      expect(consent.valid).to.be.true
+      expect(consent.isNew).to.be.false
     })
   })
   describe('uiVisible', () => {

--- a/src/test/domain/vendorlist/VendorListHelperTest.js
+++ b/src/test/domain/vendorlist/VendorListHelperTest.js
@@ -4,13 +4,18 @@ import {expect} from 'chai'
 describe('VendorListHelper should', () => {
   const vendorListHelper = new VendorListHelper()
   describe('haveAllValuesTo should', () => {
+    const oldVendorList = {
+      1: {},
+      2: {}
+    }
     it('return true if vendor.consent is an empty object and we are asking for values to false', () => {
       const vendor = {
         consent: {}
       }
       const result = vendorListHelper.haveAllValuesTo({
         object: vendor.consent,
-        valueToVerify: false
+        valueToVerify: false,
+        oldVendorList
       })
       expect(result).to.be.true
     })
@@ -20,7 +25,8 @@ describe('VendorListHelper should', () => {
       }
       const result = vendorListHelper.haveAllValuesTo({
         object: vendor.consent,
-        valueToVerify: true
+        valueToVerify: true,
+        oldVendorList
       })
       expect(result).to.be.false
     })
@@ -33,7 +39,8 @@ describe('VendorListHelper should', () => {
       }
       const result = vendorListHelper.haveAllValuesTo({
         object: vendor.consent,
-        valueToVerify: true
+        valueToVerify: true,
+        oldVendorList
       })
       expect(result).to.be.true
     })
@@ -46,9 +53,27 @@ describe('VendorListHelper should', () => {
       }
       const result = vendorListHelper.haveAllValuesTo({
         object: vendor.consent,
-        valueToVerify: true
+        valueToVerify: true,
+        oldVendorList
       })
       expect(result).to.be.false
+    })
+    it('return true if vendor.consent has a vendor consent to false but in previous oldListVersin did not exist', () => {
+      const vendor = {
+        consent: {
+          1: true,
+          2: false
+        }
+      }
+      const oldVendorListWithoutVendor2 = {
+        1: {}
+      }
+      const result = vendorListHelper.haveAllValuesTo({
+        object: vendor.consent,
+        valueToVerify: true,
+        oldVendorList: oldVendorListWithoutVendor2
+      })
+      expect(result).to.be.true
     })
     describe('setAllVendorsTo', () => {
       it('set all vendors to true', () => {

--- a/src/test/fixtures/vendorlist/VendorListValue.js
+++ b/src/test/fixtures/vendorlist/VendorListValue.js
@@ -8846,4 +8846,22559 @@ const VendorListValueSpanish = {
   }
 }
 
-export {VendorListValueEnglish, VendorListValueSpanish}
+
+const VendorList45 = {data: {
+    gvlSpecificationVersion: 2,
+    vendorListVersion: 45,
+    tcfPolicyVersion: 2,
+    lastUpdated: '2020-07-02T16:05:39Z',
+    purposes: {
+      '1': {
+        id: 1,
+        name: 'Almacenar o acceder a información en un dispositivo',
+        description: 'Se puede almacenar o acceder a cookies, identificadores de dispositivo u otra información en su dispositivo para las finalidades que se le presentan.',
+        descriptionLegal: 'Los proveedores pueden:\n* Almacenar y/o acceder a información en el dispositivo a través de cookies e identificadores de dispositivo ejecutados/instalados en el equipo del usuario.'
+      },
+      '2': {
+        id: 2,
+        name: 'Seleccionar anuncios básicos',
+        description: 'Los anuncios se pueden mostrar en función del contenido que se esté visualizando, la aplicación que se esté utilizando, su localización aproximada o su tipo de dispositivo.',
+        descriptionLegal: 'Para realizar la selección de anuncios básicos, los proveedores pueden:\n* Utilizar información en tiempo real sobre el contexto en el que se mostrará el anuncio, para mostrar el anuncio, incluida la información sobre el contenido y el dispositivo, como por ejemplo: tipo de dispositivo y sus funcionalidades, agente de usuario, URL, dirección IP \n* Utilizar los datos de localización geográfica de aproximada\n* Controlar la frecuencia con la que se muestran los anuncios a un usuario.\n* Secuenciar el orden en el que se muestran los anuncios a un usuario.\n* Evitar que un anuncio se sirva o envíe en un contexto editorial inadecuado (Brand safety)\nLos Proveedores no pueden:\n* Crear un perfil publicitario personalizado utilizando esta información para la selección de anuncios futuros sin una base jurídica separada cuya finalidad específica fuera crear un perfil publicitario personalizados.\nNota: Aproximada significa que se permite solamente una localización aproximada de, como máximo, dentro de un radio de 500 metros.\n'
+      },
+      '3': {
+        id: 3,
+        name: 'Crear un perfil publicitario personalizado',
+        description: 'Se puede elaborar un perfil sobre usted y sus intereses para mostrarle anuncios personalizados que sean pertinentes para usted.',
+        descriptionLegal: 'Para crear un perfil publicitario personalizado, los proveedores pueden:\n* Recoger información sobre un usuario, (incluyendo la actividad anterior del usuario, sus intereses, páginas web o aplicaciones visitadas con anterioridad, ubicación o información demográfica) a fin de crear o editar un perfil de usuario para su uso en publicidad personalizada.\n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones, a fin de crear o editar un perfil de usuario para su uso en publicidad personalizada\n'
+      },
+      '4': {
+        id: 4,
+        name: 'Seleccionar anuncios personalizados',
+        description: 'Se pueden mostrar anuncios personalizados basándose en su perfil.',
+        descriptionLegal: 'Para seleccionar anuncios personalizados, los proveedores pueden:\n* Seleccionar anuncios personalizados basándose en un perfil de usuario u otros datos históricos del usuario, incluida la actividad anterior de un usuario, sus intereses, visitas a sitios web o aplicaciones, ubicación o información demográfica.\n'
+      },
+      '5': {
+        id: 5,
+        name: 'Crear un perfil para la personalización de contenidos',
+        description: 'Se puede crear un perfil sobre usted y sus intereses para mostrarle contenido personalizado que le fuera pertinente.',
+        descriptionLegal: 'Para crear un un perfil para la personalización de contenidos, los proveedores pueden:\n* Recoger información sobre un usuario, incluida la actividad de un usuario, sus intereses, visitas a sitios o aplicaciones, información demográfica o ubicación, a fin de crear o editar un perfil de usuario para personalizar el contenido.\n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones, a fin de crear o editar un perfil de usuario para personalizar el contenido.\n'
+      },
+      '6': {
+        id: 6,
+        name: 'Seleccionar contenido personalizado',
+        description: 'Se puede mostrar contenido personalizado basado en su perfil.',
+        descriptionLegal: 'Para seleccionar contenido personalizado, los proveedores pueden:\n* Seleccionar contenido personalizado basándose en un perfil de usuario u otros datos históricos de usuarios, incluida la actividad anterior del usuario, sus intereses, visitas a sitios web o aplicaciones, ubicación o información demográfica.'
+      },
+      '7': {
+        id: 7,
+        name: 'Medir el rendimiento de los anuncios',
+        description: 'Se puede medir el rendimiento y eficacia de los anuncios que usted ve o con los que interactúa.',
+        descriptionLegal: 'Para medir el rendimiento de los anuncios, los proveedores pueden:\n* Medir si los anuncios fueron suministrados a un usuario y cómo este interactuó con ellos\n* Elaborar informes sobre anuncios, incluida su eficacia y rendimiento\n* Elaborar informes sobre los usuarios que interactuaron con los anuncios utilizando datos observados durante el curso de la interacción del usuario con ese anuncio\n* Elaborar informes para los editores sobre los anuncios mostrados en sus sitios web o propiedad digital\n* Medir si un anuncio sirve en un contexto editorial adecuado (seguro para la marca)\n* Determinar el porcentaje del anuncio que se tuvo la oportunidad de ser visto y la duración de esa oportunidad \n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones.\nLos proveedores no pueden:\n* Aplicar datos de información sobre el público basados en un panel de usuarios o similares a los datos de medición de anuncios sin una base jurídica independiente para utilizar estudios de mercado a fin de generar información sobre el público.\n'
+      },
+      '8': {
+        id: 8,
+        name: 'Medir el rendimiento del contenido',
+        description: 'Se puede medir el rendimiento y la eficacia del contenido que ve o con el que interactúa.',
+        descriptionLegal: 'Para medir el rendimiento del contenido, los proveedores pueden:\n* Medir e informar sobre cómo se entregó el contenido y cómo interactuaron con él los usuarios.\n* Elaborar informes, utilizando información directamente medible o conocida, sobre los usuarios que interactuaron con el contenido\n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones.\nLos proveedores no pueden:\n* Medir si los anuncios (incluida la publicidad nativa) fueron suministrados a un usuario y si este interactuó con ellos sin tener una base jurídica alternativa que lo permita.\n* Aplicar datos de información sobre el público, basados en un panel de usuarios o similares, a los datos de medición de anuncios sin una base jurídica independiente para utilizar estudios de mercado a fin de generar información sobre el público.\n'
+      },
+      '9': {
+        id: 9,
+        name: 'Utilizar estudios de mercado a fin de generar información sobre el público',
+        description: 'La investigación de mercado puede utilizarse para obtener más información sobre el público que visita sitios webs/aplicaciones y visualiza los anuncios.',
+        descriptionLegal: 'Para utilizar estudios de mercado a fin de generar información sobre el público, los proveedores pueden:\n* Elaborar informes agregados para los anunciantes o sus representantes sobre el público alcanzado por sus anuncios, a través de información basada en paneles de audiencia u obtenida de manera similar.\n* Elaborar informes agregados para los editores sobre el público al que se le mostraron contenidos y/o anuncios o que interactuaron con ellos en su propiedad, aplicando información basada en paneles de audiencia u obtenida de manera similar\n* Asociar datos off line con un usuario on line para finalidades de estudios de mercado a fin de generar información sobre el público si los proveedores han declarado que cotejan y combinan fuentes de datos off line \n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones.\nLos proveedores no pueden: \n* Medir el rendimiento y la eficacia de los anuncios que se mostraron a un usuario específico o con los que interactuó, sin una base jurídica independiente para medir el rendimiento de los anuncios.\n• Medir qué contenido se mostró a un usuario específico y cómo interactuó con el mismo, sin una base jurídica independiente para medir el rendimiento del contenido.\n'
+      },
+      '10': {
+        id: 10,
+        name: 'Desarrollar y mejorar productos',
+        description: 'Sus datos pueden utilizarse para mejorar los sistemas y/o el software existente, así como para desarrollar nuevos productos.',
+        descriptionLegal: 'Para desarrollar nuevos productos y mejorar los productos, los proveedores pueden:\n* Utilizar información para mejorar sus productos existentes con nuevas funcionalidades/características y desarrollar nuevos productos\n* Crear nuevos modelos y algoritmos mediante machine learning\nLos proveedores no pueden:\n* A partir de esta finalidad no se puede llevar a cabo ninguna otra operación de tratamiento de datos permitida en virtud de una finalidad distinta.\n'
+      }
+    },
+    specialPurposes: {
+      '1': {
+        id: 1,
+        name: 'Garantizar la seguridad, evitar fraudes y depurar errores',
+        description: 'Sus datos pueden utilizarse para supervisar y evitar actividades fraudulentas, y para asegurar que los sistemas y procesos funcionen de forma correcta y segura.',
+        descriptionLegal: 'Para garantizar la seguridad, evitar fraudes y depurar errores, los proveedores pueden:\n* Asegurarse de que los datos se transmitan de forma segura \n* Detectar y evitar actividades maliciosas, fraudulentas, inaceptables o ilegales.\n* Asegurar el funcionamiento correcto y eficaz de los sistemas y procesos, lo que incluye supervisar y mejorar el rendimiento de los sistemas y procesos empleados en las finalidades permitidas\nLos proveedores no pueden:\n* Llevar a cabo ninguna otra operación de tratamiento de datos permitida en virtud de una finalidad distinta.\nNota: Los datos recopilados y utilizados para garantizar la seguridad, evitar el fraude y depurar errores pueden incluir características del dispositivo enviadas automáticamente para su identificación, datos de geolocalización precisos y datos obtenidos analizando de forma activa las características del dispositivo para su identificación sin que sea necesario revelar más información y/o una aceptación independiente.  \n'
+      },
+      '2': {
+        id: 2,
+        name: 'Servir técnicamente anuncios o contenido',
+        description: 'Su dispositivo puede recibir y enviar información que le permita ver e interactuar con anuncios y contenido.',
+        descriptionLegal: 'Para servir información y responder a solicitudes técnicas, los proveedores pueden:\n* Utilizar la dirección IP de un usuario para entregar un anuncio a través de Internet\n* Responder a la interacción de un usuario con un anuncio enviando al usuario a una página de destino\n* Utilizar la dirección IP de un usuario para entregar contenido a través de Internet\n* Responder a la interacción de un usuario con el contenido enviando al usuario a una página de destino\n* Utilizar información sobre el tipo de dispositivo y sus capacidades para entregar anuncios o contenido, por ejemplo, para entregar el archivo publicitario o de vídeo de tamaño adecuado en un formato compatible con el dispositivo\nLos proveedores no pueden:\n* Llevar a cabo, según esta finalidad, ninguna otra operación de tratamiento de datos permitida en virtud de una finalidad distinta.\n'
+      }
+    },
+    features: {
+      '1': {
+        id: 1,
+        name: 'Cotejar y combinar fuentes de datos off line',
+        description: 'Los datos obtenidos de fuentes de datos off line pueden combinarse con su actividad on line para respaldar una o más finalidades.',
+        descriptionLegal: 'Los proveedores pueden: \n* Combinar los datos obtenidos off line con los datos recogidos on line en apoyo de una o más Finalidades o Finalidades especiales.'
+      },
+      '2': {
+        id: 2,
+        name: 'Vincular diferentes dispositivos',
+        description: 'Se puede determinar que diferentes dispositivos pertenecen a usted o a su hogar para una o más finalidades.',
+        descriptionLegal: 'Los proveedores pueden:\n* Determinar de forma determinista que dos o más dispositivos pertenecen al mismo usuario u hogar\n* Determinar de forma probabilística que dos o más dispositivos pertenecen al mismo usuario u hogar\n* Analizar activamente las características del dispositivo para encontrar su identificación probabilística si los usuarios han permitido a los proveedores analizar activamente las características del dispositivo para su identificación (Funcionalidad especial 2)\n'
+      },
+      '3': {
+        id: 3,
+        name: 'Recibir y utilizar para su identificación las características del dispositivo que    se envían automáticamente',
+        description: 'Su dispositivo puede distinguirse de otros dispositivos a partir de la información que envía automáticamente, como la dirección IP o el tipo de navegador.',
+        descriptionLegal: 'Los proveedores pueden:\n* Crear un identificador utilizando los datos recopilados automáticamente en un dispositivo para características específicas, por ejemplo, dirección IP o la cadena de agente de usuario.\n* Utilizar este identificador para intentar volver a identificar un dispositivo.\nLos proveedores no pueden:\n* Crear un identificador utilizando datos recogidos mediante el análisis activo de un dispositivo para hallar funcionalidads específicas, por ejemplo, fuentes instaladas o resolución de pantalla sin aceptación independiente del usuario para analizar de forma activa las características del dispositivo para su identificación.\n* Utilizar este identificador para volver a identificar un dispositivo.\n'
+      }
+    },
+    specialFeatures: {
+      '1': {
+        id: 1,
+        name: 'Utilizar datos de localización geográfica precisa',
+        description: 'Sus datos de localización geográfica precisa se pueden utilizar para una o más finalidades. Esto significa que su ubicación puede tener una precisión de varios metros.',
+        descriptionLegal: 'Los proveedores pueden:\n* Recoger y tratar datos de localización geográfica precisa para una o más finalidades.\nNota: La localización geográfica precisa significa que no existen restricciones sobre la precisión de la ubicación de un usuario; esto puede tener una precisión de varios metros.\n'
+      },
+      '2': {
+        id: 2,
+        name: 'Analizar activamente las características del dispositivo para su identificación',
+        description: 'Su dispositivo puede identificarse basándose en un análisis de la combinación única de las características de su dispositivo.',
+        descriptionLegal: 'Los proveedores pueden:\n* Crear un identificador utilizando datos recogidos mediante el análisis activo de un dispositivo para hallar características específicas, por ejemplo, fuentes instaladas o resolución de pantalla. \n* Utilizar este identificador para volver a identificar un dispositivo.\n'
+      }
+    },
+    stacks: {
+      '1': {
+        id: 1,
+        purposes: [],
+        specialFeatures: [
+          1,
+          2
+        ],
+        name: 'Datos de localización geográfica precisa e identificación mediante las características de dispositivos',
+        description: 'Se puede utilizar la localización geográfica precisa y la información sobre las características del dispositivo.'
+      },
+      '2': {
+        id: 2,
+        purposes: [
+          2,
+          7
+        ],
+        specialFeatures: [],
+        name: 'Anuncios básicos y medición de anuncios',
+        description: 'Se pueden mostrar anuncios básicos. Se puede medir el rendimiento de los anuncios.'
+      },
+      '3': {
+        id: 3,
+        purposes: [
+          2,
+          3,
+          4
+        ],
+        specialFeatures: [],
+        name: 'Anuncios personalizados',
+        description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios.'
+      },
+      '4': {
+        id: 4,
+        purposes: [
+          2,
+          7,
+          9
+        ],
+        specialFeatures: [],
+        name: 'Anuncios básicos y medición de anuncios',
+        description: 'Se pueden mostrar anuncios básicos. Se puede medir el rendimiento de los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '5': {
+        id: 5,
+        purposes: [
+          2,
+          3,
+          7
+        ],
+        specialFeatures: [],
+        name: 'Anuncios básicos, creación de perfil publicitario personalizado y medición de anuncios',
+        description: 'Se pueden mostrar anuncios básicos. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios.'
+      },
+      '6': {
+        id: 6,
+        purposes: [
+          2,
+          4,
+          7
+        ],
+        specialFeatures: [],
+        name: 'Mostrar anuncios personalizados y medición de anuncios',
+        description: 'Los anuncios pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios.'
+      },
+      '7': {
+        id: 7,
+        purposes: [
+          2,
+          4,
+          7,
+          9
+        ],
+        specialFeatures: [],
+        name: 'Mostrar anuncios personalizados, medición de anuncios e información sobre el público',
+        description: 'Los anuncios pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '8': {
+        id: 8,
+        purposes: [
+          2,
+          3,
+          4,
+          7
+        ],
+        specialFeatures: [],
+        name: 'Anuncios personalizados y medición de anuncios',
+        description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios.'
+      },
+      '9': {
+        id: 9,
+        purposes: [
+          2,
+          3,
+          4,
+          7,
+          9
+        ],
+        specialFeatures: [],
+        name: 'Anuncios personalizados, medición de anuncios e información sobre el público',
+        description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '10': {
+        id: 10,
+        purposes: [
+          3,
+          4
+        ],
+        specialFeatures: [],
+        name: 'Perfil y muestra de anuncios personalizados',
+        description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios.'
+      },
+      '11': {
+        id: 11,
+        purposes: [
+          5,
+          6
+        ],
+        specialFeatures: [],
+        name: 'Contenido personalizado',
+        description: 'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido.'
+      },
+      '12': {
+        id: 12,
+        purposes: [
+          6,
+          8
+        ],
+        specialFeatures: [],
+        name: 'Muestra de contenido personalizado y medición de contenido',
+        description: 'El contenido puede personalizarse basándose en un perfil. Se puede medir el rendimiento del contenido.'
+      },
+      '13': {
+        id: 13,
+        purposes: [
+          6,
+          8,
+          9
+        ],
+        specialFeatures: [],
+        name: 'Presentación de contenido personalizado, medición del contenido e información sobre el público',
+        description: 'El contenido puede personalizarse basándose en un perfil. Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '14': {
+        id: 14,
+        purposes: [
+          5,
+          6,
+          8
+        ],
+        specialFeatures: [],
+        name: 'Contenido personalizado y medición del contenido',
+        description: 'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido.'
+      },
+      '15': {
+        id: 15,
+        purposes: [
+          5,
+          6,
+          8,
+          9
+        ],
+        specialFeatures: [],
+        name: 'Contenido personalizado, medición del contenido e información sobre el público',
+        description: 'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '16': {
+        id: 16,
+        purposes: [
+          5,
+          6,
+          8,
+          9,
+          10
+        ],
+        specialFeatures: [],
+        name: 'Contenido personalizado, medición del contenido, información sobre el público y desarrollo de productos',
+        description: 'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido. Se puede inducir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software'
+      },
+      '17': {
+        id: 17,
+        purposes: [
+          7,
+          8,
+          9
+        ],
+        specialFeatures: [],
+        name: 'Medición de anuncios y del contenido e información sobre el público',
+        description: 'Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '18': {
+        id: 18,
+        purposes: [
+          7,
+          8
+        ],
+        specialFeatures: [],
+        name: 'Medición de anuncios y del contenido',
+        description: 'Se puede medir el rendimiento de los anuncios y del contenido.'
+      },
+      '19': {
+        id: 19,
+        purposes: [
+          7,
+          9
+        ],
+        specialFeatures: [],
+        name: 'Medición de anuncios e información sobre el público',
+        description: 'Se pueden medir los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '20': {
+        id: 20,
+        purposes: [
+          7,
+          8,
+          9,
+          10
+        ],
+        specialFeatures: [],
+        name: 'Medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+        description: 'Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '21': {
+        id: 21,
+        purposes: [
+          8,
+          9,
+          10
+        ],
+        specialFeatures: [],
+        name: 'Medición del contenido, información sobre el público y desarrollo de productos.',
+        description: 'Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '22': {
+        id: 22,
+        purposes: [
+          8,
+          10
+        ],
+        specialFeatures: [],
+        name: 'Medición del contenido y desarrollo de productos',
+        description: 'Se puede medir el rendimiento del contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '23': {
+        id: 23,
+        purposes: [
+          2,
+          4,
+          6,
+          7,
+          8
+        ],
+        specialFeatures: [],
+        name: 'Presentación de anuncios y contenido personalizados, medición de anuncios y del contenido',
+        description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios y del contenido.'
+      },
+      '24': {
+        id: 24,
+        purposes: [
+          2,
+          4,
+          6,
+          7,
+          8,
+          9
+        ],
+        specialFeatures: [],
+        name: 'Presentación de anuncios y contenido personalizados, medición de anuncios y del contenido e información sobre el público',
+        description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '25': {
+        id: 25,
+        purposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        specialFeatures: [],
+        name: 'Anuncios y contenido personalizados, medición de anuncios y del contenido',
+        description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios y el contenido. Se puede medir el rendimiento de los anuncios y del contenido.'
+      },
+      '26': {
+        id: 26,
+        purposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9
+        ],
+        specialFeatures: [],
+        name: 'Anuncios y contenido personalizados, medición de anuncios y del contenido e información sobre el público',
+        description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios y el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '27': {
+        id: 27,
+        purposes: [
+          3,
+          5
+        ],
+        specialFeatures: [],
+        name: 'Anuncios personalizados y contenido personalizado',
+        description: 'Se pueden añadir más datos para personalizar los anuncios y el contenido.'
+      },
+      '28': {
+        id: 28,
+        purposes: [
+          2,
+          4,
+          6
+        ],
+        specialFeatures: [],
+        name: 'Muestra de anuncios y contenido personalizados',
+        description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil.'
+      },
+      '29': {
+        id: 29,
+        purposes: [
+          2,
+          7,
+          8,
+          9
+        ],
+        specialFeatures: [],
+        name: 'Anuncios básicos, medición de anuncios y del contenido e información sobre el público',
+        description: 'Se pueden mostrar anuncios básicos. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '30': {
+        id: 30,
+        purposes: [
+          2,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9
+        ],
+        specialFeatures: [],
+        name: 'Muestra de anuncios personalizados, contenido personalizado, medición de anuncios y del contenido e información sobre el público',
+        description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '31': {
+        id: 31,
+        purposes: [
+          2,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialFeatures: [],
+        name: 'Muestra de anuncios personalizados, contenido personalizado, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+        description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '32': {
+        id: 32,
+        purposes: [
+          2,
+          5,
+          6,
+          7,
+          8,
+          9
+        ],
+        specialFeatures: [],
+        name: 'Anuncios básicos, contenido personalizado, medición de anuncios y del contenido e información sobre el público',
+        description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '33': {
+        id: 33,
+        purposes: [
+          2,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialFeatures: [],
+        name: 'Anuncios básicos, contenido personalizado, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+        description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '34': {
+        id: 34,
+        purposes: [
+          2,
+          5,
+          6,
+          8,
+          9
+        ],
+        specialFeatures: [],
+        name: 'Anuncios básicos, contenido personalizado, medición del contenido e información sobre el público',
+        description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '35': {
+        id: 35,
+        purposes: [
+          2,
+          5,
+          6,
+          8,
+          9,
+          10
+        ],
+        specialFeatures: [],
+        name: 'Anuncios básicos, contenido personalizado, medición del contenido, información sobre el público y desarrollo de productos',
+        description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '36': {
+        id: 36,
+        purposes: [
+          2,
+          5,
+          6,
+          7
+        ],
+        specialFeatures: [],
+        name: 'Anuncios básicos, contenido personalizado y medición de anuncios',
+        description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios.'
+      },
+      '37': {
+        id: 37,
+        purposes: [
+          2,
+          5,
+          6,
+          7,
+          10
+        ],
+        specialFeatures: [],
+        name: 'Anuncios básicos, contenido personalizado, medición de anuncios y desarrollo de productos',
+        description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '38': {
+        id: 38,
+        purposes: [
+          2,
+          3,
+          4,
+          7,
+          10
+        ],
+        specialFeatures: [],
+        name: 'Anuncios personalizados, medición de anuncios y desarrollo de productos',
+        description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '39': {
+        id: 39,
+        purposes: [
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        specialFeatures: [],
+        name: 'Anuncios personalizados, medición de anuncios, información sobre el público y desarrollo de productos',
+        description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '40': {
+        id: 40,
+        purposes: [
+          2,
+          3,
+          4,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialFeatures: [],
+        name: 'Anuncios personalizados, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+        description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios y del contenido. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '41': {
+        id: 41,
+        purposes: [
+          2,
+          3,
+          4,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialFeatures: [],
+        name: 'Anuncios personalizados, muestra de contenido personalizado, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+        description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios y del contenido. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '42': {
+        id: 42,
+        purposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialFeatures: [],
+        name: 'Anuncios y contenido personalizados, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+        description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios y el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      }
+    },
+    vendors: {
+      '1': {
+        id: 1,
+        name: 'Exponential Interactive, Inc d/b/a VDX.tv',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://vdx.tv/privacy/'
+      },
+      '2': {
+        id: 2,
+        name: 'Captify Technologies Limited',
+        purposes: [
+          1,
+          2,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          7,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2
+        ],
+        specialPurposes: [],
+        features: [
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'http://www.captify.co.uk/privacy-policy/'
+      },
+      '4': {
+        id: 4,
+        name: 'Roq.ad Inc.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.roq.ad/privacy-policy'
+      },
+      '6': {
+        id: 6,
+        name: 'AdSpirit GmbH',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          9
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'http://www.adspirit.de/privacy',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '8': {
+        id: 8,
+        name: 'Emerse Sverige AB',
+        purposes: [
+          1,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          8,
+          9
+        ],
+        flexiblePurposes: [
+          2,
+          9
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.emerse.com/privacy-policy/'
+      },
+      '9': {
+        id: 9,
+        name: 'AdMaxim Inc.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://www.admaxim.com/admaxim-privacy-policy/',
+        deletedDate: '2020-06-17T00:00:00Z'
+      },
+      '10': {
+        id: 10,
+        name: 'Index Exchange, Inc. ',
+        purposes: [
+          1,
+          2,
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          7
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.indexexchange.com/privacy'
+      },
+      '11': {
+        id: 11,
+        name: 'Quantcast International Limited',
+        purposes: [
+          1,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.quantcast.com/privacy/'
+      },
+      '12': {
+        id: 12,
+        name: 'BeeswaxIO Corporation',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          2
+        ],
+        features: [
+          1,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.beeswax.com/privacy/'
+      },
+      '13': {
+        id: 13,
+        name: 'Sovrn Holdings Inc',
+        purposes: [
+          1,
+          2,
+          3,
+          5,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.sovrn.com/sovrn-privacy/'
+      },
+      '14': {
+        id: 14,
+        name: 'Adkernel LLC',
+        purposes: [
+          1,
+          7
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          9
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://adkernel.com/privacy-policy/',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '15': {
+        id: 15,
+        name: 'Adikteev',
+        purposes: [
+          1,
+          3,
+          4,
+          5,
+          6,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [
+          2,
+          7
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.adikteev.com/privacy-policy-eng/'
+      },
+      '16': {
+        id: 16,
+        name: 'RTB House S.A.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.rtbhouse.com/privacy-center/services-privacy-policy/'
+      },
+      '18': {
+        id: 18,
+        name: 'Widespace AB',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7
+        ],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.widespace.com/legal/privacy-policy-notice/'
+      },
+      '21': {
+        id: 21,
+        name: 'The Trade Desk',
+        purposes: [
+          1,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          7,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.thetradedesk.com/general/privacy-policy'
+      },
+      '22': {
+        id: 22,
+        name: 'admetrics GmbH',
+        purposes: [
+          2,
+          7,
+          8,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://admetrics.io/en/privacy_policy/'
+      },
+      '23': {
+        id: 23,
+        name: 'Amobee, Inc. ',
+        purposes: [
+          1,
+          2,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          7,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.amobee.com/trust/privacy-guidelines'
+      },
+      '24': {
+        id: 24,
+        name: 'Epsilon',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.conversantmedia.eu/legal/privacy-policy'
+      },
+      '25': {
+        id: 25,
+        name: 'Verizon Media EMEA Limited',
+        purposes: [
+          1,
+          3,
+          4,
+          5,
+          6
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.verizonmedia.com/policies/ie/en/verizonmedia/privacy/index.html'
+      },
+      '28': {
+        id: 28,
+        name: 'TripleLift, Inc.',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://triplelift.com/privacy/',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '30': {
+        id: 30,
+        name: 'BidTheatre AB',
+        purposes: [
+          1,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          2
+        ],
+        flexiblePurposes: [
+          2
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.bidtheatre.com/privacy-policy'
+      },
+      '31': {
+        id: 31,
+        name: 'Ogury Ltd.',
+        purposes: [
+          1,
+          3,
+          4,
+          9
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.ogury.com/privacy-policy/'
+      },
+      '32': {
+        id: 32,
+        name: 'Xandr, Inc.',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          7,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          2
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.xandr.com/privacy/platform-privacy-policy/'
+      },
+      '33': {
+        id: 33,
+        name: 'ShareThis, Inc',
+        purposes: [
+          1,
+          3,
+          5,
+          6
+        ],
+        legIntPurposes: [
+          9,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://sharethis.com/privacy/'
+      },
+      '34': {
+        id: 34,
+        name: 'NEORY GmbH',
+        purposes: [
+          1,
+          3,
+          4,
+          5,
+          6,
+          9
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          8
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.neory.com/privacy.html',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '36': {
+        id: 36,
+        name: 'RhythmOne DBA Unruly Group Ltd',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.rhythmone.com/privacy-policy'
+      },
+      '37': {
+        id: 37,
+        name: 'NEURAL.ONE',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          7,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://web.neural.one/privacy-policy/'
+      },
+      '39': {
+        id: 39,
+        name: 'ADITION technologies AG',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.adition.com/datenschutz'
+      },
+      '40': {
+        id: 40,
+        name: 'Active Agent (ADITION technologies AG)',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://www.active-agent.com/de/unternehmen/datenschutzerklaerung/'
+      },
+      '41': {
+        id: 41,
+        name: 'Adverline',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.adverline.com/privacy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '42': {
+        id: 42,
+        name: 'Taboola Europe Limited',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.taboola.com/privacy-policy'
+      },
+      '44': {
+        id: 44,
+        name: 'The ADEX GmbH',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://theadex.com/privacy-opt-out/'
+      },
+      '45': {
+        id: 45,
+        name: 'Smart Adserver',
+        purposes: [
+          1,
+          4
+        ],
+        legIntPurposes: [
+          2,
+          7
+        ],
+        flexiblePurposes: [
+          2,
+          7
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://smartadserver.com/end-user-privacy-policy/'
+      },
+      '47': {
+        id: 47,
+        name: 'ADMAN - Phaistos Networks, S.A.',
+        purposes: [
+          1,
+          2,
+          4,
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.adman.gr/privacy'
+      },
+      '49': {
+        id: 49,
+        name: 'TRADELAB',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        legIntPurposes: [
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://tradelab.com/en/privacy/',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '50': {
+        id: 50,
+        name: 'Adform',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          7,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://site.adform.com/privacy-center/platform-privacy/product-and-services-privacy-policy/',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '51': {
+        id: 51,
+        name: 'xAd, Inc. dba GroundTruth',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.groundtruth.com/privacy-policy/'
+      },
+      '52': {
+        id: 52,
+        name: 'The Rubicon Project, Inc. ',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          7,
+          10
+        ],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://www.rubiconproject.com/rubicon-project-yield-optimization-privacy-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '53': {
+        id: 53,
+        name: 'Sirdata',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.sirdata.com/privacy/'
+      },
+      '57': {
+        id: 57,
+        name: 'ADARA MEDIA UNLIMITED',
+        purposes: [
+          1,
+          2,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          7,
+          9,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://adara.com/privacy-promise/'
+      },
+      '58': {
+        id: 58,
+        name: '33Across',
+        purposes: [
+          1,
+          2,
+          4,
+          7,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'http://www.33across.com/privacy-policy'
+      },
+      '59': {
+        id: 59,
+        name: 'Sift Media, Inc',
+        purposes: [
+          2
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2
+        ],
+        specialPurposes: [],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.sift.co/privacy'
+      },
+      '60': {
+        id: 60,
+        name: 'Rakuten Marketing LLC',
+        purposes: [
+          1,
+          3
+        ],
+        legIntPurposes: [
+          2,
+          4,
+          7,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://rakutenadvertising.com/legal-notices/services-privacy-policy/'
+      },
+      '61': {
+        id: 61,
+        name: 'GumGum, Inc.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://gumgum.com/privacy-policy'
+      },
+      '62': {
+        id: 62,
+        name: 'Justpremium BV',
+        purposes: [
+          1,
+          4,
+          5
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          4,
+          7
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://justpremium.com/privacy-policy/'
+      },
+      '63': {
+        id: 63,
+        name: 'Avocet Systems Limited',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        legIntPurposes: [
+          7,
+          8,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://avocet.io/privacy-portal'
+      },
+      '65': {
+        id: 65,
+        name: 'Location Sciences AI Ltd',
+        purposes: [
+          1,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.locationsciences.ai/privacy-policy/'
+      },
+      '66': {
+        id: 66,
+        name: 'adsquare GmbH',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          9,
+          10
+        ],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.adsquare.com/privacy'
+      },
+      '68': {
+        id: 68,
+        name: 'Sizmek by Amazon',
+        purposes: [
+          1,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.sizmek.com/privacy-policy/'
+      },
+      '69': {
+        id: 69,
+        name: 'OpenX',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.openx.com/legal/privacy-policy/'
+      },
+      '70': {
+        id: 70,
+        name: 'Yieldlab AG',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://www.yieldlab.de/meta-navigation/datenschutz/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '72': {
+        id: 72,
+        name: 'Nano Interactive GmbH',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.nanointeractive.com/privacy'
+      },
+      '73': {
+        id: 73,
+        name: 'Simplifi Holdings Inc.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4
+        ],
+        specialPurposes: [],
+        features: [
+          2
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://simpli.fi/site-privacy-policy/'
+      },
+      '76': {
+        id: 76,
+        name: 'PubMatic, Inc.',
+        purposes: [
+          1,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          2,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://pubmatic.com/privacy-policy/'
+      },
+      '77': {
+        id: 77,
+        name: 'comScore, Inc.',
+        purposes: [
+          1,
+          7,
+          8,
+          10
+        ],
+        legIntPurposes: [
+          9
+        ],
+        flexiblePurposes: [
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.scorecardresearch.com/privacy.aspx?newlanguage=1'
+      },
+      '78': {
+        id: 78,
+        name: 'Flashtalking, Inc.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://www.flashtalking.com/privacypolicy/'
+      },
+      '79': {
+        id: 79,
+        name: 'MediaMath, Inc.',
+        purposes: [
+          1,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          8,
+          10
+        ],
+        flexiblePurposes: [
+          3,
+          4
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://www.mediamath.com/privacy-policy/'
+      },
+      '80': {
+        id: 80,
+        name: 'Sharethrough, Inc',
+        purposes: [
+          1,
+          2,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          4,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://platform-cdn.sharethrough.com/privacy-policy'
+      },
+      '82': {
+        id: 82,
+        name: 'Smaato, Inc.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9
+        ],
+        legIntPurposes: [
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.smaato.com/privacy/'
+      },
+      '83': {
+        id: 83,
+        name: 'Visarity Technologies GmbH',
+        purposes: [
+          2,
+          6,
+          7,
+          8
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://primo.design/docs/PrivacyPolicyPrimo.html'
+      },
+      '84': {
+        id: 84,
+        name: 'Semasio GmbH',
+        purposes: [
+          1,
+          3,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          3,
+          9,
+          10
+        ],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.semasio.com/privacy-policy/'
+      },
+      '85': {
+        id: 85,
+        name: 'Crimtan Holdings Limited',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://crimtan.com/privacy/'
+      },
+      '86': {
+        id: 86,
+        name: 'Scene Stealer Limited',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          7,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://scenestealer.tv/privacy-policy/'
+      },
+      '88': {
+        id: 88,
+        name: 'TreSensa, Inc.',
+        purposes: [
+          1,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.tresensa.com/eu-privacy'
+      },
+      '89': {
+        id: 89,
+        name: 'Tapad, Inc.',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.tapad.com/eu-privacy-policy'
+      },
+      '90': {
+        id: 90,
+        name: 'Teroa S.A.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.e-planning.net/en/privacy.html'
+      },
+      '91': {
+        id: 91,
+        name: 'Criteo SA',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7
+        ],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.criteo.com/privacy/'
+      },
+      '92': {
+        id: 92,
+        name: '1plusX AG',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.1plusx.com/privacy-policy/'
+      },
+      '93': {
+        id: 93,
+        name: 'Adloox SA',
+        purposes: [],
+        legIntPurposes: [
+          7
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://adloox.com/disclaimer',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '94': {
+        id: 94,
+        name: 'Blis Media Limited',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://www.blis.com/privacy/'
+      },
+      '95': {
+        id: 95,
+        name: 'Lotame Solutions, inc',
+        purposes: [
+          1,
+          3,
+          5
+        ],
+        legIntPurposes: [
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.lotame.com/about-lotame/privacy/lotame-corporate-websites-privacy-policy/'
+      },
+      '97': {
+        id: 97,
+        name: 'LiveRamp, Inc.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.liveramp.com/service-privacy-policy/'
+      },
+      '98': {
+        id: 98,
+        name: 'GroupM UK Limited',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        legIntPurposes: [
+          7,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.groupm.com/privacy-notice'
+      },
+      '100': {
+        id: 100,
+        name: 'Fifty Technology Limited',
+        purposes: [
+          1,
+          2,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          7,
+          9,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://fifty.io/privacy-policy.php'
+      },
+      '101': {
+        id: 101,
+        name: 'MiQ',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://wearemiq.com/privacy-policy/'
+      },
+      '104': {
+        id: 104,
+        name: 'Sonobi, Inc',
+        purposes: [
+          1,
+          2,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          7,
+          8
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          2
+        ],
+        features: [
+          1
+        ],
+        specialFeatures: [],
+        policyUrl: 'http://sonobi.com/privacy-policy/'
+      },
+      '108': {
+        id: 108,
+        name: 'Rich Audience',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://richaudience.com/privacy/'
+      },
+      '109': {
+        id: 109,
+        name: 'LoopMe Limited',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        legIntPurposes: [
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          9
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://loopme.com/privacy-policy/'
+      },
+      '111': {
+        id: 111,
+        name: 'Showheroes SE',
+        purposes: [
+          1,
+          3,
+          4,
+          9,
+          10
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          8
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://showheroes.com/privacy/'
+      },
+      '114': {
+        id: 114,
+        name: 'Sublime',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9
+        ],
+        legIntPurposes: [
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://ayads.co/privacy.php'
+      },
+      '115': {
+        id: 115,
+        name: 'smartclip Europe GmbH',
+        purposes: [
+          1,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://privacy-portal.smartclip.net/',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '119': {
+        id: 119,
+        name: 'Fusio by S4M',
+        purposes: [
+          1,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1
+        ],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://www.s4m.io/privacy-policy/'
+      },
+      '120': {
+        id: 120,
+        name: 'Eyeota Pte Ltd',
+        purposes: [
+          1,
+          3,
+          5,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          3,
+          5,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.eyeota.com/privacy-center'
+      },
+      '126': {
+        id: 126,
+        name: 'DoubleVerify Inc.​',
+        purposes: [
+          2,
+          7,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.doubleverify.com/privacy/'
+      },
+      '127': {
+        id: 127,
+        name: 'PIXIMEDIA SAS',
+        purposes: [
+          1,
+          3,
+          4,
+          5,
+          6,
+          9,
+          10
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          8
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://piximedia.com/privacy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '128': {
+        id: 128,
+        name: 'BIDSWITCH GmbH',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://www.bidswitch.com/privacy-policy/'
+      },
+      '129': {
+        id: 129,
+        name: 'IPONWEB GmbH',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.iponweb.com/privacy-policy/'
+      },
+      '130': {
+        id: 130,
+        name: 'NextRoll, Inc.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.nextroll.com/privacy'
+      },
+      '131': {
+        id: 131,
+        name: 'ID5 Technology SAS',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.id5.io/privacy'
+      },
+      '132': {
+        id: 132,
+        name: 'Teads ',
+        purposes: [
+          1,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          9,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.teads.com/privacy-policy/'
+      },
+      '133': {
+        id: 133,
+        name: 'digitalAudience',
+        purposes: [
+          1,
+          3,
+          5,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://digitalaudience.io/legal/privacy-cookies/'
+      },
+      '134': {
+        id: 134,
+        name: 'SMARTSTREAM.TV GmbH',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.smartstream.tv/en/productprivacy',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '136': {
+        id: 136,
+        name: 'Ströer SSP GmbH (SSP)',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.stroeer.de/fileadmin/de/Konvergenz_und_Konzepte/Daten_und_Technologien/Stroeer_SSP/Downloads/Datenschutz_Stroeer_SSP.pdf'
+      },
+      '137': {
+        id: 137,
+        name: 'Ströer SSP GmbH (DSP)',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          9
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.stroeer.de/fileadmin/de/Konvergenz_und_Konzepte/Daten_und_Technologien/Stroeer_SSP/Downloads/Datenschutz_Stroeer_SSP.pdf'
+      },
+      '138': {
+        id: 138,
+        name: 'ConnectAd Realtime GmbH',
+        purposes: [
+          1,
+          3,
+          4,
+          5
+        ],
+        legIntPurposes: [
+          2,
+          7
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'http://connectadrealtime.com/privacy/'
+      },
+      '139': {
+        id: 139,
+        name: 'Permodo GmbH',
+        purposes: [
+          1,
+          2,
+          7,
+          8,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          7,
+          8,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://permodo.com/de/privacy.html',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '142': {
+        id: 142,
+        name: 'Media.net Advertising FZ-LLC',
+        purposes: [
+          1,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          2,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          5,
+          6,
+          8
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.media.net/en/privacy-policy'
+      },
+      '143': {
+        id: 143,
+        name: 'Connatix Native Exchange Inc.',
+        purposes: [
+          1,
+          2,
+          4,
+          6,
+          7,
+          8,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://connatix.com/privacy-policy/'
+      },
+      '144': {
+        id: 144,
+        name: 'district m inc.',
+        purposes: [
+          1,
+          2,
+          4,
+          7,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://districtm.net/en/page/platforms-data-and-privacy-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '147': {
+        id: 147,
+        name: 'Adacado Technologies Inc. (DBA Adacado)',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.adacado.com/privacy-policy-april-25-2018/'
+      },
+      '149': {
+        id: 149,
+        name: 'ADman Interactive SLU',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2
+        ],
+        specialPurposes: [],
+        features: [
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://admanmedia.com/politica.html?setLng=es'
+      },
+      '150': {
+        id: 150,
+        name: 'Inskin Media LTD',
+        purposes: [
+          1,
+          3,
+          4,
+          9,
+          10
+        ],
+        legIntPurposes: [
+          2,
+          7
+        ],
+        flexiblePurposes: [
+          2,
+          7
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'http://www.inskinmedia.com/privacy-policy.html'
+      },
+      '152': {
+        id: 152,
+        name: 'Meetrics GmbH',
+        purposes: [
+          1,
+          9
+        ],
+        legIntPurposes: [
+          7
+        ],
+        flexiblePurposes: [
+          7
+        ],
+        specialPurposes: [
+          1
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.meetrics.com/en/data-privacy/'
+      },
+      '153': {
+        id: 153,
+        name: 'MADVERTISE MEDIA',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          5,
+          6,
+          10
+        ],
+        specialPurposes: [
+          2
+        ],
+        features: [],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://madvertise.com/en/gdpr/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '154': {
+        id: 154,
+        name: 'YOC AG',
+        purposes: [
+          1,
+          3,
+          4,
+          10
+        ],
+        legIntPurposes: [
+          2,
+          7
+        ],
+        flexiblePurposes: [
+          2,
+          7
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://yoc.com/privacy/'
+      },
+      '155': {
+        id: 155,
+        name: 'AntVoice',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.antvoice.com/en/privacypolicy/'
+      },
+      '157': {
+        id: 157,
+        name: 'Seedtag Advertising S.L',
+        purposes: [
+          1,
+          2,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          7,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.seedtag.com/en/privacy-policy/'
+      },
+      '160': {
+        id: 160,
+        name: 'Netsprint SA',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://netsprint.eu/privacy.html',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '161': {
+        id: 161,
+        name: 'Smadex SL',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://smadex.com/end-user-privacy-policy/'
+      },
+      '162': {
+        id: 162,
+        name: 'Unruly Group Ltd',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://unruly.co/privacy/'
+      },
+      '163': {
+        id: 163,
+        name: 'Bombora Inc.',
+        purposes: [
+          1,
+          3,
+          8
+        ],
+        legIntPurposes: [
+          7,
+          10
+        ],
+        flexiblePurposes: [
+          7,
+          10
+        ],
+        specialPurposes: [],
+        features: [
+          1
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://bombora.com/privacy'
+      },
+      '164': {
+        id: 164,
+        name: 'Outbrain UK Ltd',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.outbrain.com/legal/privacy#privacy-policy'
+      },
+      '165': {
+        id: 165,
+        name: 'SpotX, Inc.',
+        purposes: [
+          1,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.spotx.tv/privacy-policy/',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '167': {
+        id: 167,
+        name: 'Audiens S.r.l.',
+        purposes: [
+          1,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'http://www.audiens.com/privacy'
+      },
+      '168': {
+        id: 168,
+        name: 'EASYmedia GmbH',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://login.rtbmarket.com/gdpr'
+      },
+      '173': {
+        id: 173,
+        name: 'Yieldmo, Inc.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.yieldmo.com/privacy/'
+      },
+      '174': {
+        id: 174,
+        name: 'A Million Ads Ltd',
+        purposes: [],
+        legIntPurposes: [
+          2,
+          4
+        ],
+        flexiblePurposes: [
+          2,
+          4
+        ],
+        specialPurposes: [],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.amillionads.com/privacy-policy'
+      },
+      '177': {
+        id: 177,
+        name: 'plista GmbH',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          7,
+          8,
+          10
+        ],
+        flexiblePurposes: [
+          7,
+          8,
+          10
+        ],
+        specialPurposes: [
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.plista.com/about/privacy/'
+      },
+      '178': {
+        id: 178,
+        name: 'Hybrid Theory',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://hybridtheory.com/privacy-policy/'
+      },
+      '179': {
+        id: 179,
+        name: 'Collective Europe Ltd.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          9
+        ],
+        legIntPurposes: [
+          7
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.collectiveuk.com/privacy.html',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '184': {
+        id: 184,
+        name: 'mediarithmics SAS',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          7
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.mediarithmics.com/en-us/content/privacy-policy'
+      },
+      '185': {
+        id: 185,
+        name: 'Bidtellect, Inc',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          8
+        ],
+        legIntPurposes: [
+          9,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.bidtellect.com/privacy-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '190': {
+        id: 190,
+        name: 'video intelligence AG',
+        purposes: [],
+        legIntPurposes: [
+          2,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.vi.ai/privacy-policy/'
+      },
+      '192': {
+        id: 192,
+        name: 'remerge GmbH',
+        purposes: [
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://remerge.io/privacy-policy.html'
+      },
+      '193': {
+        id: 193,
+        name: 'Mediasmart Mobile S.L.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://mediasmart.io/privacy/'
+      },
+      '194': {
+        id: 194,
+        name: 'Rezonence Limited',
+        purposes: [
+          1,
+          3,
+          4,
+          9
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          8,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://rezonence.com/privacy-policy/'
+      },
+      '195': {
+        id: 195,
+        name: 'advanced store GmbH',
+        purposes: [
+          1,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          2
+        ],
+        flexiblePurposes: [
+          2
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.advanced-store.com/de/datenschutz/'
+      },
+      '199': {
+        id: 199,
+        name: 'ADUX',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          6,
+          7,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          2
+        ],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.adux.com/donnees-personelles/'
+      },
+      '200': {
+        id: 200,
+        name: 'Tapjoy, Inc.',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          7
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.tapjoy.com/legal/#privacy-policy'
+      },
+      '203': {
+        id: 203,
+        name: 'Revcontent, LLC',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://intercom.help/revcontent2/en/articles/2290675-revcontent-s-privacy-policy'
+      },
+      '205': {
+        id: 205,
+        name: 'Adssets AB',
+        purposes: [
+          1,
+          2,
+          4,
+          7,
+          8,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://adssets.com/policy/'
+      },
+      '206': {
+        id: 206,
+        name: 'Hybrid Adtech GmbH',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://hybrid.ai/data_protection_policy'
+      },
+      '209': {
+        id: 209,
+        name: 'Delta Projects AB',
+        purposes: [
+          1,
+          2,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          7,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          7,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://deltaprojects.com/data-collection-policy'
+      },
+      '210': {
+        id: 210,
+        name: 'Zemanta, Inc.',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          3,
+          7,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          3,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1
+        ],
+        specialFeatures: [],
+        policyUrl: 'http://www.zemanta.com/legal/privacy'
+      },
+      '211': {
+        id: 211,
+        name: 'AdTheorent, Inc',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'http://adtheorent.com/privacy-policy'
+      },
+      '212': {
+        id: 212,
+        name: 'usemax advertisement (Emego GmbH)',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.usemax.de/?l=privacy'
+      },
+      '213': {
+        id: 213,
+        name: 'emetriq GmbH',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          2
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.emetriq.com/datenschutz/'
+      },
+      '215': {
+        id: 215,
+        name: 'ARMIS SAS',
+        purposes: [
+          1,
+          2,
+          7
+        ],
+        legIntPurposes: [
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://armis.tech/en/armis-personal-data-privacy-policy/'
+      },
+      '216': {
+        id: 216,
+        name: 'Mindlytix SAS',
+        purposes: [
+          1,
+          2,
+          3,
+          5,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'http://mindlytix.com/privacy/'
+      },
+      '217': {
+        id: 217,
+        name: '2KDirect, Inc. (dba iPromote)',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.ipromote.com/privacy-policy/'
+      },
+      '218': {
+        id: 218,
+        name: 'Bigabid Media ltd',
+        purposes: [
+          1,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          2,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.bigabid.com/privacy-policy'
+      },
+      '223': {
+        id: 223,
+        name: 'Audience Trading Platform Ltd.',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          7,
+          8
+        ],
+        flexiblePurposes: [
+          7,
+          8
+        ],
+        specialPurposes: [],
+        features: [
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://atp.io/privacy-policy'
+      },
+      '224': {
+        id: 224,
+        name: 'adrule mobile GmbH',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          8
+        ],
+        legIntPurposes: [
+          7
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          8
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.adrule.net/de/datenschutz/'
+      },
+      '226': {
+        id: 226,
+        name: 'Publicis Media GmbH',
+        purposes: [
+          1,
+          9
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          10
+        ],
+        specialPurposes: [],
+        features: [
+          1
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.publicismedia.de/datenschutz/'
+      },
+      '227': {
+        id: 227,
+        name: 'ORTEC B.V.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.ortecadscience.com/privacy-policy/'
+      },
+      '228': {
+        id: 228,
+        name: 'McCann Discipline LTD',
+        purposes: [
+          1,
+          2,
+          5,
+          6,
+          7,
+          8
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.primis.tech/privacy-policy/'
+      },
+      '231': {
+        id: 231,
+        name: 'AcuityAds Inc.',
+        purposes: [
+          1,
+          3
+        ],
+        legIntPurposes: [
+          2,
+          4,
+          7,
+          8,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://privacy.acuityads.com/corporate-privacy-policy.html',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '234': {
+        id: 234,
+        name: 'ZBO Media',
+        purposes: [
+          1,
+          3,
+          4,
+          9
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://zbo.media/mentions-legales/politique-de-confidentialite-service-publicitaire/'
+      },
+      '235': {
+        id: 235,
+        name: 'Bucksense Inc',
+        purposes: [
+          2,
+          3,
+          4,
+          7,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          9
+        ],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://www.bucksense.com/platform-privacy-policy/'
+      },
+      '240': {
+        id: 240,
+        name: '7Hops.com Inc. (ZergNet)',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          5,
+          6,
+          8,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://zergnet.com/privacy'
+      },
+      '241': {
+        id: 241,
+        name: 'OneTag Limited',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          7
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.onetag.com/privacy/'
+      },
+      '242': {
+        id: 242,
+        name: 'twiago GmbH',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.twiago.com/datenschutz/',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '243': {
+        id: 243,
+        name: 'Cloud Technologies S.A.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.cloudtechnologies.pl/en/internet-advertising-privacy-policy'
+      },
+      '248': {
+        id: 248,
+        name: 'Converge-Digital',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2
+        ],
+        flexiblePurposes: [
+          2
+        ],
+        specialPurposes: [],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://converge-digital.com/privacy-policy/',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '249': {
+        id: 249,
+        name: 'Spolecznosci Sp. z o.o. Sp. k.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.spolecznosci.pl/polityka-prywatnosci'
+      },
+      '250': {
+        id: 250,
+        name: 'Qriously Ltd',
+        purposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.brandwatch.com/legal/qriously-privacy-notice/'
+      },
+      '251': {
+        id: 251,
+        name: 'Yieldlove GmbH',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          7,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.yieldlove.com/cookie-policy'
+      },
+      '252': {
+        id: 252,
+        name: 'Jaduda GmbH',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.jadudamobile.com/datenschutzerklaerung/'
+      },
+      '253': {
+        id: 253,
+        name: 'Improve Digital BV',
+        purposes: [
+          1,
+          3,
+          4,
+          9
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          7
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.improvedigital.com/platform-privacy-policy',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '255': {
+        id: 255,
+        name: 'Onnetwork Sp. z o.o.',
+        purposes: [
+          1,
+          5,
+          6
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          8
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.onnetwork.tv/pp_services.php'
+      },
+      '256': {
+        id: 256,
+        name: 'Bounce Exchange, Inc',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          7,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.bouncex.com/privacy/'
+      },
+      '262': {
+        id: 262,
+        name: 'Fyber ',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.fyber.com/legal/privacy-policy/'
+      },
+      '263': {
+        id: 263,
+        name: 'Nativo, Inc.',
+        purposes: [
+          1,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          9,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.nativo.com/interest-based-ads'
+      },
+      '265': {
+        id: 265,
+        name: 'Instinctive, Inc.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        legIntPurposes: [
+          9,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://instinctive.io/privacy'
+      },
+      '272': {
+        id: 272,
+        name: 'A.Mob',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.we-are-adot.com/privacy-policy/'
+      },
+      '273': {
+        id: 273,
+        name: 'Bannerflow AB',
+        purposes: [
+          1,
+          4
+        ],
+        legIntPurposes: [
+          7
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.bannerflow.com/privacy '
+      },
+      '277': {
+        id: 277,
+        name: 'Codewise VL Sp. z o.o. Sp. k',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9
+        ],
+        legIntPurposes: [
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://voluumdsp.com/end-user-privacy-policy/'
+      },
+      '278': {
+        id: 278,
+        name: 'Integral Ad Science, Inc.',
+        purposes: [],
+        legIntPurposes: [
+          7,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://integralads.com/privacy-policy/'
+      },
+      '279': {
+        id: 279,
+        name: 'Mirando GmbH &amp; Co KG',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          7
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://wwwmirando.de/datenschutz/'
+      },
+      '280': {
+        id: 280,
+        name: 'Spot.IM LTD',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://www.spot.im/privacy/'
+      },
+      '281': {
+        id: 281,
+        name: 'Wizaly',
+        purposes: [
+          1,
+          7,
+          8,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.wizaly.com/terms-of-use#privacy-policy'
+      },
+      '282': {
+        id: 282,
+        name: 'Welect GmbH',
+        purposes: [
+          10
+        ],
+        legIntPurposes: [
+          2,
+          7
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.welect.de/datenschutz'
+      },
+      '284': {
+        id: 284,
+        name: 'WEBORAMA',
+        purposes: [
+          1,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          2,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://weborama.com/privacy_en/'
+      },
+      '285': {
+        id: 285,
+        name: 'Comcast International France SAS',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.freewheel.com/privacy-policy'
+      },
+      '289': {
+        id: 289,
+        name: 'mobalo GmbH',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.mobalo.com/en/privacy/'
+      },
+      '290': {
+        id: 290,
+        name: 'Readpeak Oy',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://readpeak.com/privacy-policy/'
+      },
+      '293': {
+        id: 293,
+        name: 'SpringServe, LLC',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          2
+        ],
+        policyUrl: 'https://springserve.com/privacy-policy/'
+      },
+      '294': {
+        id: 294,
+        name: 'Jivox Corporation',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          7
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.jivox.com/privacy',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '299': {
+        id: 299,
+        name: 'AdClear GmbH',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          2
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.adclear.de/datenschutzerklaerung/'
+      },
+      '301': {
+        id: 301,
+        name: 'zeotap GmbH',
+        purposes: [
+          1,
+          3,
+          4,
+          5,
+          6,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          3,
+          4,
+          5,
+          6,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://zeotap.com/privacy_policy'
+      },
+      '302': {
+        id: 302,
+        name: 'Mobile Professionals BV',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          7,
+          8,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          3,
+          5,
+          7,
+          8
+        ],
+        specialPurposes: [],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://mobpro.com/privacy.html'
+      },
+      '303': {
+        id: 303,
+        name: 'Orion Semantics',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://static.orion-semantics.com/privacy.html'
+      },
+      '304': {
+        id: 304,
+        name: 'On Device Research Limited',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://s.on-device.com/privacyPolicy'
+      },
+      '310': {
+        id: 310,
+        name: 'Adevinta Spain S.L.U.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          9
+        ],
+        legIntPurposes: [
+          7,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.adevinta.com/about/privacy/'
+      },
+      '312': {
+        id: 312,
+        name: 'Exactag GmbH',
+        purposes: [
+          1,
+          3,
+          7,
+          8
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          3,
+          7,
+          8
+        ],
+        specialPurposes: [
+          1
+        ],
+        features: [
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.exactag.com/en/data-privacy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '314': {
+        id: 314,
+        name: 'Keymantics',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.keymantics.com/assets/privacy-policy.pdf'
+      },
+      '315': {
+        id: 315,
+        name: 'Celtra, Inc.',
+        purposes: [
+          1,
+          2,
+          4,
+          7,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.celtra.com/privacy-policy/'
+      },
+      '316': {
+        id: 316,
+        name: 'Gamned',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.gamned.com/privacy-policy/'
+      },
+      '317': {
+        id: 317,
+        name: 'mainADV Srl',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.mainad.com/privacy-policy/'
+      },
+      '318': {
+        id: 318,
+        name: 'Accorp Sp. z o.o.',
+        purposes: [
+          1,
+          3,
+          4,
+          9
+        ],
+        legIntPurposes: [
+          7,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'http://www.instytut-pollster.pl/privacy-policy/'
+      },
+      '319': {
+        id: 319,
+        name: 'Clipcentric, Inc.',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://clipcentric.com/privacy.bhtml'
+      },
+      '325': {
+        id: 325,
+        name: 'Knorex',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.knorex.com/privacy'
+      },
+      '328': {
+        id: 328,
+        name: 'Gemius SA',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.gemius.com/cookie-policy.html'
+      },
+      '329': {
+        id: 329,
+        name: 'Browsi Mobile Ltd',
+        purposes: [
+          1,
+          7,
+          8
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://gobrowsi.com/browsi-privacy-policy/'
+      },
+      '333': {
+        id: 333,
+        name: 'InMobi Pte Ltd',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          9
+        ],
+        specialPurposes: [
+          1
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.inmobi.com/privacy-policy-for-eea'
+      },
+      '336': {
+        id: 336,
+        name: 'Telecoming S.A.',
+        purposes: [
+          2,
+          4
+        ],
+        legIntPurposes: [
+          7,
+          9
+        ],
+        flexiblePurposes: [
+          2,
+          4
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.telecoming.com/privacy-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '343': {
+        id: 343,
+        name: 'DIGITEKA Technologies',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://www.ultimedia.com/POLICY.html'
+      },
+      '345': {
+        id: 345,
+        name: 'The Kantar Group Limited',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'http://www.kantar.com/cookies-policies'
+      },
+      '350': {
+        id: 350,
+        name: 'Free Stream Media Corp. dba Samba TV',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://samba.tv/legal/privacy-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '351': {
+        id: 351,
+        name: 'Samba TV UK Limited',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://samba.tv/legal/privacy-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '354': {
+        id: 354,
+        name: 'Apester Ltd',
+        purposes: [
+          2,
+          4
+        ],
+        legIntPurposes: [
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          7
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://apester.com/privacy-policy/'
+      },
+      '358': {
+        id: 358,
+        name: 'MGID Inc.',
+        purposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.mgid.com/privacy-policy'
+      },
+      '359': {
+        id: 359,
+        name: 'AerServ LLC',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          9
+        ],
+        specialPurposes: [
+          1
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.inmobi.com/privacy-policy-for-eea'
+      },
+      '365': {
+        id: 365,
+        name: 'Forensiq LLC',
+        purposes: [],
+        legIntPurposes: [
+          7
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1
+        ],
+        features: [
+          1,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://impact.com/privacy-policy/'
+      },
+      '368': {
+        id: 368,
+        name: 'VECTAURY',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.vectaury.io/en/personal-data'
+      },
+      '371': {
+        id: 371,
+        name: 'Seeding Alliance GmbH',
+        purposes: [],
+        legIntPurposes: [
+          2,
+          7,
+          8
+        ],
+        flexiblePurposes: [
+          7
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://seeding-alliance.de/datenschutz'
+      },
+      '373': {
+        id: 373,
+        name: 'Nielsen Marketing Cloud',
+        purposes: [
+          1,
+          3,
+          5
+        ],
+        legIntPurposes: [
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://www.nielsen.com/us/en/privacy-statement/exelate-privacy-policy.html'
+      },
+      '374': {
+        id: 374,
+        name: 'Bmind a Sales Maker Company, S.L.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'http://www.bmind.es/legal-notice/'
+      },
+      '377': {
+        id: 377,
+        name: 'AddApptr GmbH',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          7,
+          10
+        ],
+        flexiblePurposes: [
+          7,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.addapptr.com/data-privacy'
+      },
+      '381': {
+        id: 381,
+        name: 'Solocal',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://frontend.adhslx.com/privacy.html?'
+      },
+      '382': {
+        id: 382,
+        name: 'The Reach Group GmbH',
+        purposes: [
+          1,
+          3,
+          4,
+          5,
+          6,
+          9
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          8
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://trg.de/en/privacy-statement/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '385': {
+        id: 385,
+        name: 'Oracle Data Cloud',
+        purposes: [
+          1,
+          3,
+          5,
+          9,
+          10
+        ],
+        legIntPurposes: [
+          7
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.oracle.com/legal/privacy/marketing-cloud-data-cloud-privacy-policy.html'
+      },
+      '387': {
+        id: 387,
+        name: 'Triapodi Ltd.',
+        purposes: [
+          2,
+          3,
+          4,
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://appreciate.mobi/page.html#/end-user-privacy-policy'
+      },
+      '394': {
+        id: 394,
+        name: 'AudienceProject Aps',
+        purposes: [
+          1,
+          3,
+          4,
+          5,
+          6
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          7,
+          8,
+          9
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://privacy.audienceproject.com'
+      },
+      '402': {
+        id: 402,
+        name: 'Effiliation',
+        purposes: [
+          1,
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://inter.effiliation.com/politique-confidentialite.html'
+      },
+      '408': {
+        id: 408,
+        name: 'Fidelity Media',
+        purposes: [
+          1,
+          2,
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          7
+        ],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://fidelity-media.com/privacy-policy/'
+      },
+      '409': {
+        id: 409,
+        name: 'Arrivalist Co.',
+        purposes: [
+          1,
+          9
+        ],
+        legIntPurposes: [
+          7,
+          8
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://www.arrivalist.com/privacy'
+      },
+      '410': {
+        id: 410,
+        name: 'Adtelligent Inc.',
+        purposes: [
+          1,
+          7,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://adtelligent.com/privacy-policy/'
+      },
+      '412': {
+        id: 412,
+        name: 'Cxense ASA',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.cxense.com/about-us/privacy-policy'
+      },
+      '413': {
+        id: 413,
+        name: 'Eulerian Technologies',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.eulerian.com/en/privacy/'
+      },
+      '415': {
+        id: 415,
+        name: 'Seenthis AB',
+        purposes: [],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://seenthis.co/privacy-notice-2018-04-18.pdf'
+      },
+      '416': {
+        id: 416,
+        name: 'Commanders Act',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.commandersact.com/en/privacy/'
+      },
+      '418': {
+        id: 418,
+        name: 'PROXISTORE',
+        purposes: [
+          1,
+          2,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          2
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://www.proxistore.com/common/en/cgv'
+      },
+      '422': {
+        id: 422,
+        name: 'Brand Metrics Sweden AB',
+        purposes: [
+          1,
+          6,
+          7,
+          8,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://collector.brandmetrics.com/brandmetrics_privacypolicy.pdf'
+      },
+      '423': {
+        id: 423,
+        name: 'travel audience GmbH',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://travelaudience.com/product-privacy-policy/'
+      },
+      '424': {
+        id: 424,
+        name: 'KUPONA GmbH',
+        purposes: [
+          4,
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          4
+        ],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.kupona.de/dsgvo/'
+      },
+      '428': {
+        id: 428,
+        name: 'Internet BillBoard a.s.',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          7
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.ibillboard.com/en/privacy-information/'
+      },
+      '429': {
+        id: 429,
+        name: 'Signals',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://signalsdata.com/platform-cookie-policy/'
+      },
+      '431': {
+        id: 431,
+        name: 'White Ops, Inc.',
+        purposes: [],
+        legIntPurposes: [
+          7,
+          9,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          3
+        ],
+        specialFeatures: [
+          2
+        ],
+        policyUrl: 'https://www.whiteops.com/privacy'
+      },
+      '436': {
+        id: 436,
+        name: 'INVIBES GROUP',
+        purposes: [
+          1,
+          3,
+          4,
+          5,
+          6,
+          9
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          8,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          10
+        ],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'http://www.invibes.com/terms'
+      },
+      '438': {
+        id: 438,
+        name: 'INVIDI technologies AB',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'http://www.invidi.com/wp-content/uploads/2020/02/ad-tech-services-privacy-policy.pdf'
+      },
+      '439': {
+        id: 439,
+        name: 'Bit Q Holdings Limited',
+        purposes: [
+          1,
+          7,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.rippll.com/privacy'
+      },
+      '440': {
+        id: 440,
+        name: 'DEFINE MEDIA GMBH',
+        purposes: [
+          1,
+          4
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          4,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.definemedia.de/datenschutz-conative/'
+      },
+      '444': {
+        id: 444,
+        name: 'Playbuzz Ltd (aka EX.CO)',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          5,
+          6
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://ex.co/privacy-policy/'
+      },
+      '447': {
+        id: 447,
+        name: 'Adludio Ltd',
+        purposes: [
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.adludio.com/privacy-policy/'
+      },
+      '450': {
+        id: 450,
+        name: 'Neodata Group srl',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.neodatagroup.com/en/security-policy',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '455': {
+        id: 455,
+        name: 'GDMServices, Inc. d/b/a FiksuDSP',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          10
+        ],
+        legIntPurposes: [
+          7,
+          8
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://fiksu.com/privacy-policy/'
+      },
+      '466': {
+        id: 466,
+        name: 'TACTIC™ Real-Time Marketing AS',
+        purposes: [],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://tacticrealtime.com/privacy/'
+      },
+      '467': {
+        id: 467,
+        name: 'Haensel AMS GmbH',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          7
+        ],
+        flexiblePurposes: [
+          7
+        ],
+        specialPurposes: [],
+        features: [
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://haensel-ams.com/data-privacy/'
+      },
+      '475': {
+        id: 475,
+        name: 'TAPTAP Digital SL',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7
+        ],
+        legIntPurposes: [
+          8,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://www.taptapnetworks.com/privacy_policy/'
+      },
+      '479': {
+        id: 479,
+        name: 'INFINIA MOBILE S.L.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'http://www.infiniamobile.com/privacy_policy'
+      },
+      '484': {
+        id: 484,
+        name: 'STRIATUM SAS',
+        purposes: [],
+        legIntPurposes: [
+          7,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://adledge.com/data-privacy/'
+      },
+      '486': {
+        id: 486,
+        name: 'Madington',
+        purposes: [],
+        legIntPurposes: [
+          7,
+          8,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://delivered-by-madington.com/dat-privacy-policy/'
+      },
+      '488': {
+        id: 488,
+        name: 'Opinary GmbH',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          8,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          7,
+          8,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://opinary.com/privacy-policy/'
+      },
+      '490': {
+        id: 490,
+        name: 'PLAYGROUND XYZ EMEA LTD',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7
+        ],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://playground.xyz/privacy'
+      },
+      '491': {
+        id: 491,
+        name: 'Triboo Data Analytics',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.shinystat.com/it/informativa_privacy_generale.html'
+      },
+      '495': {
+        id: 495,
+        name: 'Arcspire Limited',
+        purposes: [
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://public.arcspire.io/privacy.pdf',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '498': {
+        id: 498,
+        name: 'Dr. Banner',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        legIntPurposes: [
+          9,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://drbanner.com/privacypolicy_en/'
+      },
+      '501': {
+        id: 501,
+        name: 'Alliance Gravity Data Media',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.alliancegravity.com/politiquedeprotectiondesdonneespersonnelles'
+      },
+      '502': {
+        id: 502,
+        name: 'NEXD',
+        purposes: [
+          1,
+          7,
+          10
+        ],
+        legIntPurposes: [
+          9
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://nexd.com/privacy-policy',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '505': {
+        id: 505,
+        name: 'Shopalyst Inc',
+        purposes: [
+          1,
+          7,
+          8
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.shortlyst.com/eu/privacy_terms.html'
+      },
+      '507': {
+        id: 507,
+        name: 'AdsWizz Inc.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://www.adswizz.com/our-privacy-policy/'
+      },
+      '511': {
+        id: 511,
+        name: 'Admixer EU GmbH',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          7,
+          9
+        ],
+        legIntPurposes: [
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://admixer.com/privacy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '512': {
+        id: 512,
+        name: 'PubNative GmbH',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          8,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          2
+        ],
+        policyUrl: 'https://pubnative.net/privacy-notice/'
+      },
+      '516': {
+        id: 516,
+        name: 'Pexi B.V.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://pexi.nl/privacy-policy/'
+      },
+      '517': {
+        id: 517,
+        name: 'SunMedia ',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.sunmedia.tv/en/cookies'
+      },
+      '521': {
+        id: 521,
+        name: 'netzeffekt GmbH',
+        purposes: [
+          1,
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.netzeffekt.de/en/imprint'
+      },
+      '524': {
+        id: 524,
+        name: 'The Ozone Project Limited',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://ozoneproject.com/privacy-policy'
+      },
+      '527': {
+        id: 527,
+        name: 'Jampp LTD',
+        purposes: [
+          1,
+          2,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://jampp.com/privacy.html'
+      },
+      '528': {
+        id: 528,
+        name: 'Kayzen',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          9,
+          10
+        ],
+        legIntPurposes: [
+          7
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://kayzen.io/data-privacy-policy'
+      },
+      '530': {
+        id: 530,
+        name: 'Near Pte Ltd',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://near.co/privacy',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '531': {
+        id: 531,
+        name: 'Smartclip Hispania SL',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://rgpd-smartclip.com/'
+      },
+      '535': {
+        id: 535,
+        name: 'INNITY',
+        purposes: [
+          1,
+          2,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.innity.com/privacy-policy.php'
+      },
+      '536': {
+        id: 536,
+        name: 'GlobalWebIndex',
+        purposes: [
+          1,
+          7,
+          8,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'http://legal.trendstream.net/non-panellist_privacy_policy'
+      },
+      '539': {
+        id: 539,
+        name: 'AdDefend GmbH',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          7
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.addefend.com/en/privacy-policy/'
+      },
+      '543': {
+        id: 543,
+        name: 'PaperG, Inc. dba Thunder Industries',
+        purposes: [
+          1,
+          3,
+          4,
+          5,
+          6
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          8
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.makethunder.com/privacy'
+      },
+      '544': {
+        id: 544,
+        name: 'Kochava Inc.',
+        purposes: [],
+        legIntPurposes: [
+          7
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://www.kochava.com/support-privacy/'
+      },
+      '545': {
+        id: 545,
+        name: 'Reignn Platform Ltd',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          8,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [
+          2
+        ],
+        policyUrl: 'http://reignn.com/user-privacy-policy'
+      },
+      '546': {
+        id: 546,
+        name: 'Smart Traffik',
+        purposes: [
+          1,
+          8
+        ],
+        legIntPurposes: [
+          7
+        ],
+        flexiblePurposes: [
+          7,
+          8
+        ],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://smart-traffik.io/politique-de-confidentialite'
+      },
+      '549': {
+        id: 549,
+        name: 'Bandsintown Amplified LLC',
+        purposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://corp.bandsintown.com/privacy'
+      },
+      '550': {
+        id: 550,
+        name: 'Happydemics',
+        purposes: [
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.iubenda.com/privacy-policy/69056167/full-legal'
+      },
+      '553': {
+        id: 553,
+        name: 'Adhese',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://adhese.com/privacy-and-cookie-policy'
+      },
+      '554': {
+        id: 554,
+        name: 'RMSi Radio Marketing Service interactive GmbH',
+        purposes: [
+          1,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          9
+        ],
+        flexiblePurposes: [
+          2
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://www.rms.de/datenschutz/'
+      },
+      '556': {
+        id: 556,
+        name: 'adhood.com',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://v3.adhood.com/en/site/politikavekurallar/gizlilik.php?lang=en'
+      },
+      '559': {
+        id: 559,
+        name: 'Otto (GmbH &amp; Co KG)',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.otto.de/shoppages/service/datenschutz'
+      },
+      '561': {
+        id: 561,
+        name: 'AuDigent',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'http://audigent.com/platform-privacy-policy'
+      },
+      '565': {
+        id: 565,
+        name: 'Adobe Audience Manager',
+        purposes: [
+          1,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.adobe.com/privacy/policy.html'
+      },
+      '568': {
+        id: 568,
+        name: 'Jointag S.r.l.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://www.jointag.com/privacy/kariboo/publisher/third/'
+      },
+      '571': {
+        id: 571,
+        name: 'ViewPay',
+        purposes: [
+          1,
+          2,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'http://viewpay.tv/mentions-legales/'
+      },
+      '573': {
+        id: 573,
+        name: 'Dailymotion SA',
+        purposes: [
+          1,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          2,
+          5,
+          6,
+          7,
+          8,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.dailymotion.com/legal/privacy',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '574': {
+        id: 574,
+        name: 'Realeyes OU',
+        purposes: [
+          1,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://realview.realeyesit.com/privacy'
+      },
+      '577': {
+        id: 577,
+        name: 'Neustar on behalf of The Procter & Gamble Company',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          6,
+          9
+        ],
+        legIntPurposes: [
+          5,
+          7,
+          8
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9
+        ],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.pg.com/privacy/english/privacy_statement.shtml'
+      },
+      '580': {
+        id: 580,
+        name: 'Goldbach Group AG',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://goldbach.com/ch/de/datenschutz'
+      },
+      '587': {
+        id: 587,
+        name: 'Localsensor B.V.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.localsensor.com/privacy.html'
+      },
+      '591': {
+        id: 591,
+        name: 'Consumable, Inc.',
+        purposes: [
+          1,
+          2,
+          4,
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://consumable.com/privacy-policy.html'
+      },
+      '593': {
+        id: 593,
+        name: 'Programatica de publicidad S.L.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://datmean.com/politica-privacidad/'
+      },
+      '596': {
+        id: 596,
+        name: 'InsurAds Technologies SA.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          9,
+          10
+        ],
+        legIntPurposes: [
+          7,
+          8
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.insurads.com/privacy.html'
+      },
+      '598': {
+        id: 598,
+        name: 'audio content &amp; control GmbH',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          9
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.audio-cc.com/audiocc_privacy_policy.pdf'
+      },
+      '599': {
+        id: 599,
+        name: 'Maximus Live LLC',
+        purposes: [],
+        legIntPurposes: [
+          7,
+          8
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1
+        ],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://maximusx.com/privacy-policy/'
+      },
+      '601': {
+        id: 601,
+        name: 'WebAds B.V',
+        purposes: [
+          1,
+          2
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://privacy.webads.eu/'
+      },
+      '602': {
+        id: 602,
+        name: 'Online Solution Int Limited',
+        purposes: [
+          2,
+          7,
+          8,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          7,
+          8,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://adsafety.net/privacy.html',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '606': {
+        id: 606,
+        name: 'Impactify ',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://impactify.io/privacy-policy/'
+      },
+      '607': {
+        id: 607,
+        name: 'ucfunnel Co., Ltd.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.ucfunnel.com/privacy-policy'
+      },
+      '609': {
+        id: 609,
+        name: 'Predicio',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'http://www.predic.io/privacy',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '610': {
+        id: 610,
+        name: 'Azerion Holding B.V.',
+        purposes: [
+          1,
+          3,
+          4,
+          9
+        ],
+        legIntPurposes: [
+          2,
+          5,
+          6,
+          7,
+          8,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          5,
+          6
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://azerion.com/business/privacy.html',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '612': {
+        id: 612,
+        name: 'Adnami Aps',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.adnami.io/privacy',
+        deletedDate: '2020-03-17T00:00:00Z'
+      },
+      '613': {
+        id: 613,
+        name: 'Adserve.zone / Artworx AS',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          7
+        ],
+        flexiblePurposes: [
+          2
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://adserve.zone/adserveprivacypolicy.html'
+      },
+      '614': {
+        id: 614,
+        name: 'Market Resource Partners LLC',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          2
+        ],
+        policyUrl: 'https://www.mrpfd.com/privacy-policy/'
+      },
+      '615': {
+        id: 615,
+        name: 'Adsolutions BV',
+        purposes: [],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.adsolutions.com/privacy-policy/'
+      },
+      '617': {
+        id: 617,
+        name: 'Onfocus (Adagio)',
+        purposes: [
+          1,
+          2
+        ],
+        legIntPurposes: [
+          7
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://adagio.io/privacy'
+      },
+      '618': {
+        id: 618,
+        name: 'BEINTOO SPA',
+        purposes: [
+          1,
+          2,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://www.beintoo.com/privacy-cookie-policy/'
+      },
+      '620': {
+        id: 620,
+        name: 'Blue',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://www.getblue.io/privacy/'
+      },
+      '625': {
+        id: 625,
+        name: 'BILENDI SA',
+        purposes: [
+          1,
+          6,
+          7,
+          8,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.maximiles.com/privacy-policy'
+      },
+      '626': {
+        id: 626,
+        name: 'Hivestack Inc.',
+        purposes: [
+          1,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://hivestack.com/privacy-policy'
+      },
+      '628': {
+        id: 628,
+        name: ': Tappx',
+        purposes: [
+          1,
+          2,
+          4,
+          7,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          2
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://www.tappx.com/en/privacy-policy/'
+      },
+      '630': {
+        id: 630,
+        name: 'Contact Impact GmbH',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          7,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://contactimpact.de/privacy'
+      },
+      '631': {
+        id: 631,
+        name: 'Relay42 Netherlands B.V.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://relay42.com/privacy'
+      },
+      '639': {
+        id: 639,
+        name: 'Smile Wanted Group',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [
+          2
+        ],
+        policyUrl: 'https://www.smilewanted.com/privacy.php'
+      },
+      '645': {
+        id: 645,
+        name: 'Noster Finance S.L.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          9,
+          10
+        ],
+        legIntPurposes: [
+          7,
+          8
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://www.finect.com/terminos-legales/politica-de-cookies'
+      },
+      '646': {
+        id: 646,
+        name: 'Notify',
+        purposes: [],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://notify-group.com/en/mentions-legales/'
+      },
+      '647': {
+        id: 647,
+        name: 'Axel Springer Teaser Ad GmbH',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          7,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.adup-tech.com/privacy'
+      },
+      '648': {
+        id: 648,
+        name: 'TrueData Solutions, Inc.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://www.truedata.co/privacy-policy/'
+      },
+      '649': {
+        id: 649,
+        name: 'adality GmbH',
+        purposes: [],
+        legIntPurposes: [
+          2
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://adality.de/en/privacy/'
+      },
+      '650': {
+        id: 650,
+        name: 'Telefonica Investigación y Desarrollo S.A.U',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://www.cognitivemarketing.tid.es/'
+      },
+      '652': {
+        id: 652,
+        name: 'Skaze',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://www.skaze.fr/rgpd/'
+      },
+      '653': {
+        id: 653,
+        name: 'Smartme Analytics',
+        purposes: [
+          7,
+          8,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'http://smartmeapp.com/info/smartme/aviso_legal.php'
+      },
+      '656': {
+        id: 656,
+        name: 'Think Clever Media',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          9
+        ],
+        legIntPurposes: [
+          7,
+          8,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.contentignite.com/privacy-policy/'
+      },
+      '657': {
+        id: 657,
+        name: 'GP One GmbH',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://www.gsi-one.org/de/privacy-policy.html'
+      },
+      '659': {
+        id: 659,
+        name: 'Research and Analysis of Media in Sweden AB',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          7,
+          8,
+          9
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www2.rampanel.com/privacy-policy/'
+      },
+      '662': {
+        id: 662,
+        name: 'SoundCast',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://soundcast.fm/en/data-privacy'
+      },
+      '663': {
+        id: 663,
+        name: 'Mobsuccess',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          7
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.mobsuccess.com/en/privacy'
+      },
+      '664': {
+        id: 664,
+        name: 'adMarketplace, Inc.',
+        purposes: [
+          1,
+          2,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          7,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.admarketplace.com/privacy-policy/'
+      },
+      '665': {
+        id: 665,
+        name: 'Digital East GmbH',
+        purposes: [
+          2,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.digitaleast.mobi/en/legal/privacy-policy/'
+      },
+      '667': {
+        id: 667,
+        name: 'Liftoff Mobile, Inc.',
+        purposes: [
+          1,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          2,
+          5,
+          6,
+          7,
+          8,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://liftoff.io/privacy-policy/'
+      },
+      '668': {
+        id: 668,
+        name: 'WhatRocks Inc. ',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          2
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://www.whatrocks.co/en/privacy-policy '
+      },
+      '674': {
+        id: 674,
+        name: 'Duration Media, LLC.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.durationmedia.net/privacy-policy'
+      },
+      '675': {
+        id: 675,
+        name: 'Instreamatic inc.',
+        purposes: [
+          2,
+          3,
+          4,
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://instreamatic.com/privacy-policy/'
+      },
+      '676': {
+        id: 676,
+        name: 'BusinessClick',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.businessclick.com/documents/RegulaminProgramuBusinessClick-2019.pdf'
+      },
+      '678': {
+        id: 678,
+        name: 'Axonix LTD',
+        purposes: [
+          2
+        ],
+        legIntPurposes: [
+          7,
+          10
+        ],
+        flexiblePurposes: [
+          2
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://axonix.com/privacy-cookie-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '681': {
+        id: 681,
+        name: 'MyTraffic',
+        purposes: [
+          1,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          9
+        ],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.mytraffic.io/en/privacy'
+      },
+      '682': {
+        id: 682,
+        name: 'Radio Net Media Limited',
+        purposes: [
+          1,
+          2,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          7
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://www.adtonos.com/service-privacy-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '683': {
+        id: 683,
+        name: 'Cookie Market LTD',
+        purposes: [
+          1,
+          3,
+          4,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'http://cookie.market/privacyPolicy.php'
+      },
+      '684': {
+        id: 684,
+        name: 'Blue Billywig BV',
+        purposes: [],
+        legIntPurposes: [
+          7
+        ],
+        flexiblePurposes: [
+          7
+        ],
+        specialPurposes: [
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.bluebillywig.com/privacy-statement/'
+      },
+      '686': {
+        id: 686,
+        name: 'The MediaGrid Inc.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.themediagrid.com/privacy-policy/'
+      },
+      '687': {
+        id: 687,
+        name: 'MISSENA',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2
+        ],
+        specialPurposes: [
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://missena.com/confidentialite/'
+      },
+      '688': {
+        id: 688,
+        name: 'Effinity',
+        purposes: [],
+        legIntPurposes: [
+          2
+        ],
+        flexiblePurposes: [
+          2,
+          7
+        ],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.effiliation.com/politique-de-confidentialite/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '690': {
+        id: 690,
+        name: 'Go.pl sp. z o.o.',
+        purposes: [
+          1,
+          2,
+          3,
+          4
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://go.pl/polityka-prywatnosci/'
+      },
+      '691': {
+        id: 691,
+        name: 'Lifesight Pte. Ltd.',
+        purposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.lifesight.io/privacy-policy/'
+      },
+      '694': {
+        id: 694,
+        name: 'Snapupp Technologies SL',
+        purposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          9
+        ],
+        legIntPurposes: [
+          7,
+          8,
+          10
+        ],
+        flexiblePurposes: [
+          10
+        ],
+        specialPurposes: [],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.enterprise.noddus.com/privacy-policy',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '699': {
+        id: 699,
+        name: 'HyperTV Inc.',
+        purposes: [
+          1,
+          2,
+          4,
+          9
+        ],
+        legIntPurposes: [
+          7,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          2
+        ],
+        features: [
+          1
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.hypertvx.com/privacy/'
+      },
+      '702': {
+        id: 702,
+        name: 'Kwanko',
+        purposes: [
+          1,
+          2,
+          7,
+          8
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          7,
+          8
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.kwanko.com/fr/rgpd/'
+      },
+      '703': {
+        id: 703,
+        name: 'MindTake Research GmbH',
+        purposes: [
+          1,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1
+        ],
+        features: [
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.mindtake.com/en/reppublika-privacy-policy'
+      },
+      '707': {
+        id: 707,
+        name: 'Dentsu Aegis Network Italia SpA',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://www.dentsuaegisnetwork.com/it/it/policies/info-cookie'
+      },
+      '708': {
+        id: 708,
+        name: 'Dugout Limited ',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://dugout.com/privacy-policy'
+      },
+      '709': {
+        id: 709,
+        name: 'NC Audience Exchange, LLC (NewsIQ)',
+        purposes: [
+          1,
+          3,
+          4,
+          5
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.ncaudienceexchange.com/privacy/'
+      },
+      '711': {
+        id: 711,
+        name: 'SITU8ED SA',
+        purposes: [
+          1,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.situ8ed.com/privacy-policy/'
+      },
+      '712': {
+        id: 712,
+        name: 'Inspired Mobile Limited',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://byinspired.com/privacypolicy.pdf'
+      },
+      '713': {
+        id: 713,
+        name: 'Dataseat Ltd',
+        purposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          7,
+          8
+        ],
+        specialPurposes: [],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://dataseat.com/privacy-policy'
+      },
+      '714': {
+        id: 714,
+        name: 'Survata Inc.',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          7,
+          9
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.survata.com/respondent-privacy-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '716': {
+        id: 716,
+        name: 'OnAudience Ltd',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.onaudience.com/internet-advertising-privacy-policy'
+      },
+      '719': {
+        id: 719,
+        name: 'Online Advertising Network Sp. z o.o.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.oan.pl/en/privacy-policy'
+      },
+      '720': {
+        id: 720,
+        name: 'AAX LLC',
+        purposes: [
+          1,
+          3,
+          4
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://aax.media/privacy/',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '721': {
+        id: 721,
+        name: 'Beaconspark Ltd',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          7
+        ],
+        legIntPurposes: [
+          6,
+          8
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.engageya.com/privacy'
+      },
+      '722': {
+        id: 722,
+        name: 'agof services gmbh',
+        purposes: [],
+        legIntPurposes: [
+          3,
+          5,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          5,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          2
+        ],
+        policyUrl: 'http://www.agof.de/datenschutz/'
+      },
+      '723': {
+        id: 723,
+        name: 'Adzymic Pte Ltd',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          8
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'http://www.adzymic.co/privacy',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '725': {
+        id: 725,
+        name: 'Pubfinity LLC',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://pubfinity.com/privacy-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '727': {
+        id: 727,
+        name: 'Pinpoll GmbH (Private Limited)',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.pinpoll.com/#data_protection_declaration'
+      },
+      '728': {
+        id: 728,
+        name: 'Appier PTE Ltd',
+        purposes: [
+          1,
+          3,
+          4,
+          5,
+          6,
+          9
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          8,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.appier.com/privacy-policy/'
+      },
+      '729': {
+        id: 729,
+        name: 'Cavai AS & UK ',
+        purposes: [],
+        legIntPurposes: [
+          7,
+          8
+        ],
+        flexiblePurposes: [
+          7,
+          8
+        ],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://cav.ai/privacy-policy/'
+      },
+      '730': {
+        id: 730,
+        name: 'INFOnline GmbH',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          8
+        ],
+        flexiblePurposes: [
+          8
+        ],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.infonline.de/en/privacy-policy/'
+      },
+      '731': {
+        id: 731,
+        name: 'GeistM Technologies LTD',
+        purposes: [],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.geistm.com/privacy'
+      },
+      '733': {
+        id: 733,
+        name: 'Anzu Virtual reality LTD',
+        purposes: [
+          1,
+          2,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://anzu.io/privacy/'
+      },
+      '734': {
+        id: 734,
+        name: 'Cint AB',
+        purposes: [
+          1,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.cint.com/participant-privacy-notice'
+      },
+      '735': {
+        id: 735,
+        name: 'Deutsche Post AG',
+        purposes: [
+          1,
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.deutschepost.de/de/c/consentric/datenschutz.html'
+      },
+      '737': {
+        id: 737,
+        name: 'Monet Engine Inc',
+        purposes: [
+          1,
+          2,
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://appmonet.com/privacy-policy/'
+      },
+      '738': {
+        id: 738,
+        name: 'adbility media GmbH',
+        purposes: [
+          2,
+          3,
+          4,
+          9
+        ],
+        legIntPurposes: [
+          7
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          9
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://www.adbility-media.com/datenschutzerklaerung/'
+      },
+      '739': {
+        id: 739,
+        name: 'Blingby LLC',
+        purposes: [
+          1,
+          8,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://blingby.com/privacy'
+      },
+      '740': {
+        id: 740,
+        name: '6Sense Insights, Inc.',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          5,
+          7,
+          8,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          7,
+          8,
+          10
+        ],
+        specialPurposes: [],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://6sense.com/privacy-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '741': {
+        id: 741,
+        name: 'Brand Advance Limited',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://www.wearebrandadvance.com/website-privacy-policy'
+      },
+      '742': {
+        id: 742,
+        name: 'Audiencerate LTD',
+        purposes: [
+          1,
+          2,
+          3,
+          5,
+          6
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.audiencerate.com/privacy/'
+      },
+      '743': {
+        id: 743,
+        name: 'MOVIads Sp. z o.o. Sp. k.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://moviads.pl/polityka-prywatnosci/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '744': {
+        id: 744,
+        name: 'Vidazoo Ltd',
+        purposes: [
+          3,
+          4
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          8,
+          10
+        ],
+        flexiblePurposes: [
+          3,
+          4
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          2
+        ],
+        specialFeatures: [
+          2
+        ],
+        policyUrl: 'https://vidazoo.gitbook.io/vidazoo-legal/privacy-policy',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '745': {
+        id: 745,
+        name: 'Justtag Sp. z o.o.',
+        purposes: [
+          1,
+          3,
+          4,
+          9
+        ],
+        legIntPurposes: [
+          7
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.justtag.com/pdf/PRIVACY_POLICY_Koalametrics_english.pdf'
+      },
+      '746': {
+        id: 746,
+        name: 'Adxperience SAS',
+        purposes: [
+          4
+        ],
+        legIntPurposes: [
+          2,
+          7
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://adxperience.com/privacy-policy/'
+      },
+      '747': {
+        id: 747,
+        name: 'Kairion GmbH',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [],
+        features: [
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://kairion.de/datenschutzbestimmungen/'
+      },
+      '748': {
+        id: 748,
+        name: 'AUDIOMOB LTD',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          8,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          8,
+          9
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://www.audiomob.io/privacy'
+      },
+      '749': {
+        id: 749,
+        name: 'Good-Loop Ltd',
+        purposes: [
+          1,
+          3,
+          4,
+          5,
+          6
+        ],
+        legIntPurposes: [
+          2,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://doc.good-loop.com/policy/privacy-policy.html'
+      },
+      '750': {
+        id: 750,
+        name: 'THE NEWCO S.R.L.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://www.thenewco.it/privacy_policy_servizi_prodotti.html'
+      },
+      '751': {
+        id: 751,
+        name: 'Kiosked Ltd',
+        purposes: [],
+        legIntPurposes: [
+          2,
+          7
+        ],
+        flexiblePurposes: [
+          2,
+          7
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://kiosked.com/privacy-policy/'
+      },
+      '753': {
+        id: 753,
+        name: 'ScaleMonk Inc.',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.scalemonk.com/privacy-policy/index.html'
+      },
+      '754': {
+        id: 754,
+        name: 'DistroScale, Inc.',
+        purposes: [
+          1,
+          2
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2
+        ],
+        specialPurposes: [
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'http://www.distroscale.com/privacy-policy/'
+      },
+      '757': {
+        id: 757,
+        name: 'UAB Meazy',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          7,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://meazy.co/privacy-policy'
+      },
+      '758': {
+        id: 758,
+        name: 'GfK Netherlands B.V.',
+        purposes: [
+          1,
+          7,
+          8,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          7,
+          8,
+          9
+        ],
+        specialPurposes: [],
+        features: [
+          1
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://gfkpanel.nl/privacy'
+      },
+      '759': {
+        id: 759,
+        name: 'RevJet',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.revjet.com/privacy',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '760': {
+        id: 760,
+        name: 'VEXPRO TECHNOLOGIES LTD',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          2
+        ],
+        policyUrl: 'https://onedash.com/privacy-policy.html'
+      },
+      '761': {
+        id: 761,
+        name: 'Digiseg ApS',
+        purposes: [
+          1,
+          3,
+          5,
+          7,
+          8,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          1
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://digiseg.io/privacy-center/'
+      },
+      '762': {
+        id: 762,
+        name: 'Protected Media LTD',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          3,
+          5,
+          7,
+          8,
+          9,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.protected.media/privacy-policy/'
+      },
+      '764': {
+        id: 764,
+        name: 'Lucidity',
+        purposes: [
+          1,
+          2,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://golucidity.com/privacy-policy/'
+      },
+      '765': {
+        id: 765,
+        name: 'Grabit Interactive Media Inc dba KERV Interctive',
+        purposes: [
+          2,
+          3,
+          4,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          2
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://kervit.com/privacy-policy/'
+      },
+      '766': {
+        id: 766,
+        name: 'ADCELL | Firstlead GmbH',
+        purposes: [
+          1,
+          2
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2
+        ],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.adcell.de/agb#sector_6'
+      },
+      '768': {
+        id: 768,
+        name: 'Global Media & Entertainment Limited',
+        purposes: [
+          1,
+          2,
+          3,
+          4,
+          7,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'http://global.com/privacy-policy/'
+      },
+      '769': {
+        id: 769,
+        name: 'MEDIAMETRIE',
+        purposes: [
+          1,
+          8
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.mediametrie.fr/fr/gestion-des-cookies'
+      },
+      '770': {
+        id: 770,
+        name: 'MARKETPERF CORP',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          10
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          1,
+          2,
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.marketperf.com/assets/images/app/marketperf/pdf/privacy-policy.pdf'
+      },
+      '771': {
+        id: 771,
+        name: 'bam! interactive marketing GmbH ',
+        purposes: [
+          1,
+          7,
+          8,
+          9,
+          10
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1,
+          2
+        ],
+        policyUrl: 'https://bam-interactive.de/privacy-policy/'
+      },
+      '772': {
+        id: 772,
+        name: 'Oracle Data Cloud - Moat',
+        purposes: [],
+        legIntPurposes: [
+          7,
+          8,
+          10
+        ],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.oracle.com/legal/privacy/services-privacy-policy.html'
+      },
+      '774': {
+        id: 774,
+        name: 'Wagawin GmbH',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          7
+        ],
+        flexiblePurposes: [
+          2
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.wagawin.com/privacy-en/#productprivacy'
+      },
+      '775': {
+        id: 775,
+        name: 'SelectMedia International LTD',
+        purposes: [
+          1,
+          2
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [
+          3
+        ],
+        specialFeatures: [],
+        policyUrl: 'https://www.selectmedia.asia/terms-and-privacy/'
+      },
+      '776': {
+        id: 776,
+        name: 'Mars Media Group',
+        purposes: [
+          2
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [
+          2
+        ],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://pay-per-leads.com/terms'
+      },
+      '777': {
+        id: 777,
+        name: 'One Planet Only',
+        purposes: [
+          1
+        ],
+        legIntPurposes: [
+          2,
+          3,
+          4,
+          7
+        ],
+        flexiblePurposes: [
+          2,
+          3,
+          4,
+          7
+        ],
+        specialPurposes: [
+          1,
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://oneplanetonly.com/files/PRIVACY%20POLICY.pdf',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '778': {
+        id: 778,
+        name: 'Discover-Tech ltd',
+        purposes: [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://discover-tech.io/dsp-privacy-policy/'
+      },
+      '779': {
+        id: 779,
+        name: 'Adtarget Medya A.S.',
+        purposes: [
+          1,
+          7
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [
+          3
+        ],
+        specialFeatures: [
+          1
+        ],
+        policyUrl: 'https://adtarget.com.tr/adtarget-privacy-policy-2020.pdf'
+      },
+      '780': {
+        id: 780,
+        name: 'Aniview LTD',
+        purposes: [
+          1,
+          2,
+          7,
+          8
+        ],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [
+          2
+        ],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.aniview.com/privacy-policy/'
+      }
+    }
+  }}
+
+const VendorList46 = {data:{
+  gvlSpecificationVersion: 2,
+  vendorListVersion: 46,
+  tcfPolicyVersion: 2,
+  lastUpdated: '2020-07-09T16:05:42Z',
+  purposes: {
+    '1': {
+      id: 1,
+      name: 'Almacenar o acceder a información en un dispositivo',
+      description: 'Se puede almacenar o acceder a cookies, identificadores de dispositivo u otra información en su dispositivo para las finalidades que se le presentan.',
+      descriptionLegal: 'Los proveedores pueden:\n* Almacenar y/o acceder a información en el dispositivo a través de cookies e identificadores de dispositivo ejecutados/instalados en el equipo del usuario.'
+    },
+    '2': {
+      id: 2,
+      name: 'Seleccionar anuncios básicos',
+      description: 'Los anuncios se pueden mostrar en función del contenido que se esté visualizando, la aplicación que se esté utilizando, su localización aproximada o su tipo de dispositivo.',
+      descriptionLegal: 'Para realizar la selección de anuncios básicos, los proveedores pueden:\n* Utilizar información en tiempo real sobre el contexto en el que se mostrará el anuncio, para mostrar el anuncio, incluida la información sobre el contenido y el dispositivo, como por ejemplo: tipo de dispositivo y sus funcionalidades, agente de usuario, URL, dirección IP \n* Utilizar los datos de localización geográfica de aproximada\n* Controlar la frecuencia con la que se muestran los anuncios a un usuario.\n* Secuenciar el orden en el que se muestran los anuncios a un usuario.\n* Evitar que un anuncio se sirva o envíe en un contexto editorial inadecuado (Brand safety)\nLos Proveedores no pueden:\n* Crear un perfil publicitario personalizado utilizando esta información para la selección de anuncios futuros sin una base jurídica separada cuya finalidad específica fuera crear un perfil publicitario personalizados.\nNota: Aproximada significa que se permite solamente una localización aproximada de, como máximo, dentro de un radio de 500 metros.\n'
+    },
+    '3': {
+      id: 3,
+      name: 'Crear un perfil publicitario personalizado',
+      description: 'Se puede elaborar un perfil sobre usted y sus intereses para mostrarle anuncios personalizados que sean pertinentes para usted.',
+      descriptionLegal: 'Para crear un perfil publicitario personalizado, los proveedores pueden:\n* Recoger información sobre un usuario, (incluyendo la actividad anterior del usuario, sus intereses, páginas web o aplicaciones visitadas con anterioridad, ubicación o información demográfica) a fin de crear o editar un perfil de usuario para su uso en publicidad personalizada.\n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones, a fin de crear o editar un perfil de usuario para su uso en publicidad personalizada\n'
+    },
+    '4': {
+      id: 4,
+      name: 'Seleccionar anuncios personalizados',
+      description: 'Se pueden mostrar anuncios personalizados basándose en su perfil.',
+      descriptionLegal: 'Para seleccionar anuncios personalizados, los proveedores pueden:\n* Seleccionar anuncios personalizados basándose en un perfil de usuario u otros datos históricos del usuario, incluida la actividad anterior de un usuario, sus intereses, visitas a sitios web o aplicaciones, ubicación o información demográfica.\n'
+    },
+    '5': {
+      id: 5,
+      name: 'Crear un perfil para la personalización de contenidos',
+      description: 'Se puede crear un perfil sobre usted y sus intereses para mostrarle contenido personalizado que le fuera pertinente.',
+      descriptionLegal: 'Para crear un un perfil para la personalización de contenidos, los proveedores pueden:\n* Recoger información sobre un usuario, incluida la actividad de un usuario, sus intereses, visitas a sitios o aplicaciones, información demográfica o ubicación, a fin de crear o editar un perfil de usuario para personalizar el contenido.\n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones, a fin de crear o editar un perfil de usuario para personalizar el contenido.\n'
+    },
+    '6': {
+      id: 6,
+      name: 'Seleccionar contenido personalizado',
+      description: 'Se puede mostrar contenido personalizado basado en su perfil.',
+      descriptionLegal: 'Para seleccionar contenido personalizado, los proveedores pueden:\n* Seleccionar contenido personalizado basándose en un perfil de usuario u otros datos históricos de usuarios, incluida la actividad anterior del usuario, sus intereses, visitas a sitios web o aplicaciones, ubicación o información demográfica.'
+    },
+    '7': {
+      id: 7,
+      name: 'Medir el rendimiento de los anuncios',
+      description: 'Se puede medir el rendimiento y eficacia de los anuncios que usted ve o con los que interactúa.',
+      descriptionLegal: 'Para medir el rendimiento de los anuncios, los proveedores pueden:\n* Medir si los anuncios fueron suministrados a un usuario y cómo este interactuó con ellos\n* Elaborar informes sobre anuncios, incluida su eficacia y rendimiento\n* Elaborar informes sobre los usuarios que interactuaron con los anuncios utilizando datos observados durante el curso de la interacción del usuario con ese anuncio\n* Elaborar informes para los editores sobre los anuncios mostrados en sus sitios web o propiedad digital\n* Medir si un anuncio sirve en un contexto editorial adecuado (seguro para la marca)\n* Determinar el porcentaje del anuncio que se tuvo la oportunidad de ser visto y la duración de esa oportunidad \n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones.\nLos proveedores no pueden:\n* Aplicar datos de información sobre el público basados en un panel de usuarios o similares a los datos de medición de anuncios sin una base jurídica independiente para utilizar estudios de mercado a fin de generar información sobre el público.\n'
+    },
+    '8': {
+      id: 8,
+      name: 'Medir el rendimiento del contenido',
+      description: 'Se puede medir el rendimiento y la eficacia del contenido que ve o con el que interactúa.',
+      descriptionLegal: 'Para medir el rendimiento del contenido, los proveedores pueden:\n* Medir e informar sobre cómo se entregó el contenido y cómo interactuaron con él los usuarios.\n* Elaborar informes, utilizando información directamente medible o conocida, sobre los usuarios que interactuaron con el contenido\n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones.\nLos proveedores no pueden:\n* Medir si los anuncios (incluida la publicidad nativa) fueron suministrados a un usuario y si este interactuó con ellos sin tener una base jurídica alternativa que lo permita.\n* Aplicar datos de información sobre el público, basados en un panel de usuarios o similares, a los datos de medición de anuncios sin una base jurídica independiente para utilizar estudios de mercado a fin de generar información sobre el público.\n'
+    },
+    '9': {
+      id: 9,
+      name: 'Utilizar estudios de mercado a fin de generar información sobre el público',
+      description: 'La investigación de mercado puede utilizarse para obtener más información sobre el público que visita sitios webs/aplicaciones y visualiza los anuncios.',
+      descriptionLegal: 'Para utilizar estudios de mercado a fin de generar información sobre el público, los proveedores pueden:\n* Elaborar informes agregados para los anunciantes o sus representantes sobre el público alcanzado por sus anuncios, a través de información basada en paneles de audiencia u obtenida de manera similar.\n* Elaborar informes agregados para los editores sobre el público al que se le mostraron contenidos y/o anuncios o que interactuaron con ellos en su propiedad, aplicando información basada en paneles de audiencia u obtenida de manera similar\n* Asociar datos off line con un usuario on line para finalidades de estudios de mercado a fin de generar información sobre el público si los proveedores han declarado que cotejan y combinan fuentes de datos off line \n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones.\nLos proveedores no pueden: \n* Medir el rendimiento y la eficacia de los anuncios que se mostraron a un usuario específico o con los que interactuó, sin una base jurídica independiente para medir el rendimiento de los anuncios.\n• Medir qué contenido se mostró a un usuario específico y cómo interactuó con el mismo, sin una base jurídica independiente para medir el rendimiento del contenido.\n'
+    },
+    '10': {
+      id: 10,
+      name: 'Desarrollar y mejorar productos',
+      description: 'Sus datos pueden utilizarse para mejorar los sistemas y/o el software existente, así como para desarrollar nuevos productos.',
+      descriptionLegal: 'Para desarrollar nuevos productos y mejorar los productos, los proveedores pueden:\n* Utilizar información para mejorar sus productos existentes con nuevas funcionalidades/características y desarrollar nuevos productos\n* Crear nuevos modelos y algoritmos mediante machine learning\nLos proveedores no pueden:\n* A partir de esta finalidad no se puede llevar a cabo ninguna otra operación de tratamiento de datos permitida en virtud de una finalidad distinta.\n'
+    }
+  },
+  specialPurposes: {
+    '1': {
+      id: 1,
+      name: 'Garantizar la seguridad, evitar fraudes y depurar errores',
+      description: 'Sus datos pueden utilizarse para supervisar y evitar actividades fraudulentas, y para asegurar que los sistemas y procesos funcionen de forma correcta y segura.',
+      descriptionLegal: 'Para garantizar la seguridad, evitar fraudes y depurar errores, los proveedores pueden:\n* Asegurarse de que los datos se transmitan de forma segura \n* Detectar y evitar actividades maliciosas, fraudulentas, inaceptables o ilegales.\n* Asegurar el funcionamiento correcto y eficaz de los sistemas y procesos, lo que incluye supervisar y mejorar el rendimiento de los sistemas y procesos empleados en las finalidades permitidas\nLos proveedores no pueden:\n* Llevar a cabo ninguna otra operación de tratamiento de datos permitida en virtud de una finalidad distinta.\nNota: Los datos recopilados y utilizados para garantizar la seguridad, evitar el fraude y depurar errores pueden incluir características del dispositivo enviadas automáticamente para su identificación, datos de geolocalización precisos y datos obtenidos analizando de forma activa las características del dispositivo para su identificación sin que sea necesario revelar más información y/o una aceptación independiente.  \n'
+    },
+    '2': {
+      id: 2,
+      name: 'Servir técnicamente anuncios o contenido',
+      description: 'Su dispositivo puede recibir y enviar información que le permita ver e interactuar con anuncios y contenido.',
+      descriptionLegal: 'Para servir información y responder a solicitudes técnicas, los proveedores pueden:\n* Utilizar la dirección IP de un usuario para entregar un anuncio a través de Internet\n* Responder a la interacción de un usuario con un anuncio enviando al usuario a una página de destino\n* Utilizar la dirección IP de un usuario para entregar contenido a través de Internet\n* Responder a la interacción de un usuario con el contenido enviando al usuario a una página de destino\n* Utilizar información sobre el tipo de dispositivo y sus capacidades para entregar anuncios o contenido, por ejemplo, para entregar el archivo publicitario o de vídeo de tamaño adecuado en un formato compatible con el dispositivo\nLos proveedores no pueden:\n* Llevar a cabo, según esta finalidad, ninguna otra operación de tratamiento de datos permitida en virtud de una finalidad distinta.\n'
+    }
+  },
+  features: {
+    '1': {
+      id: 1,
+      name: 'Cotejar y combinar fuentes de datos off line',
+      description: 'Los datos obtenidos de fuentes de datos off line pueden combinarse con su actividad on line para respaldar una o más finalidades.',
+      descriptionLegal: 'Los proveedores pueden: \n* Combinar los datos obtenidos off line con los datos recogidos on line en apoyo de una o más Finalidades o Finalidades especiales.'
+    },
+    '2': {
+      id: 2,
+      name: 'Vincular diferentes dispositivos',
+      description: 'Se puede determinar que diferentes dispositivos pertenecen a usted o a su hogar para una o más finalidades.',
+      descriptionLegal: 'Los proveedores pueden:\n* Determinar de forma determinista que dos o más dispositivos pertenecen al mismo usuario u hogar\n* Determinar de forma probabilística que dos o más dispositivos pertenecen al mismo usuario u hogar\n* Analizar activamente las características del dispositivo para encontrar su identificación probabilística si los usuarios han permitido a los proveedores analizar activamente las características del dispositivo para su identificación (Funcionalidad especial 2)\n'
+    },
+    '3': {
+      id: 3,
+      name: 'Recibir y utilizar para su identificación las características del dispositivo que    se envían automáticamente',
+      description: 'Su dispositivo puede distinguirse de otros dispositivos a partir de la información que envía automáticamente, como la dirección IP o el tipo de navegador.',
+      descriptionLegal: 'Los proveedores pueden:\n* Crear un identificador utilizando los datos recopilados automáticamente en un dispositivo para características específicas, por ejemplo, dirección IP o la cadena de agente de usuario.\n* Utilizar este identificador para intentar volver a identificar un dispositivo.\nLos proveedores no pueden:\n* Crear un identificador utilizando datos recogidos mediante el análisis activo de un dispositivo para hallar funcionalidads específicas, por ejemplo, fuentes instaladas o resolución de pantalla sin aceptación independiente del usuario para analizar de forma activa las características del dispositivo para su identificación.\n* Utilizar este identificador para volver a identificar un dispositivo.\n'
+    }
+  },
+  specialFeatures: {
+    '1': {
+      id: 1,
+      name: 'Utilizar datos de localización geográfica precisa',
+      description: 'Sus datos de localización geográfica precisa se pueden utilizar para una o más finalidades. Esto significa que su ubicación puede tener una precisión de varios metros.',
+      descriptionLegal: 'Los proveedores pueden:\n* Recoger y tratar datos de localización geográfica precisa para una o más finalidades.\nNota: La localización geográfica precisa significa que no existen restricciones sobre la precisión de la ubicación de un usuario; esto puede tener una precisión de varios metros.\n'
+    },
+    '2': {
+      id: 2,
+      name: 'Analizar activamente las características del dispositivo para su identificación',
+      description: 'Su dispositivo puede identificarse basándose en un análisis de la combinación única de las características de su dispositivo.',
+      descriptionLegal: 'Los proveedores pueden:\n* Crear un identificador utilizando datos recogidos mediante el análisis activo de un dispositivo para hallar características específicas, por ejemplo, fuentes instaladas o resolución de pantalla. \n* Utilizar este identificador para volver a identificar un dispositivo.\n'
+    }
+  },
+  stacks: {
+    '1': {
+      id: 1,
+      purposes: [],
+      specialFeatures: [
+        1,
+        2
+      ],
+      name: 'Datos de localización geográfica precisa e identificación mediante las características de dispositivos',
+      description: 'Se puede utilizar la localización geográfica precisa y la información sobre las características del dispositivo.'
+    },
+    '2': {
+      id: 2,
+      purposes: [
+        2,
+        7
+      ],
+      specialFeatures: [],
+      name: 'Anuncios básicos y medición de anuncios',
+      description: 'Se pueden mostrar anuncios básicos. Se puede medir el rendimiento de los anuncios.'
+    },
+    '3': {
+      id: 3,
+      purposes: [
+        2,
+        3,
+        4
+      ],
+      specialFeatures: [],
+      name: 'Anuncios personalizados',
+      description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios.'
+    },
+    '4': {
+      id: 4,
+      purposes: [
+        2,
+        7,
+        9
+      ],
+      specialFeatures: [],
+      name: 'Anuncios básicos y medición de anuncios',
+      description: 'Se pueden mostrar anuncios básicos. Se puede medir el rendimiento de los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+    },
+    '5': {
+      id: 5,
+      purposes: [
+        2,
+        3,
+        7
+      ],
+      specialFeatures: [],
+      name: 'Anuncios básicos, creación de perfil publicitario personalizado y medición de anuncios',
+      description: 'Se pueden mostrar anuncios básicos. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios.'
+    },
+    '6': {
+      id: 6,
+      purposes: [
+        2,
+        4,
+        7
+      ],
+      specialFeatures: [],
+      name: 'Mostrar anuncios personalizados y medición de anuncios',
+      description: 'Los anuncios pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios.'
+    },
+    '7': {
+      id: 7,
+      purposes: [
+        2,
+        4,
+        7,
+        9
+      ],
+      specialFeatures: [],
+      name: 'Mostrar anuncios personalizados, medición de anuncios e información sobre el público',
+      description: 'Los anuncios pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+    },
+    '8': {
+      id: 8,
+      purposes: [
+        2,
+        3,
+        4,
+        7
+      ],
+      specialFeatures: [],
+      name: 'Anuncios personalizados y medición de anuncios',
+      description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios.'
+    },
+    '9': {
+      id: 9,
+      purposes: [
+        2,
+        3,
+        4,
+        7,
+        9
+      ],
+      specialFeatures: [],
+      name: 'Anuncios personalizados, medición de anuncios e información sobre el público',
+      description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+    },
+    '10': {
+      id: 10,
+      purposes: [
+        3,
+        4
+      ],
+      specialFeatures: [],
+      name: 'Perfil y muestra de anuncios personalizados',
+      description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios.'
+    },
+    '11': {
+      id: 11,
+      purposes: [
+        5,
+        6
+      ],
+      specialFeatures: [],
+      name: 'Contenido personalizado',
+      description: 'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido.'
+    },
+    '12': {
+      id: 12,
+      purposes: [
+        6,
+        8
+      ],
+      specialFeatures: [],
+      name: 'Muestra de contenido personalizado y medición de contenido',
+      description: 'El contenido puede personalizarse basándose en un perfil. Se puede medir el rendimiento del contenido.'
+    },
+    '13': {
+      id: 13,
+      purposes: [
+        6,
+        8,
+        9
+      ],
+      specialFeatures: [],
+      name: 'Presentación de contenido personalizado, medición del contenido e información sobre el público',
+      description: 'El contenido puede personalizarse basándose en un perfil. Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+    },
+    '14': {
+      id: 14,
+      purposes: [
+        5,
+        6,
+        8
+      ],
+      specialFeatures: [],
+      name: 'Contenido personalizado y medición del contenido',
+      description: 'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido.'
+    },
+    '15': {
+      id: 15,
+      purposes: [
+        5,
+        6,
+        8,
+        9
+      ],
+      specialFeatures: [],
+      name: 'Contenido personalizado, medición del contenido e información sobre el público',
+      description: 'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+    },
+    '16': {
+      id: 16,
+      purposes: [
+        5,
+        6,
+        8,
+        9,
+        10
+      ],
+      specialFeatures: [],
+      name: 'Contenido personalizado, medición del contenido, información sobre el público y desarrollo de productos',
+      description: 'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido. Se puede inducir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software'
+    },
+    '17': {
+      id: 17,
+      purposes: [
+        7,
+        8,
+        9
+      ],
+      specialFeatures: [],
+      name: 'Medición de anuncios y del contenido e información sobre el público',
+      description: 'Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+    },
+    '18': {
+      id: 18,
+      purposes: [
+        7,
+        8
+      ],
+      specialFeatures: [],
+      name: 'Medición de anuncios y del contenido',
+      description: 'Se puede medir el rendimiento de los anuncios y del contenido.'
+    },
+    '19': {
+      id: 19,
+      purposes: [
+        7,
+        9
+      ],
+      specialFeatures: [],
+      name: 'Medición de anuncios e información sobre el público',
+      description: 'Se pueden medir los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+    },
+    '20': {
+      id: 20,
+      purposes: [
+        7,
+        8,
+        9,
+        10
+      ],
+      specialFeatures: [],
+      name: 'Medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+      description: 'Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+    },
+    '21': {
+      id: 21,
+      purposes: [
+        8,
+        9,
+        10
+      ],
+      specialFeatures: [],
+      name: 'Medición del contenido, información sobre el público y desarrollo de productos.',
+      description: 'Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+    },
+    '22': {
+      id: 22,
+      purposes: [
+        8,
+        10
+      ],
+      specialFeatures: [],
+      name: 'Medición del contenido y desarrollo de productos',
+      description: 'Se puede medir el rendimiento del contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+    },
+    '23': {
+      id: 23,
+      purposes: [
+        2,
+        4,
+        6,
+        7,
+        8
+      ],
+      specialFeatures: [],
+      name: 'Presentación de anuncios y contenido personalizados, medición de anuncios y del contenido',
+      description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios y del contenido.'
+    },
+    '24': {
+      id: 24,
+      purposes: [
+        2,
+        4,
+        6,
+        7,
+        8,
+        9
+      ],
+      specialFeatures: [],
+      name: 'Presentación de anuncios y contenido personalizados, medición de anuncios y del contenido e información sobre el público',
+      description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+    },
+    '25': {
+      id: 25,
+      purposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      specialFeatures: [],
+      name: 'Anuncios y contenido personalizados, medición de anuncios y del contenido',
+      description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios y el contenido. Se puede medir el rendimiento de los anuncios y del contenido.'
+    },
+    '26': {
+      id: 26,
+      purposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      specialFeatures: [],
+      name: 'Anuncios y contenido personalizados, medición de anuncios y del contenido e información sobre el público',
+      description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios y el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+    },
+    '27': {
+      id: 27,
+      purposes: [
+        3,
+        5
+      ],
+      specialFeatures: [],
+      name: 'Anuncios personalizados y contenido personalizado',
+      description: 'Se pueden añadir más datos para personalizar los anuncios y el contenido.'
+    },
+    '28': {
+      id: 28,
+      purposes: [
+        2,
+        4,
+        6
+      ],
+      specialFeatures: [],
+      name: 'Muestra de anuncios y contenido personalizados',
+      description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil.'
+    },
+    '29': {
+      id: 29,
+      purposes: [
+        2,
+        7,
+        8,
+        9
+      ],
+      specialFeatures: [],
+      name: 'Anuncios básicos, medición de anuncios y del contenido e información sobre el público',
+      description: 'Se pueden mostrar anuncios básicos. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+    },
+    '30': {
+      id: 30,
+      purposes: [
+        2,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      specialFeatures: [],
+      name: 'Muestra de anuncios personalizados, contenido personalizado, medición de anuncios y del contenido e información sobre el público',
+      description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+    },
+    '31': {
+      id: 31,
+      purposes: [
+        2,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialFeatures: [],
+      name: 'Muestra de anuncios personalizados, contenido personalizado, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+      description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+    },
+    '32': {
+      id: 32,
+      purposes: [
+        2,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      specialFeatures: [],
+      name: 'Anuncios básicos, contenido personalizado, medición de anuncios y del contenido e información sobre el público',
+      description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+    },
+    '33': {
+      id: 33,
+      purposes: [
+        2,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialFeatures: [],
+      name: 'Anuncios básicos, contenido personalizado, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+      description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+    },
+    '34': {
+      id: 34,
+      purposes: [
+        2,
+        5,
+        6,
+        8,
+        9
+      ],
+      specialFeatures: [],
+      name: 'Anuncios básicos, contenido personalizado, medición del contenido e información sobre el público',
+      description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+    },
+    '35': {
+      id: 35,
+      purposes: [
+        2,
+        5,
+        6,
+        8,
+        9,
+        10
+      ],
+      specialFeatures: [],
+      name: 'Anuncios básicos, contenido personalizado, medición del contenido, información sobre el público y desarrollo de productos',
+      description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+    },
+    '36': {
+      id: 36,
+      purposes: [
+        2,
+        5,
+        6,
+        7
+      ],
+      specialFeatures: [],
+      name: 'Anuncios básicos, contenido personalizado y medición de anuncios',
+      description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios.'
+    },
+    '37': {
+      id: 37,
+      purposes: [
+        2,
+        5,
+        6,
+        7,
+        10
+      ],
+      specialFeatures: [],
+      name: 'Anuncios básicos, contenido personalizado, medición de anuncios y desarrollo de productos',
+      description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+    },
+    '38': {
+      id: 38,
+      purposes: [
+        2,
+        3,
+        4,
+        7,
+        10
+      ],
+      specialFeatures: [],
+      name: 'Anuncios personalizados, medición de anuncios y desarrollo de productos',
+      description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+    },
+    '39': {
+      id: 39,
+      purposes: [
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      specialFeatures: [],
+      name: 'Anuncios personalizados, medición de anuncios, información sobre el público y desarrollo de productos',
+      description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+    },
+    '40': {
+      id: 40,
+      purposes: [
+        2,
+        3,
+        4,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialFeatures: [],
+      name: 'Anuncios personalizados, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+      description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios y del contenido. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+    },
+    '41': {
+      id: 41,
+      purposes: [
+        2,
+        3,
+        4,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialFeatures: [],
+      name: 'Anuncios personalizados, muestra de contenido personalizado, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+      description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios y del contenido. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+    },
+    '42': {
+      id: 42,
+      purposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialFeatures: [],
+      name: 'Anuncios y contenido personalizados, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+      description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios y el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+    }
+  },
+  vendors: {
+    '1': {
+      id: 1,
+      name: 'Exponential Interactive, Inc d/b/a VDX.tv',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://vdx.tv/privacy/'
+    },
+    '2': {
+      id: 2,
+      name: 'Captify Technologies Limited',
+      purposes: [
+        1,
+        2,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        7,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2
+      ],
+      specialPurposes: [],
+      features: [
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'http://www.captify.co.uk/privacy-policy/'
+    },
+    '4': {
+      id: 4,
+      name: 'Roq.ad Inc.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.roq.ad/privacy-policy'
+    },
+    '6': {
+      id: 6,
+      name: 'AdSpirit GmbH',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        9
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'http://www.adspirit.de/privacy',
+      overflow: {
+        httpGetLimit: 32
+      }
+    },
+    '8': {
+      id: 8,
+      name: 'Emerse Sverige AB',
+      purposes: [
+        1,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        8,
+        9
+      ],
+      flexiblePurposes: [
+        2,
+        9
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.emerse.com/privacy-policy/'
+    },
+    '9': {
+      id: 9,
+      name: 'AdMaxim Inc.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://www.admaxim.com/admaxim-privacy-policy/',
+      deletedDate: '2020-06-17T00:00:00Z'
+    },
+    '10': {
+      id: 10,
+      name: 'Index Exchange, Inc. ',
+      purposes: [
+        1,
+        2,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        7
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.indexexchange.com/privacy'
+    },
+    '11': {
+      id: 11,
+      name: 'Quantcast International Limited',
+      purposes: [
+        1,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.quantcast.com/privacy/'
+    },
+    '12': {
+      id: 12,
+      name: 'BeeswaxIO Corporation',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.beeswax.com/privacy/'
+    },
+    '13': {
+      id: 13,
+      name: 'Sovrn Holdings Inc',
+      purposes: [
+        1,
+        2,
+        3,
+        5,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.sovrn.com/sovrn-privacy/'
+    },
+    '14': {
+      id: 14,
+      name: 'Adkernel LLC',
+      purposes: [
+        1,
+        7
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        9
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://adkernel.com/privacy-policy/',
+      overflow: {
+        httpGetLimit: 32
+      }
+    },
+    '15': {
+      id: 15,
+      name: 'Adikteev',
+      purposes: [
+        1,
+        3,
+        4,
+        5,
+        6,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [
+        2,
+        7
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.adikteev.com/privacy-policy-eng/'
+    },
+    '16': {
+      id: 16,
+      name: 'RTB House S.A.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.rtbhouse.com/privacy-center/services-privacy-policy/'
+    },
+    '18': {
+      id: 18,
+      name: 'Widespace AB',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7
+      ],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.widespace.com/legal/privacy-policy-notice/'
+    },
+    '21': {
+      id: 21,
+      name: 'The Trade Desk',
+      purposes: [
+        1,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        7,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.thetradedesk.com/general/privacy-policy'
+    },
+    '22': {
+      id: 22,
+      name: 'admetrics GmbH',
+      purposes: [
+        2,
+        7,
+        8,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://admetrics.io/en/privacy_policy/'
+    },
+    '23': {
+      id: 23,
+      name: 'Amobee, Inc. ',
+      purposes: [
+        1,
+        2,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        7,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.amobee.com/trust/privacy-guidelines'
+    },
+    '24': {
+      id: 24,
+      name: 'Epsilon',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.conversantmedia.eu/legal/privacy-policy'
+    },
+    '25': {
+      id: 25,
+      name: 'Verizon Media EMEA Limited',
+      purposes: [
+        1,
+        3,
+        4,
+        5,
+        6
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.verizonmedia.com/policies/ie/en/verizonmedia/privacy/index.html'
+    },
+    '28': {
+      id: 28,
+      name: 'TripleLift, Inc.',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://triplelift.com/privacy/',
+      overflow: {
+        httpGetLimit: 32
+      }
+    },
+    '30': {
+      id: 30,
+      name: 'BidTheatre AB',
+      purposes: [
+        1,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2
+      ],
+      flexiblePurposes: [
+        2
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.bidtheatre.com/privacy-policy'
+    },
+    '31': {
+      id: 31,
+      name: 'Ogury Ltd.',
+      purposes: [
+        1,
+        3,
+        4,
+        9
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.ogury.com/privacy-policy/'
+    },
+    '32': {
+      id: 32,
+      name: 'Xandr, Inc.',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        7,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        2
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.xandr.com/privacy/platform-privacy-policy/'
+    },
+    '33': {
+      id: 33,
+      name: 'ShareThis, Inc',
+      purposes: [
+        1,
+        3,
+        5,
+        6
+      ],
+      legIntPurposes: [
+        9,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://sharethis.com/privacy/'
+    },
+    '34': {
+      id: 34,
+      name: 'NEORY GmbH',
+      purposes: [
+        1,
+        3,
+        4,
+        5,
+        6,
+        9
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        8
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.neory.com/privacy.html',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '36': {
+      id: 36,
+      name: 'RhythmOne DBA Unruly Group Ltd',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.rhythmone.com/privacy-policy'
+    },
+    '37': {
+      id: 37,
+      name: 'NEURAL.ONE',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://web.neural.one/privacy-policy/'
+    },
+    '39': {
+      id: 39,
+      name: 'ADITION technologies AG',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.adition.com/datenschutz'
+    },
+    '40': {
+      id: 40,
+      name: 'Active Agent (ADITION technologies AG)',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://www.active-agent.com/de/unternehmen/datenschutzerklaerung/'
+    },
+    '41': {
+      id: 41,
+      name: 'Adverline',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.adverline.com/privacy/',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '42': {
+      id: 42,
+      name: 'Taboola Europe Limited',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.taboola.com/privacy-policy'
+    },
+    '44': {
+      id: 44,
+      name: 'The ADEX GmbH',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://theadex.com/privacy-opt-out/'
+    },
+    '45': {
+      id: 45,
+      name: 'Smart Adserver',
+      purposes: [
+        1,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        7
+      ],
+      flexiblePurposes: [
+        2,
+        7
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://smartadserver.com/end-user-privacy-policy/'
+    },
+    '47': {
+      id: 47,
+      name: 'ADMAN - Phaistos Networks, S.A.',
+      purposes: [
+        1,
+        2,
+        4,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://www.adman.gr/privacy'
+    },
+    '49': {
+      id: 49,
+      name: 'TRADELAB',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      legIntPurposes: [
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://tradelab.com/en/privacy/',
+      overflow: {
+        httpGetLimit: 32
+      }
+    },
+    '50': {
+      id: 50,
+      name: 'Adform',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        7,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://site.adform.com/privacy-center/platform-privacy/product-and-services-privacy-policy/',
+      overflow: {
+        httpGetLimit: 32
+      }
+    },
+    '51': {
+      id: 51,
+      name: 'xAd, Inc. dba GroundTruth',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.groundtruth.com/privacy-policy/'
+    },
+    '52': {
+      id: 52,
+      name: 'The Rubicon Project, Inc. ',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        7,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://www.rubiconproject.com/rubicon-project-yield-optimization-privacy-policy/',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '53': {
+      id: 53,
+      name: 'Sirdata',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.sirdata.com/privacy/'
+    },
+    '57': {
+      id: 57,
+      name: 'ADARA MEDIA UNLIMITED',
+      purposes: [
+        1,
+        2,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        7,
+        9,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://adara.com/privacy-promise/'
+    },
+    '58': {
+      id: 58,
+      name: '33Across',
+      purposes: [
+        1,
+        2,
+        4,
+        7,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'http://www.33across.com/privacy-policy'
+    },
+    '59': {
+      id: 59,
+      name: 'Sift Media, Inc',
+      purposes: [
+        2
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2
+      ],
+      specialPurposes: [],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.sift.co/privacy'
+    },
+    '60': {
+      id: 60,
+      name: 'Rakuten Marketing LLC',
+      purposes: [
+        1,
+        3
+      ],
+      legIntPurposes: [
+        2,
+        4,
+        7,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://rakutenadvertising.com/legal-notices/services-privacy-policy/'
+    },
+    '61': {
+      id: 61,
+      name: 'GumGum, Inc.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://gumgum.com/privacy-policy'
+    },
+    '62': {
+      id: 62,
+      name: 'Justpremium BV',
+      purposes: [
+        1,
+        4,
+        5,
+        10
+      ],
+      legIntPurposes: [
+        2,
+        7
+      ],
+      flexiblePurposes: [
+        2,
+        4,
+        7,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://justpremium.com/privacy-policy/'
+    },
+    '63': {
+      id: 63,
+      name: 'Avocet Systems Limited',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      legIntPurposes: [
+        7,
+        8,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://avocet.io/privacy-portal'
+    },
+    '65': {
+      id: 65,
+      name: 'Location Sciences AI Ltd',
+      purposes: [
+        1,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        7,
+        8
+      ],
+      specialPurposes: [
+        1
+      ],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.locationsciences.ai/privacy-policy/'
+    },
+    '66': {
+      id: 66,
+      name: 'adsquare GmbH',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        9,
+        10
+      ],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.adsquare.com/privacy'
+    },
+    '68': {
+      id: 68,
+      name: 'Sizmek by Amazon',
+      purposes: [
+        1,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.sizmek.com/privacy-policy/'
+    },
+    '69': {
+      id: 69,
+      name: 'OpenX',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.openx.com/legal/privacy-policy/'
+    },
+    '70': {
+      id: 70,
+      name: 'Yieldlab AG',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://www.yieldlab.de/meta-navigation/datenschutz/',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '72': {
+      id: 72,
+      name: 'Nano Interactive GmbH',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://www.nanointeractive.com/privacy'
+    },
+    '73': {
+      id: 73,
+      name: 'Simplifi Holdings Inc.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4
+      ],
+      specialPurposes: [],
+      features: [
+        2
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://simpli.fi/site-privacy-policy/'
+    },
+    '76': {
+      id: 76,
+      name: 'PubMatic, Inc.',
+      purposes: [
+        1,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://pubmatic.com/privacy-policy/'
+    },
+    '77': {
+      id: 77,
+      name: 'comScore, Inc.',
+      purposes: [
+        1,
+        7,
+        8,
+        10
+      ],
+      legIntPurposes: [
+        9
+      ],
+      flexiblePurposes: [
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.scorecardresearch.com/privacy.aspx?newlanguage=1'
+    },
+    '78': {
+      id: 78,
+      name: 'Flashtalking, Inc.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://www.flashtalking.com/privacypolicy/'
+    },
+    '79': {
+      id: 79,
+      name: 'MediaMath, Inc.',
+      purposes: [
+        1,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        10
+      ],
+      flexiblePurposes: [
+        3,
+        4
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://www.mediamath.com/privacy-policy/'
+    },
+    '80': {
+      id: 80,
+      name: 'Sharethrough, Inc',
+      purposes: [
+        1,
+        2,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        4,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://platform-cdn.sharethrough.com/privacy-policy'
+    },
+    '82': {
+      id: 82,
+      name: 'Smaato, Inc.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9
+      ],
+      legIntPurposes: [
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.smaato.com/privacy/'
+    },
+    '83': {
+      id: 83,
+      name: 'Visarity Technologies GmbH',
+      purposes: [
+        2,
+        6,
+        7,
+        8
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://primo.design/docs/PrivacyPolicyPrimo.html'
+    },
+    '84': {
+      id: 84,
+      name: 'Semasio GmbH',
+      purposes: [
+        1,
+        3,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        3,
+        9,
+        10
+      ],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://www.semasio.com/privacy-policy/'
+    },
+    '85': {
+      id: 85,
+      name: 'Crimtan Holdings Limited',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://crimtan.com/privacy/'
+    },
+    '86': {
+      id: 86,
+      name: 'Scene Stealer Limited',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        7,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://scenestealer.tv/privacy-policy/'
+    },
+    '88': {
+      id: 88,
+      name: 'TreSensa, Inc.',
+      purposes: [
+        1,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.tresensa.com/eu-privacy'
+    },
+    '89': {
+      id: 89,
+      name: 'Tapad, Inc.',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.tapad.com/eu-privacy-policy'
+    },
+    '90': {
+      id: 90,
+      name: 'Teroa S.A.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.e-planning.net/en/privacy.html'
+    },
+    '91': {
+      id: 91,
+      name: 'Criteo SA',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7
+      ],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.criteo.com/privacy/'
+    },
+    '92': {
+      id: 92,
+      name: '1plusX AG',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.1plusx.com/privacy-policy/'
+    },
+    '93': {
+      id: 93,
+      name: 'Adloox SA',
+      purposes: [],
+      legIntPurposes: [
+        7
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://adloox.com/disclaimer',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '94': {
+      id: 94,
+      name: 'Blis Media Limited',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://www.blis.com/privacy/'
+    },
+    '95': {
+      id: 95,
+      name: 'Lotame Solutions, inc',
+      purposes: [
+        1,
+        3,
+        5
+      ],
+      legIntPurposes: [
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.lotame.com/about-lotame/privacy/lotame-corporate-websites-privacy-policy/'
+    },
+    '97': {
+      id: 97,
+      name: 'LiveRamp, Inc.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.liveramp.com/service-privacy-policy/'
+    },
+    '98': {
+      id: 98,
+      name: 'GroupM UK Limited',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      legIntPurposes: [
+        7,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.groupm.com/privacy-notice'
+    },
+    '100': {
+      id: 100,
+      name: 'Fifty Technology Limited',
+      purposes: [
+        1,
+        2,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        7,
+        9,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://fifty.io/privacy-policy.php'
+    },
+    '101': {
+      id: 101,
+      name: 'MiQ',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://wearemiq.com/privacy-policy/'
+    },
+    '104': {
+      id: 104,
+      name: 'Sonobi, Inc',
+      purposes: [
+        1,
+        2,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        7,
+        8
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        2
+      ],
+      features: [
+        1
+      ],
+      specialFeatures: [],
+      policyUrl: 'http://sonobi.com/privacy-policy/'
+    },
+    '108': {
+      id: 108,
+      name: 'Rich Audience',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://richaudience.com/privacy/'
+    },
+    '109': {
+      id: 109,
+      name: 'LoopMe Limited',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      legIntPurposes: [
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        9
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://loopme.com/privacy-policy/'
+    },
+    '110': {
+      id: 110,
+      name: 'Dynata LLC',
+      purposes: [
+        1,
+        7,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.opinionoutpost.co.uk/en-gb/policies/privacy'
+    },
+    '111': {
+      id: 111,
+      name: 'Showheroes SE',
+      purposes: [
+        1,
+        3,
+        4,
+        9,
+        10
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        8
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://showheroes.com/privacy/'
+    },
+    '114': {
+      id: 114,
+      name: 'Sublime',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9
+      ],
+      legIntPurposes: [
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://ayads.co/privacy.php'
+    },
+    '115': {
+      id: 115,
+      name: 'smartclip Europe GmbH',
+      purposes: [
+        1,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://privacy-portal.smartclip.net/',
+      overflow: {
+        httpGetLimit: 32
+      }
+    },
+    '119': {
+      id: 119,
+      name: 'Fusio by S4M',
+      purposes: [
+        1,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1
+      ],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://www.s4m.io/privacy-policy/'
+    },
+    '120': {
+      id: 120,
+      name: 'Eyeota Pte Ltd',
+      purposes: [
+        1,
+        3,
+        5,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        3,
+        5,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.eyeota.com/privacy-center'
+    },
+    '126': {
+      id: 126,
+      name: 'DoubleVerify Inc.​',
+      purposes: [
+        2,
+        7,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.doubleverify.com/privacy/'
+    },
+    '127': {
+      id: 127,
+      name: 'PIXIMEDIA SAS',
+      purposes: [
+        1,
+        3,
+        4,
+        5,
+        6,
+        9,
+        10
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        8
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://piximedia.com/privacy/',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '128': {
+      id: 128,
+      name: 'BIDSWITCH GmbH',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://www.bidswitch.com/privacy-policy/'
+    },
+    '129': {
+      id: 129,
+      name: 'IPONWEB GmbH',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.iponweb.com/privacy-policy/'
+    },
+    '130': {
+      id: 130,
+      name: 'NextRoll, Inc.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.nextroll.com/privacy'
+    },
+    '131': {
+      id: 131,
+      name: 'ID5 Technology SAS',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.id5.io/privacy'
+    },
+    '132': {
+      id: 132,
+      name: 'Teads ',
+      purposes: [
+        1,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        9,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.teads.com/privacy-policy/'
+    },
+    '133': {
+      id: 133,
+      name: 'digitalAudience',
+      purposes: [
+        1,
+        3,
+        5,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://digitalaudience.io/legal/privacy-cookies/'
+    },
+    '134': {
+      id: 134,
+      name: 'SMARTSTREAM.TV GmbH',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.smartstream.tv/en/productprivacy',
+      overflow: {
+        httpGetLimit: 32
+      }
+    },
+    '136': {
+      id: 136,
+      name: 'Ströer SSP GmbH (SSP)',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.stroeer.de/fileadmin/de/Konvergenz_und_Konzepte/Daten_und_Technologien/Stroeer_SSP/Downloads/Datenschutz_Stroeer_SSP.pdf'
+    },
+    '137': {
+      id: 137,
+      name: 'Ströer SSP GmbH (DSP)',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        9
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.stroeer.de/fileadmin/de/Konvergenz_und_Konzepte/Daten_und_Technologien/Stroeer_SSP/Downloads/Datenschutz_Stroeer_SSP.pdf'
+    },
+    '138': {
+      id: 138,
+      name: 'ConnectAd Realtime GmbH',
+      purposes: [
+        1,
+        3,
+        4,
+        5
+      ],
+      legIntPurposes: [
+        2,
+        7
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'http://connectadrealtime.com/privacy/'
+    },
+    '139': {
+      id: 139,
+      name: 'Permodo GmbH',
+      purposes: [
+        1,
+        2,
+        7,
+        8,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        7,
+        8,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://permodo.com/de/privacy.html',
+      overflow: {
+        httpGetLimit: 32
+      }
+    },
+    '142': {
+      id: 142,
+      name: 'Media.net Advertising FZ-LLC',
+      purposes: [
+        1,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        5,
+        6,
+        8
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.media.net/en/privacy-policy'
+    },
+    '143': {
+      id: 143,
+      name: 'Connatix Native Exchange Inc.',
+      purposes: [
+        1,
+        2,
+        4,
+        6,
+        7,
+        8,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://connatix.com/privacy-policy/'
+    },
+    '144': {
+      id: 144,
+      name: 'district m inc.',
+      purposes: [
+        1,
+        2,
+        4,
+        7,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://districtm.net/en/page/platforms-data-and-privacy-policy/',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '147': {
+      id: 147,
+      name: 'Adacado Technologies Inc. (DBA Adacado)',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.adacado.com/privacy-policy-april-25-2018/'
+    },
+    '149': {
+      id: 149,
+      name: 'ADman Interactive SLU',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2
+      ],
+      specialPurposes: [],
+      features: [
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://admanmedia.com/politica.html?setLng=es'
+    },
+    '150': {
+      id: 150,
+      name: 'Inskin Media LTD',
+      purposes: [
+        1,
+        3,
+        4,
+        9,
+        10
+      ],
+      legIntPurposes: [
+        2,
+        7
+      ],
+      flexiblePurposes: [
+        2,
+        7
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'http://www.inskinmedia.com/privacy-policy.html'
+    },
+    '152': {
+      id: 152,
+      name: 'Meetrics GmbH',
+      purposes: [
+        1,
+        9
+      ],
+      legIntPurposes: [
+        7
+      ],
+      flexiblePurposes: [
+        7
+      ],
+      specialPurposes: [
+        1
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.meetrics.com/en/data-privacy/'
+    },
+    '153': {
+      id: 153,
+      name: 'MADVERTISE MEDIA',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        5,
+        6,
+        10
+      ],
+      specialPurposes: [
+        2
+      ],
+      features: [],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://madvertise.com/en/gdpr/',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '154': {
+      id: 154,
+      name: 'YOC AG',
+      purposes: [
+        1,
+        3,
+        4,
+        10
+      ],
+      legIntPurposes: [
+        2,
+        7
+      ],
+      flexiblePurposes: [
+        2,
+        7
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://yoc.com/privacy/'
+    },
+    '155': {
+      id: 155,
+      name: 'AntVoice',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.antvoice.com/en/privacypolicy/'
+    },
+    '157': {
+      id: 157,
+      name: 'Seedtag Advertising S.L',
+      purposes: [
+        1,
+        2,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        7,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.seedtag.com/en/privacy-policy/'
+    },
+    '160': {
+      id: 160,
+      name: 'Netsprint SA',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://netsprint.eu/privacy.html',
+      overflow: {
+        httpGetLimit: 32
+      }
+    },
+    '161': {
+      id: 161,
+      name: 'Smadex SL',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://smadex.com/end-user-privacy-policy/'
+    },
+    '162': {
+      id: 162,
+      name: 'Unruly Group Ltd',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://unruly.co/privacy/'
+    },
+    '163': {
+      id: 163,
+      name: 'Bombora Inc.',
+      purposes: [
+        1,
+        3,
+        8
+      ],
+      legIntPurposes: [
+        7,
+        10
+      ],
+      flexiblePurposes: [
+        7,
+        10
+      ],
+      specialPurposes: [],
+      features: [
+        1
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://bombora.com/privacy'
+    },
+    '164': {
+      id: 164,
+      name: 'Outbrain UK Ltd',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.outbrain.com/legal/privacy#privacy-policy'
+    },
+    '165': {
+      id: 165,
+      name: 'SpotX, Inc.',
+      purposes: [
+        1,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.spotx.tv/privacy-policy/',
+      overflow: {
+        httpGetLimit: 32
+      }
+    },
+    '167': {
+      id: 167,
+      name: 'Audiens S.r.l.',
+      purposes: [
+        1,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'http://www.audiens.com/privacy'
+    },
+    '168': {
+      id: 168,
+      name: 'EASYmedia GmbH',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://login.rtbmarket.com/gdpr'
+    },
+    '173': {
+      id: 173,
+      name: 'Yieldmo, Inc.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.yieldmo.com/privacy/'
+    },
+    '174': {
+      id: 174,
+      name: 'A Million Ads Ltd',
+      purposes: [],
+      legIntPurposes: [
+        2,
+        4
+      ],
+      flexiblePurposes: [
+        2,
+        4
+      ],
+      specialPurposes: [],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.amillionads.com/privacy-policy'
+    },
+    '177': {
+      id: 177,
+      name: 'plista GmbH',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        7,
+        8,
+        10
+      ],
+      flexiblePurposes: [
+        7,
+        8,
+        10
+      ],
+      specialPurposes: [
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.plista.com/about/privacy/'
+    },
+    '178': {
+      id: 178,
+      name: 'Hybrid Theory',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://hybridtheory.com/privacy-policy/'
+    },
+    '179': {
+      id: 179,
+      name: 'Collective Europe Ltd.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        9
+      ],
+      legIntPurposes: [
+        7
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.collectiveuk.com/privacy.html',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '184': {
+      id: 184,
+      name: 'mediarithmics SAS',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        7
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.mediarithmics.com/en-us/content/privacy-policy'
+    },
+    '185': {
+      id: 185,
+      name: 'Bidtellect, Inc',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      legIntPurposes: [
+        9,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.bidtellect.com/privacy-policy/',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '190': {
+      id: 190,
+      name: 'video intelligence AG',
+      purposes: [],
+      legIntPurposes: [
+        2,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.vi.ai/privacy-policy/'
+    },
+    '192': {
+      id: 192,
+      name: 'remerge GmbH',
+      purposes: [
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://remerge.io/privacy-policy.html'
+    },
+    '193': {
+      id: 193,
+      name: 'Mediasmart Mobile S.L.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://mediasmart.io/privacy/'
+    },
+    '194': {
+      id: 194,
+      name: 'Rezonence Limited',
+      purposes: [
+        1,
+        3,
+        4,
+        9
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        8,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://rezonence.com/privacy-policy/'
+    },
+    '195': {
+      id: 195,
+      name: 'advanced store GmbH',
+      purposes: [
+        1,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2
+      ],
+      flexiblePurposes: [
+        2
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://www.advanced-store.com/de/datenschutz/'
+    },
+    '199': {
+      id: 199,
+      name: 'ADUX',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        6,
+        7,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        2
+      ],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.adux.com/donnees-personelles/'
+    },
+    '200': {
+      id: 200,
+      name: 'Tapjoy, Inc.',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        7
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.tapjoy.com/legal/#privacy-policy'
+    },
+    '203': {
+      id: 203,
+      name: 'Revcontent, LLC',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://intercom.help/revcontent2/en/articles/2290675-revcontent-s-privacy-policy'
+    },
+    '205': {
+      id: 205,
+      name: 'Adssets AB',
+      purposes: [
+        1,
+        2,
+        4,
+        7,
+        8,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://adssets.com/policy/'
+    },
+    '206': {
+      id: 206,
+      name: 'Hybrid Adtech GmbH',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://hybrid.ai/data_protection_policy'
+    },
+    '209': {
+      id: 209,
+      name: 'Delta Projects AB',
+      purposes: [
+        1,
+        2,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        7,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        7,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://deltaprojects.com/data-collection-policy'
+    },
+    '210': {
+      id: 210,
+      name: 'Zemanta, Inc.',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        3,
+        7,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        3,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1
+      ],
+      specialFeatures: [],
+      policyUrl: 'http://www.zemanta.com/legal/privacy'
+    },
+    '211': {
+      id: 211,
+      name: 'AdTheorent, Inc',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'http://adtheorent.com/privacy-policy'
+    },
+    '212': {
+      id: 212,
+      name: 'usemax advertisement (Emego GmbH)',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://www.usemax.de/?l=privacy'
+    },
+    '213': {
+      id: 213,
+      name: 'emetriq GmbH',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        2
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.emetriq.com/datenschutz/'
+    },
+    '215': {
+      id: 215,
+      name: 'ARMIS SAS',
+      purposes: [
+        1,
+        2,
+        7
+      ],
+      legIntPurposes: [
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://armis.tech/en/armis-personal-data-privacy-policy/'
+    },
+    '216': {
+      id: 216,
+      name: 'Mindlytix SAS',
+      purposes: [
+        1,
+        2,
+        3,
+        5,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'http://mindlytix.com/privacy/'
+    },
+    '217': {
+      id: 217,
+      name: '2KDirect, Inc. (dba iPromote)',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.ipromote.com/privacy-policy/'
+    },
+    '218': {
+      id: 218,
+      name: 'Bigabid Media ltd',
+      purposes: [
+        1,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.bigabid.com/privacy-policy'
+    },
+    '223': {
+      id: 223,
+      name: 'Audience Trading Platform Ltd.',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        7,
+        8
+      ],
+      flexiblePurposes: [
+        7,
+        8
+      ],
+      specialPurposes: [],
+      features: [
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://atp.io/privacy-policy'
+    },
+    '224': {
+      id: 224,
+      name: 'adrule mobile GmbH',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        8
+      ],
+      legIntPurposes: [
+        7
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.adrule.net/de/datenschutz/'
+    },
+    '226': {
+      id: 226,
+      name: 'Publicis Media GmbH',
+      purposes: [
+        1,
+        9
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        10
+      ],
+      specialPurposes: [],
+      features: [
+        1
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.publicismedia.de/datenschutz/'
+    },
+    '227': {
+      id: 227,
+      name: 'ORTEC B.V.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.ortecadscience.com/privacy-policy/'
+    },
+    '228': {
+      id: 228,
+      name: 'McCann Discipline LTD',
+      purposes: [
+        1,
+        2,
+        5,
+        6,
+        7,
+        8
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.primis.tech/privacy-policy/'
+    },
+    '231': {
+      id: 231,
+      name: 'AcuityAds Inc.',
+      purposes: [
+        1,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        8,
+        10
+      ],
+      flexiblePurposes: [
+        3,
+        4
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://privacy.acuityads.com/corporate-privacy-policy.html',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '234': {
+      id: 234,
+      name: 'ZBO Media',
+      purposes: [
+        1,
+        3,
+        4,
+        9
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://zbo.media/mentions-legales/politique-de-confidentialite-service-publicitaire/'
+    },
+    '235': {
+      id: 235,
+      name: 'Bucksense Inc',
+      purposes: [
+        2,
+        3,
+        4,
+        7,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        9
+      ],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://www.bucksense.com/platform-privacy-policy/'
+    },
+    '240': {
+      id: 240,
+      name: '7Hops.com Inc. (ZergNet)',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        5,
+        6,
+        8,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://zergnet.com/privacy'
+    },
+    '241': {
+      id: 241,
+      name: 'OneTag Limited',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        7
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.onetag.com/privacy/'
+    },
+    '242': {
+      id: 242,
+      name: 'twiago GmbH',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.twiago.com/datenschutz/',
+      overflow: {
+        httpGetLimit: 32
+      }
+    },
+    '243': {
+      id: 243,
+      name: 'Cloud Technologies S.A.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.cloudtechnologies.pl/en/internet-advertising-privacy-policy'
+    },
+    '248': {
+      id: 248,
+      name: 'Converge-Digital',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2
+      ],
+      flexiblePurposes: [
+        2
+      ],
+      specialPurposes: [],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://converge-digital.com/privacy-policy/',
+      overflow: {
+        httpGetLimit: 32
+      }
+    },
+    '249': {
+      id: 249,
+      name: 'Spolecznosci Sp. z o.o. Sp. k.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.spolecznosci.pl/polityka-prywatnosci'
+    },
+    '250': {
+      id: 250,
+      name: 'Qriously Ltd',
+      purposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.brandwatch.com/legal/qriously-privacy-notice/'
+    },
+    '251': {
+      id: 251,
+      name: 'Yieldlove GmbH',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        7,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://www.yieldlove.com/cookie-policy'
+    },
+    '252': {
+      id: 252,
+      name: 'Jaduda GmbH',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.jadudamobile.com/datenschutzerklaerung/'
+    },
+    '253': {
+      id: 253,
+      name: 'Improve Digital BV',
+      purposes: [
+        1,
+        3,
+        4,
+        9
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        7,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.improvedigital.com/platform-privacy-policy',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '255': {
+      id: 255,
+      name: 'Onnetwork Sp. z o.o.',
+      purposes: [
+        1,
+        5,
+        6
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        8
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.onnetwork.tv/pp_services.php'
+    },
+    '256': {
+      id: 256,
+      name: 'Bounce Exchange, Inc',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        7,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.bouncex.com/privacy/'
+    },
+    '262': {
+      id: 262,
+      name: 'Fyber ',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.fyber.com/legal/privacy-policy/'
+    },
+    '263': {
+      id: 263,
+      name: 'Nativo, Inc.',
+      purposes: [
+        1,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        9,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.nativo.com/interest-based-ads'
+    },
+    '265': {
+      id: 265,
+      name: 'Instinctive, Inc.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      legIntPurposes: [
+        9,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://instinctive.io/privacy'
+    },
+    '272': {
+      id: 272,
+      name: 'A.Mob',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.we-are-adot.com/privacy-policy/'
+    },
+    '273': {
+      id: 273,
+      name: 'Bannerflow AB',
+      purposes: [
+        1,
+        4
+      ],
+      legIntPurposes: [
+        7
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.bannerflow.com/privacy '
+    },
+    '275': {
+      id: 275,
+      name: 'TabMo SAS',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://static.tabmo.io.s3.amazonaws.com/privacy-policy/index.html'
+    },
+    '277': {
+      id: 277,
+      name: 'Codewise VL Sp. z o.o. Sp. k',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9
+      ],
+      legIntPurposes: [
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://voluumdsp.com/end-user-privacy-policy/'
+    },
+    '278': {
+      id: 278,
+      name: 'Integral Ad Science, Inc.',
+      purposes: [],
+      legIntPurposes: [
+        7,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://integralads.com/privacy-policy/'
+    },
+    '279': {
+      id: 279,
+      name: 'Mirando GmbH &amp; Co KG',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        7
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://wwwmirando.de/datenschutz/'
+    },
+    '280': {
+      id: 280,
+      name: 'Spot.IM LTD',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://www.spot.im/privacy/'
+    },
+    '281': {
+      id: 281,
+      name: 'Wizaly',
+      purposes: [
+        1,
+        7,
+        8,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.wizaly.com/terms-of-use#privacy-policy'
+    },
+    '282': {
+      id: 282,
+      name: 'Welect GmbH',
+      purposes: [
+        10
+      ],
+      legIntPurposes: [
+        2,
+        7
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.welect.de/datenschutz'
+    },
+    '284': {
+      id: 284,
+      name: 'WEBORAMA',
+      purposes: [
+        1,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://weborama.com/privacy_en/'
+    },
+    '285': {
+      id: 285,
+      name: 'Comcast International France SAS',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.freewheel.com/privacy-policy'
+    },
+    '289': {
+      id: 289,
+      name: 'mobalo GmbH',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.mobalo.com/en/privacy/'
+    },
+    '290': {
+      id: 290,
+      name: 'Readpeak Oy',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://readpeak.com/privacy-policy/'
+    },
+    '293': {
+      id: 293,
+      name: 'SpringServe, LLC',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        2
+      ],
+      policyUrl: 'https://springserve.com/privacy-policy/'
+    },
+    '294': {
+      id: 294,
+      name: 'Jivox Corporation',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.jivox.com/privacy',
+      overflow: {
+        httpGetLimit: 32
+      }
+    },
+    '299': {
+      id: 299,
+      name: 'AdClear GmbH',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        2
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.adclear.de/datenschutzerklaerung/'
+    },
+    '301': {
+      id: 301,
+      name: 'zeotap GmbH',
+      purposes: [
+        1,
+        3,
+        4,
+        5,
+        6,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        3,
+        4,
+        5,
+        6,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://zeotap.com/privacy_policy'
+    },
+    '302': {
+      id: 302,
+      name: 'Mobile Professionals BV',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        8,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        3,
+        5,
+        7,
+        8
+      ],
+      specialPurposes: [],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://mobpro.com/privacy.html'
+    },
+    '303': {
+      id: 303,
+      name: 'Orion Semantics',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://static.orion-semantics.com/privacy.html'
+    },
+    '304': {
+      id: 304,
+      name: 'On Device Research Limited',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://s.on-device.com/privacyPolicy'
+    },
+    '310': {
+      id: 310,
+      name: 'Adevinta Spain S.L.U.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        9
+      ],
+      legIntPurposes: [
+        7,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.adevinta.com/about/privacy/'
+    },
+    '312': {
+      id: 312,
+      name: 'Exactag GmbH',
+      purposes: [
+        1,
+        3,
+        7,
+        8
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        3,
+        7,
+        8
+      ],
+      specialPurposes: [
+        1
+      ],
+      features: [
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.exactag.com/en/data-privacy/',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '314': {
+      id: 314,
+      name: 'Keymantics',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.keymantics.com/assets/privacy-policy.pdf'
+    },
+    '315': {
+      id: 315,
+      name: 'Celtra, Inc.',
+      purposes: [
+        1,
+        2,
+        4,
+        7,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.celtra.com/privacy-policy/'
+    },
+    '316': {
+      id: 316,
+      name: 'Gamned',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.gamned.com/privacy-policy/'
+    },
+    '317': {
+      id: 317,
+      name: 'mainADV Srl',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://www.mainad.com/privacy-policy/'
+    },
+    '318': {
+      id: 318,
+      name: 'Accorp Sp. z o.o.',
+      purposes: [
+        1,
+        3,
+        4,
+        9
+      ],
+      legIntPurposes: [
+        7,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'http://www.instytut-pollster.pl/privacy-policy/'
+    },
+    '319': {
+      id: 319,
+      name: 'Clipcentric, Inc.',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://clipcentric.com/privacy.bhtml'
+    },
+    '325': {
+      id: 325,
+      name: 'Knorex',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.knorex.com/privacy'
+    },
+    '328': {
+      id: 328,
+      name: 'Gemius SA',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.gemius.com/cookie-policy.html'
+    },
+    '329': {
+      id: 329,
+      name: 'Browsi Mobile Ltd',
+      purposes: [
+        1,
+        7,
+        8
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://gobrowsi.com/browsi-privacy-policy/'
+    },
+    '333': {
+      id: 333,
+      name: 'InMobi Pte Ltd',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        9
+      ],
+      specialPurposes: [
+        1
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.inmobi.com/privacy-policy-for-eea'
+    },
+    '336': {
+      id: 336,
+      name: 'Telecoming S.A.',
+      purposes: [
+        2,
+        4
+      ],
+      legIntPurposes: [
+        7,
+        9
+      ],
+      flexiblePurposes: [
+        2,
+        4
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://www.telecoming.com/privacy-policy/',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '343': {
+      id: 343,
+      name: 'DIGITEKA Technologies',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://www.ultimedia.com/POLICY.html'
+    },
+    '345': {
+      id: 345,
+      name: 'The Kantar Group Limited',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'http://www.kantar.com/cookies-policies'
+    },
+    '350': {
+      id: 350,
+      name: 'Free Stream Media Corp. dba Samba TV',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://samba.tv/legal/privacy-policy/',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '351': {
+      id: 351,
+      name: 'Samba TV UK Limited',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://samba.tv/legal/privacy-policy/',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '354': {
+      id: 354,
+      name: 'Apester Ltd',
+      purposes: [
+        2,
+        4
+      ],
+      legIntPurposes: [
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        7
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://apester.com/privacy-policy/'
+    },
+    '358': {
+      id: 358,
+      name: 'MGID Inc.',
+      purposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.mgid.com/privacy-policy'
+    },
+    '359': {
+      id: 359,
+      name: 'AerServ LLC',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        9
+      ],
+      specialPurposes: [
+        1
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.inmobi.com/privacy-policy-for-eea'
+    },
+    '365': {
+      id: 365,
+      name: 'Forensiq LLC',
+      purposes: [],
+      legIntPurposes: [
+        7
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1
+      ],
+      features: [
+        1,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://impact.com/privacy-policy/'
+    },
+    '368': {
+      id: 368,
+      name: 'VECTAURY',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.vectaury.io/en/personal-data'
+    },
+    '371': {
+      id: 371,
+      name: 'Seeding Alliance GmbH',
+      purposes: [],
+      legIntPurposes: [
+        2,
+        7,
+        8
+      ],
+      flexiblePurposes: [
+        7
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://seeding-alliance.de/datenschutz'
+    },
+    '373': {
+      id: 373,
+      name: 'Nielsen Marketing Cloud',
+      purposes: [
+        1,
+        3,
+        5
+      ],
+      legIntPurposes: [
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://www.nielsen.com/us/en/privacy-statement/exelate-privacy-policy.html'
+    },
+    '374': {
+      id: 374,
+      name: 'Bmind a Sales Maker Company, S.L.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'http://www.bmind.es/legal-notice/'
+    },
+    '377': {
+      id: 377,
+      name: 'AddApptr GmbH',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        7,
+        10
+      ],
+      flexiblePurposes: [
+        7,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.addapptr.com/data-privacy'
+    },
+    '381': {
+      id: 381,
+      name: 'Solocal',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://frontend.adhslx.com/privacy.html?'
+    },
+    '382': {
+      id: 382,
+      name: 'The Reach Group GmbH',
+      purposes: [
+        1,
+        3,
+        4,
+        5,
+        6,
+        9
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        8
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://trg.de/en/privacy-statement/',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '385': {
+      id: 385,
+      name: 'Oracle Data Cloud',
+      purposes: [
+        1,
+        3,
+        5,
+        9,
+        10
+      ],
+      legIntPurposes: [
+        7
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.oracle.com/legal/privacy/marketing-cloud-data-cloud-privacy-policy.html'
+    },
+    '387': {
+      id: 387,
+      name: 'Triapodi Ltd.',
+      purposes: [
+        2,
+        3,
+        4,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://appreciate.mobi/page.html#/end-user-privacy-policy'
+    },
+    '388': {
+      id: 388,
+      name: 'numberly',
+      purposes: [
+        1,
+        3,
+        4,
+        5,
+        6,
+        9
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        8,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        7,
+        8,
+        10
+      ],
+      specialPurposes: [
+        1
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://numberly.com/en/privacy/'
+    },
+    '394': {
+      id: 394,
+      name: 'AudienceProject Aps',
+      purposes: [
+        1,
+        3,
+        4,
+        5,
+        6
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        7,
+        8,
+        9
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://privacy.audienceproject.com'
+    },
+    '402': {
+      id: 402,
+      name: 'Effiliation',
+      purposes: [
+        1,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://inter.effiliation.com/politique-confidentialite.html'
+    },
+    '408': {
+      id: 408,
+      name: 'Fidelity Media',
+      purposes: [
+        1,
+        2,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        7
+      ],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://fidelity-media.com/privacy-policy/'
+    },
+    '409': {
+      id: 409,
+      name: 'Arrivalist Co.',
+      purposes: [
+        1,
+        9
+      ],
+      legIntPurposes: [
+        7,
+        8
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://www.arrivalist.com/privacy'
+    },
+    '410': {
+      id: 410,
+      name: 'Adtelligent Inc.',
+      purposes: [
+        1,
+        7,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://adtelligent.com/privacy-policy/'
+    },
+    '412': {
+      id: 412,
+      name: 'Cxense ASA',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.cxense.com/about-us/privacy-policy'
+    },
+    '413': {
+      id: 413,
+      name: 'Eulerian Technologies',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.eulerian.com/en/privacy/'
+    },
+    '415': {
+      id: 415,
+      name: 'Seenthis AB',
+      purposes: [],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://seenthis.co/privacy-notice-2018-04-18.pdf'
+    },
+    '416': {
+      id: 416,
+      name: 'Commanders Act',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.commandersact.com/en/privacy/'
+    },
+    '418': {
+      id: 418,
+      name: 'PROXISTORE',
+      purposes: [
+        1,
+        2,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        2
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://www.proxistore.com/common/en/cgv'
+    },
+    '422': {
+      id: 422,
+      name: 'Brand Metrics Sweden AB',
+      purposes: [
+        1,
+        6,
+        7,
+        8,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://collector.brandmetrics.com/brandmetrics_privacypolicy.pdf'
+    },
+    '423': {
+      id: 423,
+      name: 'travel audience GmbH',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://travelaudience.com/product-privacy-policy/'
+    },
+    '424': {
+      id: 424,
+      name: 'KUPONA GmbH',
+      purposes: [
+        4,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        4
+      ],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.kupona.de/dsgvo/'
+    },
+    '428': {
+      id: 428,
+      name: 'Internet BillBoard a.s.',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        7
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://www.ibillboard.com/en/privacy-information/'
+    },
+    '429': {
+      id: 429,
+      name: 'Signals',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://signalsdata.com/platform-cookie-policy/'
+    },
+    '431': {
+      id: 431,
+      name: 'White Ops, Inc.',
+      purposes: [],
+      legIntPurposes: [
+        7,
+        9,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        3
+      ],
+      specialFeatures: [
+        2
+      ],
+      policyUrl: 'https://www.whiteops.com/privacy'
+    },
+    '436': {
+      id: 436,
+      name: 'INVIBES GROUP',
+      purposes: [
+        1,
+        3,
+        4,
+        5,
+        6,
+        9
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        8,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        10
+      ],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'http://www.invibes.com/terms'
+    },
+    '438': {
+      id: 438,
+      name: 'INVIDI technologies AB',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'http://www.invidi.com/wp-content/uploads/2020/02/ad-tech-services-privacy-policy.pdf'
+    },
+    '439': {
+      id: 439,
+      name: 'Bit Q Holdings Limited',
+      purposes: [
+        1,
+        7,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.rippll.com/privacy'
+    },
+    '440': {
+      id: 440,
+      name: 'DEFINE MEDIA GMBH',
+      purposes: [
+        1,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        4,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://www.definemedia.de/datenschutz-conative/'
+    },
+    '444': {
+      id: 444,
+      name: 'Playbuzz Ltd (aka EX.CO)',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        5,
+        6
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://ex.co/privacy-policy/'
+    },
+    '447': {
+      id: 447,
+      name: 'Adludio Ltd',
+      purposes: [
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.adludio.com/privacy-policy/'
+    },
+    '450': {
+      id: 450,
+      name: 'Neodata Group srl',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.neodatagroup.com/en/security-policy',
+      overflow: {
+        httpGetLimit: 32
+      }
+    },
+    '455': {
+      id: 455,
+      name: 'GDMServices, Inc. d/b/a FiksuDSP',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        10
+      ],
+      legIntPurposes: [
+        7,
+        8
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://fiksu.com/privacy-policy/'
+    },
+    '466': {
+      id: 466,
+      name: 'TACTIC™ Real-Time Marketing AS',
+      purposes: [],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://tacticrealtime.com/privacy/'
+    },
+    '467': {
+      id: 467,
+      name: 'Haensel AMS GmbH',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        7
+      ],
+      flexiblePurposes: [
+        7
+      ],
+      specialPurposes: [],
+      features: [
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://haensel-ams.com/data-privacy/'
+    },
+    '475': {
+      id: 475,
+      name: 'TAPTAP Digital SL',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ],
+      legIntPurposes: [
+        8,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://www.taptapnetworks.com/privacy_policy/'
+    },
+    '479': {
+      id: 479,
+      name: 'INFINIA MOBILE S.L.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'http://www.infiniamobile.com/privacy_policy'
+    },
+    '484': {
+      id: 484,
+      name: 'STRIATUM SAS',
+      purposes: [],
+      legIntPurposes: [
+        7,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://adledge.com/data-privacy/'
+    },
+    '486': {
+      id: 486,
+      name: 'Madington',
+      purposes: [],
+      legIntPurposes: [
+        7,
+        8,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://delivered-by-madington.com/dat-privacy-policy/'
+    },
+    '488': {
+      id: 488,
+      name: 'Opinary GmbH',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        8,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        7,
+        8,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://opinary.com/privacy-policy/'
+    },
+    '490': {
+      id: 490,
+      name: 'PLAYGROUND XYZ EMEA LTD',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7
+      ],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://playground.xyz/privacy'
+    },
+    '491': {
+      id: 491,
+      name: 'Triboo Data Analytics',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.shinystat.com/it/informativa_privacy_generale.html'
+    },
+    '495': {
+      id: 495,
+      name: 'Arcspire Limited',
+      purposes: [
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://public.arcspire.io/privacy.pdf',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '498': {
+      id: 498,
+      name: 'Dr. Banner',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      legIntPurposes: [
+        9,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://drbanner.com/privacypolicy_en/'
+    },
+    '501': {
+      id: 501,
+      name: 'Alliance Gravity Data Media',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.alliancegravity.com/politiquedeprotectiondesdonneespersonnelles'
+    },
+    '502': {
+      id: 502,
+      name: 'NEXD',
+      purposes: [
+        1,
+        7,
+        10
+      ],
+      legIntPurposes: [
+        9
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://nexd.com/privacy-policy',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '505': {
+      id: 505,
+      name: 'Shopalyst Inc',
+      purposes: [
+        1,
+        7,
+        8
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.shortlyst.com/eu/privacy_terms.html'
+    },
+    '507': {
+      id: 507,
+      name: 'AdsWizz Inc.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://www.adswizz.com/our-privacy-policy/'
+    },
+    '508': {
+      id: 508,
+      name: 'Lucid Holdings, LLC',
+      purposes: [
+        1,
+        7,
+        8,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        7,
+        8,
+        9
+      ],
+      specialPurposes: [
+        1
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'luc.id/privacy-policy'
+    },
+    '511': {
+      id: 511,
+      name: 'Admixer EU GmbH',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        9
+      ],
+      legIntPurposes: [
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://admixer.com/privacy/',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '512': {
+      id: 512,
+      name: 'PubNative GmbH',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        8,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        2
+      ],
+      policyUrl: 'https://pubnative.net/privacy-notice/'
+    },
+    '516': {
+      id: 516,
+      name: 'Pexi B.V.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://pexi.nl/privacy-policy/'
+    },
+    '517': {
+      id: 517,
+      name: 'SunMedia ',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.sunmedia.tv/en/cookies'
+    },
+    '521': {
+      id: 521,
+      name: 'netzeffekt GmbH',
+      purposes: [
+        1,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.netzeffekt.de/en/imprint'
+    },
+    '524': {
+      id: 524,
+      name: 'The Ozone Project Limited',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://ozoneproject.com/privacy-policy'
+    },
+    '527': {
+      id: 527,
+      name: 'Jampp LTD',
+      purposes: [
+        1,
+        2,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://jampp.com/privacy.html'
+    },
+    '528': {
+      id: 528,
+      name: 'Kayzen',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        9,
+        10
+      ],
+      legIntPurposes: [
+        7
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://kayzen.io/data-privacy-policy'
+    },
+    '530': {
+      id: 530,
+      name: 'Near Pte Ltd',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://near.co/privacy',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '531': {
+      id: 531,
+      name: 'Smartclip Hispania SL',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://rgpd-smartclip.com/'
+    },
+    '535': {
+      id: 535,
+      name: 'INNITY',
+      purposes: [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.innity.com/privacy-policy.php'
+    },
+    '536': {
+      id: 536,
+      name: 'GlobalWebIndex',
+      purposes: [
+        1,
+        7,
+        8,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'http://legal.trendstream.net/non-panellist_privacy_policy'
+    },
+    '539': {
+      id: 539,
+      name: 'AdDefend GmbH',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        7
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.addefend.com/en/privacy-policy/'
+    },
+    '543': {
+      id: 543,
+      name: 'PaperG, Inc. dba Thunder Industries',
+      purposes: [
+        1,
+        3,
+        4,
+        5,
+        6
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        8
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.makethunder.com/privacy'
+    },
+    '544': {
+      id: 544,
+      name: 'Kochava Inc.',
+      purposes: [],
+      legIntPurposes: [
+        7
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://www.kochava.com/support-privacy/'
+    },
+    '545': {
+      id: 545,
+      name: 'Reignn Platform Ltd',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        8,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [
+        2
+      ],
+      policyUrl: 'http://reignn.com/user-privacy-policy'
+    },
+    '546': {
+      id: 546,
+      name: 'Smart Traffik',
+      purposes: [
+        1,
+        8
+      ],
+      legIntPurposes: [
+        7
+      ],
+      flexiblePurposes: [
+        7,
+        8
+      ],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://smart-traffik.io/politique-de-confidentialite'
+    },
+    '549': {
+      id: 549,
+      name: 'Bandsintown Amplified LLC',
+      purposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://corp.bandsintown.com/privacy'
+    },
+    '550': {
+      id: 550,
+      name: 'Happydemics',
+      purposes: [
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.iubenda.com/privacy-policy/69056167/full-legal'
+    },
+    '553': {
+      id: 553,
+      name: 'Adhese',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://adhese.com/privacy-and-cookie-policy'
+    },
+    '554': {
+      id: 554,
+      name: 'RMSi Radio Marketing Service interactive GmbH',
+      purposes: [
+        1,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        9
+      ],
+      flexiblePurposes: [
+        2
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://www.rms.de/datenschutz/'
+    },
+    '556': {
+      id: 556,
+      name: 'adhood.com',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://v3.adhood.com/en/site/politikavekurallar/gizlilik.php?lang=en'
+    },
+    '559': {
+      id: 559,
+      name: 'Otto (GmbH &amp; Co KG)',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.otto.de/shoppages/service/datenschutz'
+    },
+    '561': {
+      id: 561,
+      name: 'AuDigent',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'http://audigent.com/platform-privacy-policy'
+    },
+    '565': {
+      id: 565,
+      name: 'Adobe Audience Manager',
+      purposes: [
+        1,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.adobe.com/privacy/policy.html'
+    },
+    '568': {
+      id: 568,
+      name: 'Jointag S.r.l.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://www.jointag.com/privacy/kariboo/publisher/third/'
+    },
+    '571': {
+      id: 571,
+      name: 'ViewPay',
+      purposes: [
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'http://viewpay.tv/mentions-legales/'
+    },
+    '573': {
+      id: 573,
+      name: 'Dailymotion SA',
+      purposes: [
+        1,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        5,
+        6,
+        7,
+        8,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.dailymotion.com/legal/privacy',
+      overflow: {
+        httpGetLimit: 32
+      }
+    },
+    '574': {
+      id: 574,
+      name: 'Realeyes OU',
+      purposes: [
+        1,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://realview.realeyesit.com/privacy'
+    },
+    '577': {
+      id: 577,
+      name: 'Neustar on behalf of The Procter & Gamble Company',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        6,
+        9
+      ],
+      legIntPurposes: [
+        5,
+        7,
+        8
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.pg.com/privacy/english/privacy_statement.shtml'
+    },
+    '580': {
+      id: 580,
+      name: 'Goldbach Group AG',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://goldbach.com/ch/de/datenschutz'
+    },
+    '587': {
+      id: 587,
+      name: 'Localsensor B.V.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.localsensor.com/privacy.html'
+    },
+    '591': {
+      id: 591,
+      name: 'Consumable, Inc.',
+      purposes: [
+        1,
+        2,
+        4,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://consumable.com/privacy-policy.html'
+    },
+    '593': {
+      id: 593,
+      name: 'Programatica de publicidad S.L.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://datmean.com/politica-privacidad/'
+    },
+    '596': {
+      id: 596,
+      name: 'InsurAds Technologies SA.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        9,
+        10
+      ],
+      legIntPurposes: [
+        7,
+        8
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.insurads.com/privacy.html'
+    },
+    '598': {
+      id: 598,
+      name: 'audio content &amp; control GmbH',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        9
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.audio-cc.com/audiocc_privacy_policy.pdf'
+    },
+    '599': {
+      id: 599,
+      name: 'Maximus Live LLC',
+      purposes: [],
+      legIntPurposes: [
+        7,
+        8
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1
+      ],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://maximusx.com/privacy-policy/'
+    },
+    '601': {
+      id: 601,
+      name: 'WebAds B.V',
+      purposes: [
+        1,
+        2
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://privacy.webads.eu/'
+    },
+    '602': {
+      id: 602,
+      name: 'Online Solution Int Limited',
+      purposes: [
+        2,
+        7,
+        8,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        7,
+        8,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://adsafety.net/privacy.html',
+      overflow: {
+        httpGetLimit: 32
+      }
+    },
+    '606': {
+      id: 606,
+      name: 'Impactify ',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://impactify.io/privacy-policy/'
+    },
+    '607': {
+      id: 607,
+      name: 'ucfunnel Co., Ltd.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.ucfunnel.com/privacy-policy'
+    },
+    '609': {
+      id: 609,
+      name: 'Predicio',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'http://www.predic.io/privacy',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '610': {
+      id: 610,
+      name: 'Azerion Holding B.V.',
+      purposes: [
+        1,
+        3,
+        4,
+        9
+      ],
+      legIntPurposes: [
+        2,
+        5,
+        6,
+        7,
+        8,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        5,
+        6
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://azerion.com/business/privacy.html',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '612': {
+      id: 612,
+      name: 'Adnami Aps',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.adnami.io/privacy',
+      deletedDate: '2020-03-17T00:00:00Z'
+    },
+    '613': {
+      id: 613,
+      name: 'Adserve.zone / Artworx AS',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        7
+      ],
+      flexiblePurposes: [
+        2
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://adserve.zone/adserveprivacypolicy.html'
+    },
+    '614': {
+      id: 614,
+      name: 'Market Resource Partners LLC',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        2
+      ],
+      policyUrl: 'https://www.mrpfd.com/privacy-policy/'
+    },
+    '615': {
+      id: 615,
+      name: 'Adsolutions BV',
+      purposes: [],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.adsolutions.com/privacy-policy/'
+    },
+    '617': {
+      id: 617,
+      name: 'Onfocus (Adagio)',
+      purposes: [
+        1,
+        2
+      ],
+      legIntPurposes: [
+        7
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://adagio.io/privacy'
+    },
+    '618': {
+      id: 618,
+      name: 'BEINTOO SPA',
+      purposes: [
+        1,
+        2,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://www.beintoo.com/privacy-cookie-policy/'
+    },
+    '620': {
+      id: 620,
+      name: 'Blue',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://www.getblue.io/privacy/'
+    },
+    '625': {
+      id: 625,
+      name: 'BILENDI SA',
+      purposes: [
+        1,
+        6,
+        7,
+        8,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.maximiles.com/privacy-policy'
+    },
+    '626': {
+      id: 626,
+      name: 'Hivestack Inc.',
+      purposes: [
+        1,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://hivestack.com/privacy-policy'
+    },
+    '628': {
+      id: 628,
+      name: ': Tappx',
+      purposes: [
+        1,
+        2,
+        4,
+        7,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        2
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://www.tappx.com/en/privacy-policy/'
+    },
+    '630': {
+      id: 630,
+      name: 'Contact Impact GmbH',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        7,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://contactimpact.de/privacy'
+    },
+    '631': {
+      id: 631,
+      name: 'Relay42 Netherlands B.V.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://relay42.com/privacy'
+    },
+    '638': {
+      id: 638,
+      name: 'Passendo Aps',
+      purposes: [
+        1,
+        2,
+        4,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://passendo.com/users-privacy-policy'
+    },
+    '639': {
+      id: 639,
+      name: 'Smile Wanted Group',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [
+        2
+      ],
+      policyUrl: 'https://www.smilewanted.com/privacy.php'
+    },
+    '645': {
+      id: 645,
+      name: 'Noster Finance S.L.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        9,
+        10
+      ],
+      legIntPurposes: [
+        7,
+        8
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://www.finect.com/terminos-legales/politica-de-cookies'
+    },
+    '646': {
+      id: 646,
+      name: 'Notify',
+      purposes: [],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://notify-group.com/en/mentions-legales/'
+    },
+    '647': {
+      id: 647,
+      name: 'Axel Springer Teaser Ad GmbH',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        7,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.adup-tech.com/privacy'
+    },
+    '648': {
+      id: 648,
+      name: 'TrueData Solutions, Inc.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://www.truedata.co/privacy-policy/'
+    },
+    '649': {
+      id: 649,
+      name: 'adality GmbH',
+      purposes: [],
+      legIntPurposes: [
+        2
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://adality.de/en/privacy/'
+    },
+    '650': {
+      id: 650,
+      name: 'Telefonica Investigación y Desarrollo S.A.U',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://www.cognitivemarketing.tid.es/'
+    },
+    '652': {
+      id: 652,
+      name: 'Skaze',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://www.skaze.fr/rgpd/'
+    },
+    '653': {
+      id: 653,
+      name: 'Smartme Analytics',
+      purposes: [
+        7,
+        8,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'http://smartmeapp.com/info/smartme/aviso_legal.php',
+      deletedDate: '2020-07-03T00:00:00Z'
+    },
+    '655': {
+      id: 655,
+      name: 'Sportradar AG',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://www.sportradar.com/about-us/privacy/'
+    },
+    '656': {
+      id: 656,
+      name: 'Think Clever Media',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        9
+      ],
+      legIntPurposes: [
+        7,
+        8,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.contentignite.com/privacy-policy/'
+    },
+    '657': {
+      id: 657,
+      name: 'GP One GmbH',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://www.gsi-one.org/de/privacy-policy.html'
+    },
+    '659': {
+      id: 659,
+      name: 'Research and Analysis of Media in Sweden AB',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        7,
+        8,
+        9
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www2.rampanel.com/privacy-policy/'
+    },
+    '662': {
+      id: 662,
+      name: 'SoundCast',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://soundcast.fm/en/data-privacy'
+    },
+    '663': {
+      id: 663,
+      name: 'Mobsuccess',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        7
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.mobsuccess.com/en/privacy'
+    },
+    '664': {
+      id: 664,
+      name: 'adMarketplace, Inc.',
+      purposes: [
+        1,
+        2,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        7,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.admarketplace.com/privacy-policy/'
+    },
+    '665': {
+      id: 665,
+      name: 'Digital East GmbH',
+      purposes: [
+        2,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.digitaleast.mobi/en/legal/privacy-policy/'
+    },
+    '667': {
+      id: 667,
+      name: 'Liftoff Mobile, Inc.',
+      purposes: [
+        1,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        5,
+        6,
+        7,
+        8,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://liftoff.io/privacy-policy/'
+    },
+    '668': {
+      id: 668,
+      name: 'WhatRocks Inc. ',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        2
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://www.whatrocks.co/en/privacy-policy '
+    },
+    '674': {
+      id: 674,
+      name: 'Duration Media, LLC.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.durationmedia.net/privacy-policy'
+    },
+    '675': {
+      id: 675,
+      name: 'Instreamatic inc.',
+      purposes: [
+        2,
+        3,
+        4,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://instreamatic.com/privacy-policy/'
+    },
+    '676': {
+      id: 676,
+      name: 'BusinessClick',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.businessclick.com/documents/RegulaminProgramuBusinessClick-2019.pdf'
+    },
+    '678': {
+      id: 678,
+      name: 'Axonix LTD',
+      purposes: [
+        2
+      ],
+      legIntPurposes: [
+        7,
+        10
+      ],
+      flexiblePurposes: [
+        2
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://axonix.com/privacy-cookie-policy/',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '681': {
+      id: 681,
+      name: 'MyTraffic',
+      purposes: [
+        1,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        9
+      ],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.mytraffic.io/en/privacy'
+    },
+    '682': {
+      id: 682,
+      name: 'Radio Net Media Limited',
+      purposes: [
+        1,
+        2,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        7
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://www.adtonos.com/service-privacy-policy/',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '683': {
+      id: 683,
+      name: 'Cookie Market LTD',
+      purposes: [
+        1,
+        3,
+        4,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'http://cookie.market/privacyPolicy.php'
+    },
+    '684': {
+      id: 684,
+      name: 'Blue Billywig BV',
+      purposes: [],
+      legIntPurposes: [
+        7
+      ],
+      flexiblePurposes: [
+        7
+      ],
+      specialPurposes: [
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.bluebillywig.com/privacy-statement/'
+    },
+    '686': {
+      id: 686,
+      name: 'The MediaGrid Inc.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.themediagrid.com/privacy-policy/'
+    },
+    '687': {
+      id: 687,
+      name: 'MISSENA',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2
+      ],
+      specialPurposes: [
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://missena.com/confidentialite/'
+    },
+    '688': {
+      id: 688,
+      name: 'Effinity',
+      purposes: [],
+      legIntPurposes: [
+        2
+      ],
+      flexiblePurposes: [
+        2,
+        7
+      ],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.effiliation.com/politique-de-confidentialite/',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '690': {
+      id: 690,
+      name: 'Go.pl sp. z o.o.',
+      purposes: [
+        1,
+        2,
+        3,
+        4
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://go.pl/polityka-prywatnosci/'
+    },
+    '691': {
+      id: 691,
+      name: 'Lifesight Pte. Ltd.',
+      purposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.lifesight.io/privacy-policy/'
+    },
+    '694': {
+      id: 694,
+      name: 'Snapupp Technologies SL',
+      purposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        9
+      ],
+      legIntPurposes: [
+        7,
+        8,
+        10
+      ],
+      flexiblePurposes: [
+        10
+      ],
+      specialPurposes: [],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.enterprise.noddus.com/privacy-policy',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '699': {
+      id: 699,
+      name: 'HyperTV Inc.',
+      purposes: [
+        1,
+        2,
+        4,
+        9
+      ],
+      legIntPurposes: [
+        7,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        2
+      ],
+      features: [
+        1
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.hypertvx.com/privacy/'
+    },
+    '702': {
+      id: 702,
+      name: 'Kwanko',
+      purposes: [
+        1,
+        2,
+        7,
+        8
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        7,
+        8
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.kwanko.com/fr/rgpd/'
+    },
+    '703': {
+      id: 703,
+      name: 'MindTake Research GmbH',
+      purposes: [
+        1,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1
+      ],
+      features: [
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.mindtake.com/en/reppublika-privacy-policy'
+    },
+    '707': {
+      id: 707,
+      name: 'Dentsu Aegis Network Italia SpA',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://www.dentsuaegisnetwork.com/it/it/policies/info-cookie'
+    },
+    '708': {
+      id: 708,
+      name: 'Dugout Limited ',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://dugout.com/privacy-policy'
+    },
+    '709': {
+      id: 709,
+      name: 'NC Audience Exchange, LLC (NewsIQ)',
+      purposes: [
+        1,
+        3,
+        4,
+        5
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.ncaudienceexchange.com/privacy/'
+    },
+    '711': {
+      id: 711,
+      name: 'SITU8ED SA',
+      purposes: [
+        1,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.situ8ed.com/privacy-policy/'
+    },
+    '712': {
+      id: 712,
+      name: 'Inspired Mobile Limited',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://byinspired.com/privacypolicy.pdf'
+    },
+    '713': {
+      id: 713,
+      name: 'Dataseat Ltd',
+      purposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        7,
+        8
+      ],
+      specialPurposes: [],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://dataseat.com/privacy-policy'
+    },
+    '714': {
+      id: 714,
+      name: 'Survata Inc.',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        7,
+        9
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.survata.com/respondent-privacy-policy/',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '716': {
+      id: 716,
+      name: 'OnAudience Ltd',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.onaudience.com/internet-advertising-privacy-policy'
+    },
+    '719': {
+      id: 719,
+      name: 'Online Advertising Network Sp. z o.o.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.oan.pl/en/privacy-policy'
+    },
+    '720': {
+      id: 720,
+      name: 'AAX LLC',
+      purposes: [
+        1,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://aax.media/privacy/',
+      overflow: {
+        httpGetLimit: 32
+      }
+    },
+    '721': {
+      id: 721,
+      name: 'Beaconspark Ltd',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        7
+      ],
+      legIntPurposes: [
+        6,
+        8
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.engageya.com/privacy'
+    },
+    '722': {
+      id: 722,
+      name: 'agof - daily campaign facts',
+      purposes: [
+        1,
+        8,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        7
+      ],
+      specialPurposes: [
+        1
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://www.agof.de/datenschutz/'
+    },
+    '723': {
+      id: 723,
+      name: 'Adzymic Pte Ltd',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        8
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'http://www.adzymic.co/privacy',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '725': {
+      id: 725,
+      name: 'Pubfinity LLC',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://pubfinity.com/privacy-policy/',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '727': {
+      id: 727,
+      name: 'Pinpoll GmbH (Private Limited)',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.pinpoll.com/#data_protection_declaration'
+    },
+    '728': {
+      id: 728,
+      name: 'Appier PTE Ltd',
+      purposes: [
+        1,
+        3,
+        4,
+        5,
+        6,
+        9
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        8,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.appier.com/privacy-policy/'
+    },
+    '729': {
+      id: 729,
+      name: 'Cavai AS & UK ',
+      purposes: [],
+      legIntPurposes: [
+        7,
+        8
+      ],
+      flexiblePurposes: [
+        7,
+        8
+      ],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://cav.ai/privacy-policy/'
+    },
+    '730': {
+      id: 730,
+      name: 'INFOnline GmbH',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        8
+      ],
+      flexiblePurposes: [
+        8
+      ],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.infonline.de/en/privacy-policy/'
+    },
+    '731': {
+      id: 731,
+      name: 'GeistM Technologies LTD',
+      purposes: [],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.geistm.com/privacy'
+    },
+    '733': {
+      id: 733,
+      name: 'Anzu Virtual reality LTD',
+      purposes: [
+        1,
+        2,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://anzu.io/privacy/'
+    },
+    '734': {
+      id: 734,
+      name: 'Cint AB',
+      purposes: [
+        1,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.cint.com/participant-privacy-notice'
+    },
+    '735': {
+      id: 735,
+      name: 'Deutsche Post AG',
+      purposes: [
+        1,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.deutschepost.de/de/c/consentric/datenschutz.html'
+    },
+    '737': {
+      id: 737,
+      name: 'Monet Engine Inc',
+      purposes: [
+        1,
+        2,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://appmonet.com/privacy-policy/'
+    },
+    '738': {
+      id: 738,
+      name: 'adbility media GmbH',
+      purposes: [
+        2,
+        3,
+        4,
+        9
+      ],
+      legIntPurposes: [
+        7
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        9
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://www.adbility-media.com/datenschutzerklaerung/'
+    },
+    '739': {
+      id: 739,
+      name: 'Blingby LLC',
+      purposes: [
+        1,
+        8,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://blingby.com/privacy'
+    },
+    '740': {
+      id: 740,
+      name: '6Sense Insights, Inc.',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        5,
+        7,
+        8,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        7,
+        8,
+        10
+      ],
+      specialPurposes: [],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://6sense.com/privacy-policy/',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '741': {
+      id: 741,
+      name: 'Brand Advance Limited',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://www.wearebrandadvance.com/website-privacy-policy'
+    },
+    '742': {
+      id: 742,
+      name: 'Audiencerate LTD',
+      purposes: [
+        1,
+        2,
+        3,
+        5,
+        6
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.audiencerate.com/privacy/'
+    },
+    '743': {
+      id: 743,
+      name: 'MOVIads Sp. z o.o. Sp. k.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://moviads.pl/polityka-prywatnosci/',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '744': {
+      id: 744,
+      name: 'Vidazoo Ltd',
+      purposes: [
+        3,
+        4
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        8,
+        10
+      ],
+      flexiblePurposes: [
+        3,
+        4
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        2
+      ],
+      specialFeatures: [
+        2
+      ],
+      policyUrl: 'https://vidazoo.gitbook.io/vidazoo-legal/privacy-policy',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '745': {
+      id: 745,
+      name: 'Justtag Sp. z o.o.',
+      purposes: [
+        1,
+        3,
+        4,
+        9
+      ],
+      legIntPurposes: [
+        7
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.justtag.com/pdf/PRIVACY_POLICY_Koalametrics_english.pdf'
+    },
+    '746': {
+      id: 746,
+      name: 'Adxperience SAS',
+      purposes: [
+        4
+      ],
+      legIntPurposes: [
+        2,
+        7
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://adxperience.com/privacy-policy/'
+    },
+    '747': {
+      id: 747,
+      name: 'Kairion GmbH',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [],
+      features: [
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://kairion.de/datenschutzbestimmungen/'
+    },
+    '748': {
+      id: 748,
+      name: 'AUDIOMOB LTD',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        8,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        8,
+        9
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://www.audiomob.io/privacy'
+    },
+    '749': {
+      id: 749,
+      name: 'Good-Loop Ltd',
+      purposes: [
+        1,
+        3,
+        4,
+        5,
+        6
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://doc.good-loop.com/policy/privacy-policy.html'
+    },
+    '750': {
+      id: 750,
+      name: 'THE NEWCO S.R.L.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://www.thenewco.it/privacy_policy_servizi_prodotti.html'
+    },
+    '751': {
+      id: 751,
+      name: 'Kiosked Ltd',
+      purposes: [],
+      legIntPurposes: [
+        2,
+        7
+      ],
+      flexiblePurposes: [
+        2,
+        7
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://kiosked.com/privacy-policy/'
+    },
+    '753': {
+      id: 753,
+      name: 'ScaleMonk Inc.',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.scalemonk.com/privacy-policy/index.html'
+    },
+    '754': {
+      id: 754,
+      name: 'DistroScale, Inc.',
+      purposes: [
+        1,
+        2
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2
+      ],
+      specialPurposes: [
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'http://www.distroscale.com/privacy-policy/'
+    },
+    '757': {
+      id: 757,
+      name: 'UAB Meazy',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://meazy.co/privacy-policy'
+    },
+    '758': {
+      id: 758,
+      name: 'GfK Netherlands B.V.',
+      purposes: [
+        1,
+        7,
+        8,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        7,
+        8,
+        9
+      ],
+      specialPurposes: [],
+      features: [
+        1
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://gfkpanel.nl/privacy'
+    },
+    '759': {
+      id: 759,
+      name: 'RevJet',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.revjet.com/privacy',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '760': {
+      id: 760,
+      name: 'VEXPRO TECHNOLOGIES LTD',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        2
+      ],
+      policyUrl: 'https://onedash.com/privacy-policy.html'
+    },
+    '761': {
+      id: 761,
+      name: 'Digiseg ApS',
+      purposes: [
+        1,
+        3,
+        5,
+        7,
+        8,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        1
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://digiseg.io/privacy-center/'
+    },
+    '762': {
+      id: 762,
+      name: 'Protected Media LTD',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        3,
+        5,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.protected.media/privacy-policy/'
+    },
+    '764': {
+      id: 764,
+      name: 'Lucidity',
+      purposes: [
+        1,
+        2,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://golucidity.com/privacy-policy/'
+    },
+    '765': {
+      id: 765,
+      name: 'Grabit Interactive Media Inc dba KERV Interctive',
+      purposes: [
+        2,
+        3,
+        4,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        2
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://kervit.com/privacy-policy/'
+    },
+    '766': {
+      id: 766,
+      name: 'ADCELL | Firstlead GmbH',
+      purposes: [
+        1,
+        2
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2
+      ],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.adcell.de/agb#sector_6'
+    },
+    '768': {
+      id: 768,
+      name: 'Global Media & Entertainment Limited',
+      purposes: [
+        1,
+        2,
+        3,
+        4,
+        7,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'http://global.com/privacy-policy/'
+    },
+    '769': {
+      id: 769,
+      name: 'MEDIAMETRIE',
+      purposes: [
+        1,
+        8
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.mediametrie.fr/fr/gestion-des-cookies'
+    },
+    '770': {
+      id: 770,
+      name: 'MARKETPERF CORP',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2,
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.marketperf.com/assets/images/app/marketperf/pdf/privacy-policy.pdf'
+    },
+    '771': {
+      id: 771,
+      name: 'bam! interactive marketing GmbH ',
+      purposes: [
+        1,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://bam-interactive.de/privacy-policy/'
+    },
+    '772': {
+      id: 772,
+      name: 'Oracle Data Cloud - Moat',
+      purposes: [],
+      legIntPurposes: [
+        7,
+        8,
+        10
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.oracle.com/legal/privacy/services-privacy-policy.html'
+    },
+    '774': {
+      id: 774,
+      name: 'Wagawin GmbH',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        7
+      ],
+      flexiblePurposes: [
+        2
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.wagawin.com/privacy-en/#productprivacy'
+    },
+    '775': {
+      id: 775,
+      name: 'SelectMedia International LTD',
+      purposes: [
+        1,
+        2
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        3
+      ],
+      specialFeatures: [],
+      policyUrl: 'https://www.selectmedia.asia/terms-and-privacy/'
+    },
+    '776': {
+      id: 776,
+      name: 'Mars Media Group',
+      purposes: [
+        2
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [
+        2
+      ],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://pay-per-leads.com/terms'
+    },
+    '777': {
+      id: 777,
+      name: 'One Planet Only',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        7
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://oneplanetonly.com/files/PRIVACY%20POLICY.pdf',
+      overflow: {
+        httpGetLimit: 32
+      }
+    },
+    '778': {
+      id: 778,
+      name: 'Discover-Tech ltd',
+      purposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://discover-tech.io/dsp-privacy-policy/'
+    },
+    '779': {
+      id: 779,
+      name: 'Adtarget Medya A.S.',
+      purposes: [
+        1,
+        7
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [
+        3
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://adtarget.com.tr/adtarget-privacy-policy-2020.pdf'
+    },
+    '780': {
+      id: 780,
+      name: 'Aniview LTD',
+      purposes: [
+        1,
+        2,
+        7,
+        8
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.aniview.com/privacy-policy/'
+    },
+    '781': {
+      id: 781,
+      name: 'FeedAd GmbH',
+      purposes: [
+        1,
+        3,
+        4,
+        5,
+        6,
+        8,
+        9
+      ],
+      legIntPurposes: [
+        2,
+        7,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        7,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        2,
+        3
+      ],
+      specialFeatures: [
+        1,
+        2
+      ],
+      policyUrl: 'https://feedad.com/privacy/',
+      overflow: {
+        httpGetLimit: 128
+      }
+    },
+    '782': {
+      id: 782,
+      name: 'AirGrid LTD',
+      purposes: [
+        1,
+        3,
+        5,
+        7,
+        8,
+        9,
+        10
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'airgid.io/privacy-policy'
+    },
+    '783': {
+      id: 783,
+      name: 'Audienzz AG',
+      purposes: [
+        1
+      ],
+      legIntPurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [
+        1,
+        2
+      ],
+      specialFeatures: [
+        1
+      ],
+      policyUrl: 'https://audienzz.ch/wp-content/uploads/2020/03/AGB_audienzz_2020.pdf'
+    },
+    '784': {
+      id: 784,
+      name: 'Nubo LTD',
+      purposes: [],
+      legIntPurposes: [
+        2
+      ],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.recod3.com/privacypolicy.php'
+    },
+    '785': {
+      id: 785,
+      name: 'agof - daily digital facts',
+      purposes: [
+        1,
+        9
+      ],
+      legIntPurposes: [],
+      flexiblePurposes: [],
+      specialPurposes: [
+        1
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'http://www.agof.de/datenschutz/'
+    },
+    '786': {
+      id: 786,
+      name: 'TargetVideo GmbH',
+      purposes: [
+        1,
+        2,
+        3,
+        4
+      ],
+      legIntPurposes: [
+        7,
+        8,
+        10
+      ],
+      flexiblePurposes: [
+        2,
+        3,
+        4,
+        7,
+        8,
+        10
+      ],
+      specialPurposes: [
+        1,
+        2
+      ],
+      features: [],
+      specialFeatures: [],
+      policyUrl: 'https://www.target-video.com/datenschutz/'
+    }
+  }
+}}
+
+export {VendorListValueEnglish, VendorListValueSpanish, VendorList46, VendorList45}

--- a/src/test/fixtures/vendorlist/VendorListValue.js
+++ b/src/test/fixtures/vendorlist/VendorListValue.js
@@ -8846,8 +8846,8 @@ const VendorListValueSpanish = {
   }
 }
 
-
-const VendorList45 = {data: {
+const VendorList45 = {
+  data: {
     gvlSpecificationVersion: 2,
     vendorListVersion: 45,
     tcfPolicyVersion: 2,
@@ -8856,743 +8856,557 @@ const VendorList45 = {data: {
       '1': {
         id: 1,
         name: 'Almacenar o acceder a información en un dispositivo',
-        description: 'Se puede almacenar o acceder a cookies, identificadores de dispositivo u otra información en su dispositivo para las finalidades que se le presentan.',
-        descriptionLegal: 'Los proveedores pueden:\n* Almacenar y/o acceder a información en el dispositivo a través de cookies e identificadores de dispositivo ejecutados/instalados en el equipo del usuario.'
+        description:
+          'Se puede almacenar o acceder a cookies, identificadores de dispositivo u otra información en su dispositivo para las finalidades que se le presentan.',
+        descriptionLegal:
+          'Los proveedores pueden:\n* Almacenar y/o acceder a información en el dispositivo a través de cookies e identificadores de dispositivo ejecutados/instalados en el equipo del usuario.'
       },
       '2': {
         id: 2,
         name: 'Seleccionar anuncios básicos',
-        description: 'Los anuncios se pueden mostrar en función del contenido que se esté visualizando, la aplicación que se esté utilizando, su localización aproximada o su tipo de dispositivo.',
-        descriptionLegal: 'Para realizar la selección de anuncios básicos, los proveedores pueden:\n* Utilizar información en tiempo real sobre el contexto en el que se mostrará el anuncio, para mostrar el anuncio, incluida la información sobre el contenido y el dispositivo, como por ejemplo: tipo de dispositivo y sus funcionalidades, agente de usuario, URL, dirección IP \n* Utilizar los datos de localización geográfica de aproximada\n* Controlar la frecuencia con la que se muestran los anuncios a un usuario.\n* Secuenciar el orden en el que se muestran los anuncios a un usuario.\n* Evitar que un anuncio se sirva o envíe en un contexto editorial inadecuado (Brand safety)\nLos Proveedores no pueden:\n* Crear un perfil publicitario personalizado utilizando esta información para la selección de anuncios futuros sin una base jurídica separada cuya finalidad específica fuera crear un perfil publicitario personalizados.\nNota: Aproximada significa que se permite solamente una localización aproximada de, como máximo, dentro de un radio de 500 metros.\n'
+        description:
+          'Los anuncios se pueden mostrar en función del contenido que se esté visualizando, la aplicación que se esté utilizando, su localización aproximada o su tipo de dispositivo.',
+        descriptionLegal:
+          'Para realizar la selección de anuncios básicos, los proveedores pueden:\n* Utilizar información en tiempo real sobre el contexto en el que se mostrará el anuncio, para mostrar el anuncio, incluida la información sobre el contenido y el dispositivo, como por ejemplo: tipo de dispositivo y sus funcionalidades, agente de usuario, URL, dirección IP \n* Utilizar los datos de localización geográfica de aproximada\n* Controlar la frecuencia con la que se muestran los anuncios a un usuario.\n* Secuenciar el orden en el que se muestran los anuncios a un usuario.\n* Evitar que un anuncio se sirva o envíe en un contexto editorial inadecuado (Brand safety)\nLos Proveedores no pueden:\n* Crear un perfil publicitario personalizado utilizando esta información para la selección de anuncios futuros sin una base jurídica separada cuya finalidad específica fuera crear un perfil publicitario personalizados.\nNota: Aproximada significa que se permite solamente una localización aproximada de, como máximo, dentro de un radio de 500 metros.\n'
       },
       '3': {
         id: 3,
         name: 'Crear un perfil publicitario personalizado',
-        description: 'Se puede elaborar un perfil sobre usted y sus intereses para mostrarle anuncios personalizados que sean pertinentes para usted.',
-        descriptionLegal: 'Para crear un perfil publicitario personalizado, los proveedores pueden:\n* Recoger información sobre un usuario, (incluyendo la actividad anterior del usuario, sus intereses, páginas web o aplicaciones visitadas con anterioridad, ubicación o información demográfica) a fin de crear o editar un perfil de usuario para su uso en publicidad personalizada.\n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones, a fin de crear o editar un perfil de usuario para su uso en publicidad personalizada\n'
+        description:
+          'Se puede elaborar un perfil sobre usted y sus intereses para mostrarle anuncios personalizados que sean pertinentes para usted.',
+        descriptionLegal:
+          'Para crear un perfil publicitario personalizado, los proveedores pueden:\n* Recoger información sobre un usuario, (incluyendo la actividad anterior del usuario, sus intereses, páginas web o aplicaciones visitadas con anterioridad, ubicación o información demográfica) a fin de crear o editar un perfil de usuario para su uso en publicidad personalizada.\n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones, a fin de crear o editar un perfil de usuario para su uso en publicidad personalizada\n'
       },
       '4': {
         id: 4,
         name: 'Seleccionar anuncios personalizados',
-        description: 'Se pueden mostrar anuncios personalizados basándose en su perfil.',
-        descriptionLegal: 'Para seleccionar anuncios personalizados, los proveedores pueden:\n* Seleccionar anuncios personalizados basándose en un perfil de usuario u otros datos históricos del usuario, incluida la actividad anterior de un usuario, sus intereses, visitas a sitios web o aplicaciones, ubicación o información demográfica.\n'
+        description:
+          'Se pueden mostrar anuncios personalizados basándose en su perfil.',
+        descriptionLegal:
+          'Para seleccionar anuncios personalizados, los proveedores pueden:\n* Seleccionar anuncios personalizados basándose en un perfil de usuario u otros datos históricos del usuario, incluida la actividad anterior de un usuario, sus intereses, visitas a sitios web o aplicaciones, ubicación o información demográfica.\n'
       },
       '5': {
         id: 5,
         name: 'Crear un perfil para la personalización de contenidos',
-        description: 'Se puede crear un perfil sobre usted y sus intereses para mostrarle contenido personalizado que le fuera pertinente.',
-        descriptionLegal: 'Para crear un un perfil para la personalización de contenidos, los proveedores pueden:\n* Recoger información sobre un usuario, incluida la actividad de un usuario, sus intereses, visitas a sitios o aplicaciones, información demográfica o ubicación, a fin de crear o editar un perfil de usuario para personalizar el contenido.\n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones, a fin de crear o editar un perfil de usuario para personalizar el contenido.\n'
+        description:
+          'Se puede crear un perfil sobre usted y sus intereses para mostrarle contenido personalizado que le fuera pertinente.',
+        descriptionLegal:
+          'Para crear un un perfil para la personalización de contenidos, los proveedores pueden:\n* Recoger información sobre un usuario, incluida la actividad de un usuario, sus intereses, visitas a sitios o aplicaciones, información demográfica o ubicación, a fin de crear o editar un perfil de usuario para personalizar el contenido.\n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones, a fin de crear o editar un perfil de usuario para personalizar el contenido.\n'
       },
       '6': {
         id: 6,
         name: 'Seleccionar contenido personalizado',
-        description: 'Se puede mostrar contenido personalizado basado en su perfil.',
-        descriptionLegal: 'Para seleccionar contenido personalizado, los proveedores pueden:\n* Seleccionar contenido personalizado basándose en un perfil de usuario u otros datos históricos de usuarios, incluida la actividad anterior del usuario, sus intereses, visitas a sitios web o aplicaciones, ubicación o información demográfica.'
+        description:
+          'Se puede mostrar contenido personalizado basado en su perfil.',
+        descriptionLegal:
+          'Para seleccionar contenido personalizado, los proveedores pueden:\n* Seleccionar contenido personalizado basándose en un perfil de usuario u otros datos históricos de usuarios, incluida la actividad anterior del usuario, sus intereses, visitas a sitios web o aplicaciones, ubicación o información demográfica.'
       },
       '7': {
         id: 7,
         name: 'Medir el rendimiento de los anuncios',
-        description: 'Se puede medir el rendimiento y eficacia de los anuncios que usted ve o con los que interactúa.',
-        descriptionLegal: 'Para medir el rendimiento de los anuncios, los proveedores pueden:\n* Medir si los anuncios fueron suministrados a un usuario y cómo este interactuó con ellos\n* Elaborar informes sobre anuncios, incluida su eficacia y rendimiento\n* Elaborar informes sobre los usuarios que interactuaron con los anuncios utilizando datos observados durante el curso de la interacción del usuario con ese anuncio\n* Elaborar informes para los editores sobre los anuncios mostrados en sus sitios web o propiedad digital\n* Medir si un anuncio sirve en un contexto editorial adecuado (seguro para la marca)\n* Determinar el porcentaje del anuncio que se tuvo la oportunidad de ser visto y la duración de esa oportunidad \n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones.\nLos proveedores no pueden:\n* Aplicar datos de información sobre el público basados en un panel de usuarios o similares a los datos de medición de anuncios sin una base jurídica independiente para utilizar estudios de mercado a fin de generar información sobre el público.\n'
+        description:
+          'Se puede medir el rendimiento y eficacia de los anuncios que usted ve o con los que interactúa.',
+        descriptionLegal:
+          'Para medir el rendimiento de los anuncios, los proveedores pueden:\n* Medir si los anuncios fueron suministrados a un usuario y cómo este interactuó con ellos\n* Elaborar informes sobre anuncios, incluida su eficacia y rendimiento\n* Elaborar informes sobre los usuarios que interactuaron con los anuncios utilizando datos observados durante el curso de la interacción del usuario con ese anuncio\n* Elaborar informes para los editores sobre los anuncios mostrados en sus sitios web o propiedad digital\n* Medir si un anuncio sirve en un contexto editorial adecuado (seguro para la marca)\n* Determinar el porcentaje del anuncio que se tuvo la oportunidad de ser visto y la duración de esa oportunidad \n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones.\nLos proveedores no pueden:\n* Aplicar datos de información sobre el público basados en un panel de usuarios o similares a los datos de medición de anuncios sin una base jurídica independiente para utilizar estudios de mercado a fin de generar información sobre el público.\n'
       },
       '8': {
         id: 8,
         name: 'Medir el rendimiento del contenido',
-        description: 'Se puede medir el rendimiento y la eficacia del contenido que ve o con el que interactúa.',
-        descriptionLegal: 'Para medir el rendimiento del contenido, los proveedores pueden:\n* Medir e informar sobre cómo se entregó el contenido y cómo interactuaron con él los usuarios.\n* Elaborar informes, utilizando información directamente medible o conocida, sobre los usuarios que interactuaron con el contenido\n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones.\nLos proveedores no pueden:\n* Medir si los anuncios (incluida la publicidad nativa) fueron suministrados a un usuario y si este interactuó con ellos sin tener una base jurídica alternativa que lo permita.\n* Aplicar datos de información sobre el público, basados en un panel de usuarios o similares, a los datos de medición de anuncios sin una base jurídica independiente para utilizar estudios de mercado a fin de generar información sobre el público.\n'
+        description:
+          'Se puede medir el rendimiento y la eficacia del contenido que ve o con el que interactúa.',
+        descriptionLegal:
+          'Para medir el rendimiento del contenido, los proveedores pueden:\n* Medir e informar sobre cómo se entregó el contenido y cómo interactuaron con él los usuarios.\n* Elaborar informes, utilizando información directamente medible o conocida, sobre los usuarios que interactuaron con el contenido\n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones.\nLos proveedores no pueden:\n* Medir si los anuncios (incluida la publicidad nativa) fueron suministrados a un usuario y si este interactuó con ellos sin tener una base jurídica alternativa que lo permita.\n* Aplicar datos de información sobre el público, basados en un panel de usuarios o similares, a los datos de medición de anuncios sin una base jurídica independiente para utilizar estudios de mercado a fin de generar información sobre el público.\n'
       },
       '9': {
         id: 9,
-        name: 'Utilizar estudios de mercado a fin de generar información sobre el público',
-        description: 'La investigación de mercado puede utilizarse para obtener más información sobre el público que visita sitios webs/aplicaciones y visualiza los anuncios.',
-        descriptionLegal: 'Para utilizar estudios de mercado a fin de generar información sobre el público, los proveedores pueden:\n* Elaborar informes agregados para los anunciantes o sus representantes sobre el público alcanzado por sus anuncios, a través de información basada en paneles de audiencia u obtenida de manera similar.\n* Elaborar informes agregados para los editores sobre el público al que se le mostraron contenidos y/o anuncios o que interactuaron con ellos en su propiedad, aplicando información basada en paneles de audiencia u obtenida de manera similar\n* Asociar datos off line con un usuario on line para finalidades de estudios de mercado a fin de generar información sobre el público si los proveedores han declarado que cotejan y combinan fuentes de datos off line \n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones.\nLos proveedores no pueden: \n* Medir el rendimiento y la eficacia de los anuncios que se mostraron a un usuario específico o con los que interactuó, sin una base jurídica independiente para medir el rendimiento de los anuncios.\n• Medir qué contenido se mostró a un usuario específico y cómo interactuó con el mismo, sin una base jurídica independiente para medir el rendimiento del contenido.\n'
+        name:
+          'Utilizar estudios de mercado a fin de generar información sobre el público',
+        description:
+          'La investigación de mercado puede utilizarse para obtener más información sobre el público que visita sitios webs/aplicaciones y visualiza los anuncios.',
+        descriptionLegal:
+          'Para utilizar estudios de mercado a fin de generar información sobre el público, los proveedores pueden:\n* Elaborar informes agregados para los anunciantes o sus representantes sobre el público alcanzado por sus anuncios, a través de información basada en paneles de audiencia u obtenida de manera similar.\n* Elaborar informes agregados para los editores sobre el público al que se le mostraron contenidos y/o anuncios o que interactuaron con ellos en su propiedad, aplicando información basada en paneles de audiencia u obtenida de manera similar\n* Asociar datos off line con un usuario on line para finalidades de estudios de mercado a fin de generar información sobre el público si los proveedores han declarado que cotejan y combinan fuentes de datos off line \n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones.\nLos proveedores no pueden: \n* Medir el rendimiento y la eficacia de los anuncios que se mostraron a un usuario específico o con los que interactuó, sin una base jurídica independiente para medir el rendimiento de los anuncios.\n• Medir qué contenido se mostró a un usuario específico y cómo interactuó con el mismo, sin una base jurídica independiente para medir el rendimiento del contenido.\n'
       },
       '10': {
         id: 10,
         name: 'Desarrollar y mejorar productos',
-        description: 'Sus datos pueden utilizarse para mejorar los sistemas y/o el software existente, así como para desarrollar nuevos productos.',
-        descriptionLegal: 'Para desarrollar nuevos productos y mejorar los productos, los proveedores pueden:\n* Utilizar información para mejorar sus productos existentes con nuevas funcionalidades/características y desarrollar nuevos productos\n* Crear nuevos modelos y algoritmos mediante machine learning\nLos proveedores no pueden:\n* A partir de esta finalidad no se puede llevar a cabo ninguna otra operación de tratamiento de datos permitida en virtud de una finalidad distinta.\n'
+        description:
+          'Sus datos pueden utilizarse para mejorar los sistemas y/o el software existente, así como para desarrollar nuevos productos.',
+        descriptionLegal:
+          'Para desarrollar nuevos productos y mejorar los productos, los proveedores pueden:\n* Utilizar información para mejorar sus productos existentes con nuevas funcionalidades/características y desarrollar nuevos productos\n* Crear nuevos modelos y algoritmos mediante machine learning\nLos proveedores no pueden:\n* A partir de esta finalidad no se puede llevar a cabo ninguna otra operación de tratamiento de datos permitida en virtud de una finalidad distinta.\n'
       }
     },
     specialPurposes: {
       '1': {
         id: 1,
         name: 'Garantizar la seguridad, evitar fraudes y depurar errores',
-        description: 'Sus datos pueden utilizarse para supervisar y evitar actividades fraudulentas, y para asegurar que los sistemas y procesos funcionen de forma correcta y segura.',
-        descriptionLegal: 'Para garantizar la seguridad, evitar fraudes y depurar errores, los proveedores pueden:\n* Asegurarse de que los datos se transmitan de forma segura \n* Detectar y evitar actividades maliciosas, fraudulentas, inaceptables o ilegales.\n* Asegurar el funcionamiento correcto y eficaz de los sistemas y procesos, lo que incluye supervisar y mejorar el rendimiento de los sistemas y procesos empleados en las finalidades permitidas\nLos proveedores no pueden:\n* Llevar a cabo ninguna otra operación de tratamiento de datos permitida en virtud de una finalidad distinta.\nNota: Los datos recopilados y utilizados para garantizar la seguridad, evitar el fraude y depurar errores pueden incluir características del dispositivo enviadas automáticamente para su identificación, datos de geolocalización precisos y datos obtenidos analizando de forma activa las características del dispositivo para su identificación sin que sea necesario revelar más información y/o una aceptación independiente.  \n'
+        description:
+          'Sus datos pueden utilizarse para supervisar y evitar actividades fraudulentas, y para asegurar que los sistemas y procesos funcionen de forma correcta y segura.',
+        descriptionLegal:
+          'Para garantizar la seguridad, evitar fraudes y depurar errores, los proveedores pueden:\n* Asegurarse de que los datos se transmitan de forma segura \n* Detectar y evitar actividades maliciosas, fraudulentas, inaceptables o ilegales.\n* Asegurar el funcionamiento correcto y eficaz de los sistemas y procesos, lo que incluye supervisar y mejorar el rendimiento de los sistemas y procesos empleados en las finalidades permitidas\nLos proveedores no pueden:\n* Llevar a cabo ninguna otra operación de tratamiento de datos permitida en virtud de una finalidad distinta.\nNota: Los datos recopilados y utilizados para garantizar la seguridad, evitar el fraude y depurar errores pueden incluir características del dispositivo enviadas automáticamente para su identificación, datos de geolocalización precisos y datos obtenidos analizando de forma activa las características del dispositivo para su identificación sin que sea necesario revelar más información y/o una aceptación independiente.  \n'
       },
       '2': {
         id: 2,
         name: 'Servir técnicamente anuncios o contenido',
-        description: 'Su dispositivo puede recibir y enviar información que le permita ver e interactuar con anuncios y contenido.',
-        descriptionLegal: 'Para servir información y responder a solicitudes técnicas, los proveedores pueden:\n* Utilizar la dirección IP de un usuario para entregar un anuncio a través de Internet\n* Responder a la interacción de un usuario con un anuncio enviando al usuario a una página de destino\n* Utilizar la dirección IP de un usuario para entregar contenido a través de Internet\n* Responder a la interacción de un usuario con el contenido enviando al usuario a una página de destino\n* Utilizar información sobre el tipo de dispositivo y sus capacidades para entregar anuncios o contenido, por ejemplo, para entregar el archivo publicitario o de vídeo de tamaño adecuado en un formato compatible con el dispositivo\nLos proveedores no pueden:\n* Llevar a cabo, según esta finalidad, ninguna otra operación de tratamiento de datos permitida en virtud de una finalidad distinta.\n'
+        description:
+          'Su dispositivo puede recibir y enviar información que le permita ver e interactuar con anuncios y contenido.',
+        descriptionLegal:
+          'Para servir información y responder a solicitudes técnicas, los proveedores pueden:\n* Utilizar la dirección IP de un usuario para entregar un anuncio a través de Internet\n* Responder a la interacción de un usuario con un anuncio enviando al usuario a una página de destino\n* Utilizar la dirección IP de un usuario para entregar contenido a través de Internet\n* Responder a la interacción de un usuario con el contenido enviando al usuario a una página de destino\n* Utilizar información sobre el tipo de dispositivo y sus capacidades para entregar anuncios o contenido, por ejemplo, para entregar el archivo publicitario o de vídeo de tamaño adecuado en un formato compatible con el dispositivo\nLos proveedores no pueden:\n* Llevar a cabo, según esta finalidad, ninguna otra operación de tratamiento de datos permitida en virtud de una finalidad distinta.\n'
       }
     },
     features: {
       '1': {
         id: 1,
         name: 'Cotejar y combinar fuentes de datos off line',
-        description: 'Los datos obtenidos de fuentes de datos off line pueden combinarse con su actividad on line para respaldar una o más finalidades.',
-        descriptionLegal: 'Los proveedores pueden: \n* Combinar los datos obtenidos off line con los datos recogidos on line en apoyo de una o más Finalidades o Finalidades especiales.'
+        description:
+          'Los datos obtenidos de fuentes de datos off line pueden combinarse con su actividad on line para respaldar una o más finalidades.',
+        descriptionLegal:
+          'Los proveedores pueden: \n* Combinar los datos obtenidos off line con los datos recogidos on line en apoyo de una o más Finalidades o Finalidades especiales.'
       },
       '2': {
         id: 2,
         name: 'Vincular diferentes dispositivos',
-        description: 'Se puede determinar que diferentes dispositivos pertenecen a usted o a su hogar para una o más finalidades.',
-        descriptionLegal: 'Los proveedores pueden:\n* Determinar de forma determinista que dos o más dispositivos pertenecen al mismo usuario u hogar\n* Determinar de forma probabilística que dos o más dispositivos pertenecen al mismo usuario u hogar\n* Analizar activamente las características del dispositivo para encontrar su identificación probabilística si los usuarios han permitido a los proveedores analizar activamente las características del dispositivo para su identificación (Funcionalidad especial 2)\n'
+        description:
+          'Se puede determinar que diferentes dispositivos pertenecen a usted o a su hogar para una o más finalidades.',
+        descriptionLegal:
+          'Los proveedores pueden:\n* Determinar de forma determinista que dos o más dispositivos pertenecen al mismo usuario u hogar\n* Determinar de forma probabilística que dos o más dispositivos pertenecen al mismo usuario u hogar\n* Analizar activamente las características del dispositivo para encontrar su identificación probabilística si los usuarios han permitido a los proveedores analizar activamente las características del dispositivo para su identificación (Funcionalidad especial 2)\n'
       },
       '3': {
         id: 3,
-        name: 'Recibir y utilizar para su identificación las características del dispositivo que    se envían automáticamente',
-        description: 'Su dispositivo puede distinguirse de otros dispositivos a partir de la información que envía automáticamente, como la dirección IP o el tipo de navegador.',
-        descriptionLegal: 'Los proveedores pueden:\n* Crear un identificador utilizando los datos recopilados automáticamente en un dispositivo para características específicas, por ejemplo, dirección IP o la cadena de agente de usuario.\n* Utilizar este identificador para intentar volver a identificar un dispositivo.\nLos proveedores no pueden:\n* Crear un identificador utilizando datos recogidos mediante el análisis activo de un dispositivo para hallar funcionalidads específicas, por ejemplo, fuentes instaladas o resolución de pantalla sin aceptación independiente del usuario para analizar de forma activa las características del dispositivo para su identificación.\n* Utilizar este identificador para volver a identificar un dispositivo.\n'
+        name:
+          'Recibir y utilizar para su identificación las características del dispositivo que    se envían automáticamente',
+        description:
+          'Su dispositivo puede distinguirse de otros dispositivos a partir de la información que envía automáticamente, como la dirección IP o el tipo de navegador.',
+        descriptionLegal:
+          'Los proveedores pueden:\n* Crear un identificador utilizando los datos recopilados automáticamente en un dispositivo para características específicas, por ejemplo, dirección IP o la cadena de agente de usuario.\n* Utilizar este identificador para intentar volver a identificar un dispositivo.\nLos proveedores no pueden:\n* Crear un identificador utilizando datos recogidos mediante el análisis activo de un dispositivo para hallar funcionalidads específicas, por ejemplo, fuentes instaladas o resolución de pantalla sin aceptación independiente del usuario para analizar de forma activa las características del dispositivo para su identificación.\n* Utilizar este identificador para volver a identificar un dispositivo.\n'
       }
     },
     specialFeatures: {
       '1': {
         id: 1,
         name: 'Utilizar datos de localización geográfica precisa',
-        description: 'Sus datos de localización geográfica precisa se pueden utilizar para una o más finalidades. Esto significa que su ubicación puede tener una precisión de varios metros.',
-        descriptionLegal: 'Los proveedores pueden:\n* Recoger y tratar datos de localización geográfica precisa para una o más finalidades.\nNota: La localización geográfica precisa significa que no existen restricciones sobre la precisión de la ubicación de un usuario; esto puede tener una precisión de varios metros.\n'
+        description:
+          'Sus datos de localización geográfica precisa se pueden utilizar para una o más finalidades. Esto significa que su ubicación puede tener una precisión de varios metros.',
+        descriptionLegal:
+          'Los proveedores pueden:\n* Recoger y tratar datos de localización geográfica precisa para una o más finalidades.\nNota: La localización geográfica precisa significa que no existen restricciones sobre la precisión de la ubicación de un usuario; esto puede tener una precisión de varios metros.\n'
       },
       '2': {
         id: 2,
-        name: 'Analizar activamente las características del dispositivo para su identificación',
-        description: 'Su dispositivo puede identificarse basándose en un análisis de la combinación única de las características de su dispositivo.',
-        descriptionLegal: 'Los proveedores pueden:\n* Crear un identificador utilizando datos recogidos mediante el análisis activo de un dispositivo para hallar características específicas, por ejemplo, fuentes instaladas o resolución de pantalla. \n* Utilizar este identificador para volver a identificar un dispositivo.\n'
+        name:
+          'Analizar activamente las características del dispositivo para su identificación',
+        description:
+          'Su dispositivo puede identificarse basándose en un análisis de la combinación única de las características de su dispositivo.',
+        descriptionLegal:
+          'Los proveedores pueden:\n* Crear un identificador utilizando datos recogidos mediante el análisis activo de un dispositivo para hallar características específicas, por ejemplo, fuentes instaladas o resolución de pantalla. \n* Utilizar este identificador para volver a identificar un dispositivo.\n'
       }
     },
     stacks: {
       '1': {
         id: 1,
         purposes: [],
-        specialFeatures: [
-          1,
-          2
-        ],
-        name: 'Datos de localización geográfica precisa e identificación mediante las características de dispositivos',
-        description: 'Se puede utilizar la localización geográfica precisa y la información sobre las características del dispositivo.'
+        specialFeatures: [1, 2],
+        name:
+          'Datos de localización geográfica precisa e identificación mediante las características de dispositivos',
+        description:
+          'Se puede utilizar la localización geográfica precisa y la información sobre las características del dispositivo.'
       },
       '2': {
         id: 2,
-        purposes: [
-          2,
-          7
-        ],
+        purposes: [2, 7],
         specialFeatures: [],
         name: 'Anuncios básicos y medición de anuncios',
-        description: 'Se pueden mostrar anuncios básicos. Se puede medir el rendimiento de los anuncios.'
+        description:
+          'Se pueden mostrar anuncios básicos. Se puede medir el rendimiento de los anuncios.'
       },
       '3': {
         id: 3,
-        purposes: [
-          2,
-          3,
-          4
-        ],
+        purposes: [2, 3, 4],
         specialFeatures: [],
         name: 'Anuncios personalizados',
-        description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios.'
+        description:
+          'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios.'
       },
       '4': {
         id: 4,
-        purposes: [
-          2,
-          7,
-          9
-        ],
+        purposes: [2, 7, 9],
         specialFeatures: [],
         name: 'Anuncios básicos y medición de anuncios',
-        description: 'Se pueden mostrar anuncios básicos. Se puede medir el rendimiento de los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+        description:
+          'Se pueden mostrar anuncios básicos. Se puede medir el rendimiento de los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
       },
       '5': {
         id: 5,
-        purposes: [
-          2,
-          3,
-          7
-        ],
+        purposes: [2, 3, 7],
         specialFeatures: [],
-        name: 'Anuncios básicos, creación de perfil publicitario personalizado y medición de anuncios',
-        description: 'Se pueden mostrar anuncios básicos. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios.'
+        name:
+          'Anuncios básicos, creación de perfil publicitario personalizado y medición de anuncios',
+        description:
+          'Se pueden mostrar anuncios básicos. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios.'
       },
       '6': {
         id: 6,
-        purposes: [
-          2,
-          4,
-          7
-        ],
+        purposes: [2, 4, 7],
         specialFeatures: [],
         name: 'Mostrar anuncios personalizados y medición de anuncios',
-        description: 'Los anuncios pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios.'
+        description:
+          'Los anuncios pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios.'
       },
       '7': {
         id: 7,
-        purposes: [
-          2,
-          4,
-          7,
-          9
-        ],
+        purposes: [2, 4, 7, 9],
         specialFeatures: [],
-        name: 'Mostrar anuncios personalizados, medición de anuncios e información sobre el público',
-        description: 'Los anuncios pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+        name:
+          'Mostrar anuncios personalizados, medición de anuncios e información sobre el público',
+        description:
+          'Los anuncios pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
       },
       '8': {
         id: 8,
-        purposes: [
-          2,
-          3,
-          4,
-          7
-        ],
+        purposes: [2, 3, 4, 7],
         specialFeatures: [],
         name: 'Anuncios personalizados y medición de anuncios',
-        description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios.'
+        description:
+          'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios.'
       },
       '9': {
         id: 9,
-        purposes: [
-          2,
-          3,
-          4,
-          7,
-          9
-        ],
+        purposes: [2, 3, 4, 7, 9],
         specialFeatures: [],
-        name: 'Anuncios personalizados, medición de anuncios e información sobre el público',
-        description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+        name:
+          'Anuncios personalizados, medición de anuncios e información sobre el público',
+        description:
+          'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
       },
       '10': {
         id: 10,
-        purposes: [
-          3,
-          4
-        ],
+        purposes: [3, 4],
         specialFeatures: [],
         name: 'Perfil y muestra de anuncios personalizados',
-        description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios.'
+        description:
+          'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios.'
       },
       '11': {
         id: 11,
-        purposes: [
-          5,
-          6
-        ],
+        purposes: [5, 6],
         specialFeatures: [],
         name: 'Contenido personalizado',
-        description: 'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido.'
+        description:
+          'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido.'
       },
       '12': {
         id: 12,
-        purposes: [
-          6,
-          8
-        ],
+        purposes: [6, 8],
         specialFeatures: [],
         name: 'Muestra de contenido personalizado y medición de contenido',
-        description: 'El contenido puede personalizarse basándose en un perfil. Se puede medir el rendimiento del contenido.'
+        description:
+          'El contenido puede personalizarse basándose en un perfil. Se puede medir el rendimiento del contenido.'
       },
       '13': {
         id: 13,
-        purposes: [
-          6,
-          8,
-          9
-        ],
+        purposes: [6, 8, 9],
         specialFeatures: [],
-        name: 'Presentación de contenido personalizado, medición del contenido e información sobre el público',
-        description: 'El contenido puede personalizarse basándose en un perfil. Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+        name:
+          'Presentación de contenido personalizado, medición del contenido e información sobre el público',
+        description:
+          'El contenido puede personalizarse basándose en un perfil. Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
       },
       '14': {
         id: 14,
-        purposes: [
-          5,
-          6,
-          8
-        ],
+        purposes: [5, 6, 8],
         specialFeatures: [],
         name: 'Contenido personalizado y medición del contenido',
-        description: 'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido.'
+        description:
+          'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido.'
       },
       '15': {
         id: 15,
-        purposes: [
-          5,
-          6,
-          8,
-          9
-        ],
+        purposes: [5, 6, 8, 9],
         specialFeatures: [],
-        name: 'Contenido personalizado, medición del contenido e información sobre el público',
-        description: 'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+        name:
+          'Contenido personalizado, medición del contenido e información sobre el público',
+        description:
+          'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
       },
       '16': {
         id: 16,
-        purposes: [
-          5,
-          6,
-          8,
-          9,
-          10
-        ],
+        purposes: [5, 6, 8, 9, 10],
         specialFeatures: [],
-        name: 'Contenido personalizado, medición del contenido, información sobre el público y desarrollo de productos',
-        description: 'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido. Se puede inducir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software'
+        name:
+          'Contenido personalizado, medición del contenido, información sobre el público y desarrollo de productos',
+        description:
+          'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido. Se puede inducir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software'
       },
       '17': {
         id: 17,
-        purposes: [
-          7,
-          8,
-          9
-        ],
+        purposes: [7, 8, 9],
         specialFeatures: [],
-        name: 'Medición de anuncios y del contenido e información sobre el público',
-        description: 'Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+        name:
+          'Medición de anuncios y del contenido e información sobre el público',
+        description:
+          'Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
       },
       '18': {
         id: 18,
-        purposes: [
-          7,
-          8
-        ],
+        purposes: [7, 8],
         specialFeatures: [],
         name: 'Medición de anuncios y del contenido',
-        description: 'Se puede medir el rendimiento de los anuncios y del contenido.'
+        description:
+          'Se puede medir el rendimiento de los anuncios y del contenido.'
       },
       '19': {
         id: 19,
-        purposes: [
-          7,
-          9
-        ],
+        purposes: [7, 9],
         specialFeatures: [],
         name: 'Medición de anuncios e información sobre el público',
-        description: 'Se pueden medir los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+        description:
+          'Se pueden medir los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
       },
       '20': {
         id: 20,
-        purposes: [
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [7, 8, 9, 10],
         specialFeatures: [],
-        name: 'Medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
-        description: 'Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+        name:
+          'Medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+        description:
+          'Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
       },
       '21': {
         id: 21,
-        purposes: [
-          8,
-          9,
-          10
-        ],
+        purposes: [8, 9, 10],
         specialFeatures: [],
-        name: 'Medición del contenido, información sobre el público y desarrollo de productos.',
-        description: 'Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+        name:
+          'Medición del contenido, información sobre el público y desarrollo de productos.',
+        description:
+          'Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
       },
       '22': {
         id: 22,
-        purposes: [
-          8,
-          10
-        ],
+        purposes: [8, 10],
         specialFeatures: [],
         name: 'Medición del contenido y desarrollo de productos',
-        description: 'Se puede medir el rendimiento del contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+        description:
+          'Se puede medir el rendimiento del contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
       },
       '23': {
         id: 23,
-        purposes: [
-          2,
-          4,
-          6,
-          7,
-          8
-        ],
+        purposes: [2, 4, 6, 7, 8],
         specialFeatures: [],
-        name: 'Presentación de anuncios y contenido personalizados, medición de anuncios y del contenido',
-        description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios y del contenido.'
+        name:
+          'Presentación de anuncios y contenido personalizados, medición de anuncios y del contenido',
+        description:
+          'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios y del contenido.'
       },
       '24': {
         id: 24,
-        purposes: [
-          2,
-          4,
-          6,
-          7,
-          8,
-          9
-        ],
+        purposes: [2, 4, 6, 7, 8, 9],
         specialFeatures: [],
-        name: 'Presentación de anuncios y contenido personalizados, medición de anuncios y del contenido e información sobre el público',
-        description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+        name:
+          'Presentación de anuncios y contenido personalizados, medición de anuncios y del contenido e información sobre el público',
+        description:
+          'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
       },
       '25': {
         id: 25,
-        purposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8
-        ],
+        purposes: [2, 3, 4, 5, 6, 7, 8],
         specialFeatures: [],
-        name: 'Anuncios y contenido personalizados, medición de anuncios y del contenido',
-        description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios y el contenido. Se puede medir el rendimiento de los anuncios y del contenido.'
+        name:
+          'Anuncios y contenido personalizados, medición de anuncios y del contenido',
+        description:
+          'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios y el contenido. Se puede medir el rendimiento de los anuncios y del contenido.'
       },
       '26': {
         id: 26,
-        purposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9
-        ],
+        purposes: [2, 3, 4, 5, 6, 7, 8, 9],
         specialFeatures: [],
-        name: 'Anuncios y contenido personalizados, medición de anuncios y del contenido e información sobre el público',
-        description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios y el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+        name:
+          'Anuncios y contenido personalizados, medición de anuncios y del contenido e información sobre el público',
+        description:
+          'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios y el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
       },
       '27': {
         id: 27,
-        purposes: [
-          3,
-          5
-        ],
+        purposes: [3, 5],
         specialFeatures: [],
         name: 'Anuncios personalizados y contenido personalizado',
-        description: 'Se pueden añadir más datos para personalizar los anuncios y el contenido.'
+        description:
+          'Se pueden añadir más datos para personalizar los anuncios y el contenido.'
       },
       '28': {
         id: 28,
-        purposes: [
-          2,
-          4,
-          6
-        ],
+        purposes: [2, 4, 6],
         specialFeatures: [],
         name: 'Muestra de anuncios y contenido personalizados',
-        description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil.'
+        description:
+          'Los anuncios y el contenido pueden personalizarse basándose en un perfil.'
       },
       '29': {
         id: 29,
-        purposes: [
-          2,
-          7,
-          8,
-          9
-        ],
+        purposes: [2, 7, 8, 9],
         specialFeatures: [],
-        name: 'Anuncios básicos, medición de anuncios y del contenido e información sobre el público',
-        description: 'Se pueden mostrar anuncios básicos. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+        name:
+          'Anuncios básicos, medición de anuncios y del contenido e información sobre el público',
+        description:
+          'Se pueden mostrar anuncios básicos. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
       },
       '30': {
         id: 30,
-        purposes: [
-          2,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9
-        ],
+        purposes: [2, 4, 5, 6, 7, 8, 9],
         specialFeatures: [],
-        name: 'Muestra de anuncios personalizados, contenido personalizado, medición de anuncios y del contenido e información sobre el público',
-        description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+        name:
+          'Muestra de anuncios personalizados, contenido personalizado, medición de anuncios y del contenido e información sobre el público',
+        description:
+          'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
       },
       '31': {
         id: 31,
-        purposes: [
-          2,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [2, 4, 5, 6, 7, 8, 9, 10],
         specialFeatures: [],
-        name: 'Muestra de anuncios personalizados, contenido personalizado, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
-        description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+        name:
+          'Muestra de anuncios personalizados, contenido personalizado, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+        description:
+          'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
       },
       '32': {
         id: 32,
-        purposes: [
-          2,
-          5,
-          6,
-          7,
-          8,
-          9
-        ],
+        purposes: [2, 5, 6, 7, 8, 9],
         specialFeatures: [],
-        name: 'Anuncios básicos, contenido personalizado, medición de anuncios y del contenido e información sobre el público',
-        description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+        name:
+          'Anuncios básicos, contenido personalizado, medición de anuncios y del contenido e información sobre el público',
+        description:
+          'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
       },
       '33': {
         id: 33,
-        purposes: [
-          2,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [2, 5, 6, 7, 8, 9, 10],
         specialFeatures: [],
-        name: 'Anuncios básicos, contenido personalizado, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
-        description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+        name:
+          'Anuncios básicos, contenido personalizado, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+        description:
+          'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
       },
       '34': {
         id: 34,
-        purposes: [
-          2,
-          5,
-          6,
-          8,
-          9
-        ],
+        purposes: [2, 5, 6, 8, 9],
         specialFeatures: [],
-        name: 'Anuncios básicos, contenido personalizado, medición del contenido e información sobre el público',
-        description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+        name:
+          'Anuncios básicos, contenido personalizado, medición del contenido e información sobre el público',
+        description:
+          'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
       },
       '35': {
         id: 35,
-        purposes: [
-          2,
-          5,
-          6,
-          8,
-          9,
-          10
-        ],
+        purposes: [2, 5, 6, 8, 9, 10],
         specialFeatures: [],
-        name: 'Anuncios básicos, contenido personalizado, medición del contenido, información sobre el público y desarrollo de productos',
-        description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+        name:
+          'Anuncios básicos, contenido personalizado, medición del contenido, información sobre el público y desarrollo de productos',
+        description:
+          'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
       },
       '36': {
         id: 36,
-        purposes: [
-          2,
-          5,
-          6,
-          7
-        ],
+        purposes: [2, 5, 6, 7],
         specialFeatures: [],
-        name: 'Anuncios básicos, contenido personalizado y medición de anuncios',
-        description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios.'
+        name:
+          'Anuncios básicos, contenido personalizado y medición de anuncios',
+        description:
+          'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios.'
       },
       '37': {
         id: 37,
-        purposes: [
-          2,
-          5,
-          6,
-          7,
-          10
-        ],
+        purposes: [2, 5, 6, 7, 10],
         specialFeatures: [],
-        name: 'Anuncios básicos, contenido personalizado, medición de anuncios y desarrollo de productos',
-        description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+        name:
+          'Anuncios básicos, contenido personalizado, medición de anuncios y desarrollo de productos',
+        description:
+          'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
       },
       '38': {
         id: 38,
-        purposes: [
-          2,
-          3,
-          4,
-          7,
-          10
-        ],
+        purposes: [2, 3, 4, 7, 10],
         specialFeatures: [],
-        name: 'Anuncios personalizados, medición de anuncios y desarrollo de productos',
-        description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+        name:
+          'Anuncios personalizados, medición de anuncios y desarrollo de productos',
+        description:
+          'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
       },
       '39': {
         id: 39,
-        purposes: [
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [2, 3, 4, 7, 9, 10],
         specialFeatures: [],
-        name: 'Anuncios personalizados, medición de anuncios, información sobre el público y desarrollo de productos',
-        description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+        name:
+          'Anuncios personalizados, medición de anuncios, información sobre el público y desarrollo de productos',
+        description:
+          'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
       },
       '40': {
         id: 40,
-        purposes: [
-          2,
-          3,
-          4,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [2, 3, 4, 7, 8, 9, 10],
         specialFeatures: [],
-        name: 'Anuncios personalizados, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
-        description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios y del contenido. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+        name:
+          'Anuncios personalizados, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+        description:
+          'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios y del contenido. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
       },
       '41': {
         id: 41,
-        purposes: [
-          2,
-          3,
-          4,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [2, 3, 4, 6, 7, 8, 9, 10],
         specialFeatures: [],
-        name: 'Anuncios personalizados, muestra de contenido personalizado, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
-        description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios y del contenido. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+        name:
+          'Anuncios personalizados, muestra de contenido personalizado, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+        description:
+          'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios y del contenido. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
       },
       '42': {
         id: 42,
-        purposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
         specialFeatures: [],
-        name: 'Anuncios y contenido personalizados, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
-        description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios y el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+        name:
+          'Anuncios y contenido personalizados, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+        description:
+          'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios y el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
       }
     },
     vendors: {
       '1': {
         id: 1,
         name: 'Exponential Interactive, Inc d/b/a VDX.tv',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          3
-        ],
+        flexiblePurposes: [2, 3, 4, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 3],
         specialFeatures: [],
         policyUrl: 'https://vdx.tv/privacy/'
       },
       '2': {
         id: 2,
         name: 'Captify Technologies Limited',
-        purposes: [
-          1,
-          2,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          7,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2
-        ],
+        purposes: [1, 2, 3, 4],
+        legIntPurposes: [7, 9, 10],
+        flexiblePurposes: [2],
         specialPurposes: [],
-        features: [
-          2
-        ],
+        features: [2],
         specialFeatures: [],
         policyUrl: 'http://www.captify.co.uk/privacy-policy/'
       },
       '4': {
         id: 4,
         name: 'Roq.ad Inc.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.roq.ad/privacy-policy'
       },
       '6': {
         id: 6,
         name: 'AdSpirit GmbH',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          9
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
+        flexiblePurposes: [2, 3, 4, 7, 9],
+        specialPurposes: [1, 2],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'http://www.adspirit.de/privacy',
         overflow: {
@@ -9602,194 +9416,79 @@ const VendorList45 = {data: {
       '8': {
         id: 8,
         name: 'Emerse Sverige AB',
-        purposes: [
-          1,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          8,
-          9
-        ],
-        flexiblePurposes: [
-          2,
-          9
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2
-        ],
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 8, 9],
+        flexiblePurposes: [2, 9],
+        specialPurposes: [1, 2],
+        features: [1, 2],
         specialFeatures: [],
         policyUrl: 'https://www.emerse.com/privacy-policy/'
       },
       '9': {
         id: 9,
         name: 'AdMaxim Inc.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'http://www.admaxim.com/admaxim-privacy-policy/',
         deletedDate: '2020-06-17T00:00:00Z'
       },
       '10': {
         id: 10,
         name: 'Index Exchange, Inc. ',
-        purposes: [
-          1,
-          2,
-          7
-        ],
+        purposes: [1, 2, 7],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          7
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        flexiblePurposes: [2, 7],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'https://www.indexexchange.com/privacy'
       },
       '11': {
         id: 11,
         name: 'Quantcast International Limited',
-        purposes: [
-          1,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          8,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          3
-        ],
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 3],
         specialFeatures: [],
         policyUrl: 'https://www.quantcast.com/privacy/'
       },
       '12': {
         id: 12,
         name: 'BeeswaxIO Corporation',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7
-        ],
+        purposes: [1, 2, 3, 4, 7],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          2
-        ],
-        features: [
-          1,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [2],
+        features: [1, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.beeswax.com/privacy/'
       },
       '13': {
         id: 13,
         name: 'Sovrn Holdings Inc',
-        purposes: [
-          1,
-          2,
-          3,
-          5,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 5, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://www.sovrn.com/sovrn-privacy/'
       },
       '14': {
         id: 14,
         name: 'Adkernel LLC',
-        purposes: [
-          1,
-          7
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          9
-        ],
+        purposes: [1, 7],
+        legIntPurposes: [2, 3, 4, 9],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'http://adkernel.com/privacy-policy/',
         overflow: {
           httpGetLimit: 32
@@ -9798,68 +9497,32 @@ const VendorList45 = {data: {
       '15': {
         id: 15,
         name: 'Adikteev',
-        purposes: [
-          1,
-          3,
-          4,
-          5,
-          6,
-          8,
-          9,
-          10
-        ],
-        legIntPurposes: [
-          2,
-          7
-        ],
+        purposes: [1, 3, 4, 5, 6, 8, 9, 10],
+        legIntPurposes: [2, 7],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          2
-        ],
+        specialPurposes: [1, 2],
+        features: [2],
         specialFeatures: [],
         policyUrl: 'https://www.adikteev.com/privacy-policy-eng/'
       },
       '16': {
         id: 16,
         name: 'RTB House S.A.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1
-        ],
+        specialPurposes: [1],
         features: [],
         specialFeatures: [],
-        policyUrl: 'https://www.rtbhouse.com/privacy-center/services-privacy-policy/'
+        policyUrl:
+          'https://www.rtbhouse.com/privacy-center/services-privacy-policy/'
       },
       '18': {
         id: 18,
         name: 'Widespace AB',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7
-        ],
+        purposes: [1, 2, 3, 4, 7],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7
-        ],
+        flexiblePurposes: [2, 3, 4, 7],
         specialPurposes: [],
         features: [],
         specialFeatures: [],
@@ -9868,43 +9531,18 @@ const VendorList45 = {data: {
       '21': {
         id: 21,
         name: 'The Trade Desk',
-        purposes: [
-          1,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          7,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2
-        ],
-        specialFeatures: [
-          1
-        ],
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 10],
+        flexiblePurposes: [2, 7, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [1],
         policyUrl: 'https://www.thetradedesk.com/general/privacy-policy'
       },
       '22': {
         id: 22,
         name: 'admetrics GmbH',
-        purposes: [
-          2,
-          7,
-          8,
-          9
-        ],
+        purposes: [2, 7, 8, 9],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
@@ -9915,126 +9553,46 @@ const VendorList45 = {data: {
       '23': {
         id: 23,
         name: 'Amobee, Inc. ',
-        purposes: [
-          1,
-          2,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          7,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4],
+        legIntPurposes: [7, 9, 10],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://www.amobee.com/trust/privacy-guidelines'
       },
       '24': {
         id: 24,
         name: 'Epsilon',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://www.conversantmedia.eu/legal/privacy-policy'
       },
       '25': {
         id: 25,
         name: 'Verizon Media EMEA Limited',
-        purposes: [
-          1,
-          3,
-          4,
-          5,
-          6
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          8,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
-        policyUrl: 'https://www.verizonmedia.com/policies/ie/en/verizonmedia/privacy/index.html'
+        purposes: [1, 3, 4, 5, 6],
+        legIntPurposes: [2, 7, 8, 9, 10],
+        flexiblePurposes: [2, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl:
+          'https://www.verizonmedia.com/policies/ie/en/verizonmedia/privacy/index.html'
       },
       '28': {
         id: 28,
         name: 'TripleLift, Inc.',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          7,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 7, 9, 10],
+        flexiblePurposes: [2, 7, 9, 10],
+        specialPurposes: [1, 2],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://triplelift.com/privacy/',
         overflow: {
           httpGetLimit: 32
@@ -10043,139 +9601,55 @@ const VendorList45 = {data: {
       '30': {
         id: 30,
         name: 'BidTheatre AB',
-        purposes: [
-          1,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          2
-        ],
-        flexiblePurposes: [
-          2
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          2
-        ],
+        purposes: [1, 3, 4],
+        legIntPurposes: [2],
+        flexiblePurposes: [2],
+        specialPurposes: [1, 2],
+        features: [2],
         specialFeatures: [],
         policyUrl: 'https://www.bidtheatre.com/privacy-policy'
       },
       '31': {
         id: 31,
         name: 'Ogury Ltd.',
-        purposes: [
-          1,
-          3,
-          4,
-          9
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          10
-        ],
+        purposes: [1, 3, 4, 9],
+        legIntPurposes: [2, 7, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          2
-        ],
+        specialPurposes: [1, 2],
+        features: [2],
         specialFeatures: [],
         policyUrl: 'https://www.ogury.com/privacy-policy/'
       },
       '32': {
         id: 32,
         name: 'Xandr, Inc.',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          7,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          2
-        ],
-        specialFeatures: [
-          1
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 7, 10],
+        flexiblePurposes: [2, 7, 10],
+        specialPurposes: [1, 2],
+        features: [2],
+        specialFeatures: [1],
         policyUrl: 'https://www.xandr.com/privacy/platform-privacy-policy/'
       },
       '33': {
         id: 33,
         name: 'ShareThis, Inc',
-        purposes: [
-          1,
-          3,
-          5,
-          6
-        ],
-        legIntPurposes: [
-          9,
-          10
-        ],
+        purposes: [1, 3, 5, 6],
+        legIntPurposes: [9, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://sharethis.com/privacy/'
       },
       '34': {
         id: 34,
         name: 'NEORY GmbH',
-        purposes: [
-          1,
-          3,
-          4,
-          5,
-          6,
-          9
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          8
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
+        purposes: [1, 3, 4, 5, 6, 9],
+        legIntPurposes: [2, 7, 8],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9],
+        specialPurposes: [1, 2],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://www.neory.com/privacy.html',
         overflow: {
@@ -10185,147 +9659,55 @@ const VendorList45 = {data: {
       '36': {
         id: 36,
         name: 'RhythmOne DBA Unruly Group Ltd',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.rhythmone.com/privacy-policy'
       },
       '37': {
         id: 37,
         name: 'NEURAL.ONE',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          7,
-          9
-        ],
+        purposes: [1, 2, 3, 4, 5, 7, 9],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://web.neural.one/privacy-policy/'
       },
       '39': {
         id: 39,
         name: 'ADITION technologies AG',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.adition.com/datenschutz'
       },
       '40': {
         id: 40,
         name: 'Active Agent (ADITION technologies AG)',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
-        policyUrl: 'http://www.active-agent.com/de/unternehmen/datenschutzerklaerung/'
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl:
+          'http://www.active-agent.com/de/unternehmen/datenschutzerklaerung/'
       },
       '41': {
         id: 41,
         name: 'Adverline',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://www.adverline.com/privacy/',
@@ -10336,122 +9718,43 @@ const VendorList45 = {data: {
       '42': {
         id: 42,
         name: 'Taboola Europe Limited',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://www.taboola.com/privacy-policy'
       },
       '44': {
         id: 44,
         name: 'The ADEX GmbH',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://theadex.com/privacy-opt-out/'
       },
       '45': {
         id: 45,
         name: 'Smart Adserver',
-        purposes: [
-          1,
-          4
-        ],
-        legIntPurposes: [
-          2,
-          7
-        ],
-        flexiblePurposes: [
-          2,
-          7
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        purposes: [1, 4],
+        legIntPurposes: [2, 7],
+        flexiblePurposes: [2, 7],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'https://smartadserver.com/end-user-privacy-policy/'
       },
       '47': {
         id: 47,
         name: 'ADMAN - Phaistos Networks, S.A.',
-        purposes: [
-          1,
-          2,
-          4,
-          7
-        ],
+        purposes: [1, 2, 4, 7],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'http://www.adman.gr/privacy'
@@ -10459,34 +9762,12 @@ const VendorList45 = {data: {
       '49': {
         id: 49,
         name: 'TRADELAB',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6
-        ],
-        legIntPurposes: [
-          7,
-          8,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6],
+        legIntPurposes: [7, 8, 9, 10],
+        flexiblePurposes: [7, 8, 9, 10],
         specialPurposes: [],
-        features: [
-          1,
-          2
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [1, 2],
+        specialFeatures: [1],
         policyUrl: 'https://tradelab.com/en/privacy/',
         overflow: {
           httpGetLimit: 32
@@ -10495,30 +9776,14 @@ const VendorList45 = {data: {
       '50': {
         id: 50,
         name: 'Adform',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          7,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2
-        ],
+        flexiblePurposes: [2, 7, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2],
         specialFeatures: [],
-        policyUrl: 'https://site.adform.com/privacy-center/platform-privacy/product-and-services-privacy-policy/',
+        policyUrl:
+          'https://site.adform.com/privacy-center/platform-privacy/product-and-services-privacy-policy/',
         overflow: {
           httpGetLimit: 32
         }
@@ -10526,53 +9791,25 @@ const VendorList45 = {data: {
       '51': {
         id: 51,
         name: 'xAd, Inc. dba GroundTruth',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.groundtruth.com/privacy-policy/'
       },
       '52': {
         id: 52,
         name: 'The Rubicon Project, Inc. ',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          7,
-          10
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 7, 10],
+        flexiblePurposes: [2, 7, 10],
         specialPurposes: [],
         features: [],
-        specialFeatures: [
-          1
-        ],
-        policyUrl: 'http://www.rubiconproject.com/rubicon-project-yield-optimization-privacy-policy/',
+        specialFeatures: [1],
+        policyUrl:
+          'http://www.rubiconproject.com/rubicon-project-yield-optimization-privacy-policy/',
         overflow: {
           httpGetLimit: 128
         }
@@ -10580,146 +9817,66 @@ const VendorList45 = {data: {
       '53': {
         id: 53,
         name: 'Sirdata',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://www.sirdata.com/privacy/'
       },
       '57': {
         id: 57,
         name: 'ADARA MEDIA UNLIMITED',
-        purposes: [
-          1,
-          2,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4],
+        legIntPurposes: [7, 9, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://adara.com/privacy-promise/'
       },
       '58': {
         id: 58,
         name: '33Across',
-        purposes: [
-          1,
-          2,
-          4,
-          7,
-          10
-        ],
+        purposes: [1, 2, 4, 7, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          2
-        ],
+        specialPurposes: [1, 2],
+        features: [2],
         specialFeatures: [],
         policyUrl: 'http://www.33across.com/privacy-policy'
       },
       '59': {
         id: 59,
         name: 'Sift Media, Inc',
-        purposes: [
-          2
-        ],
+        purposes: [2],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2
-        ],
+        flexiblePurposes: [2],
         specialPurposes: [],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'https://www.sift.co/privacy'
       },
       '60': {
         id: 60,
         name: 'Rakuten Marketing LLC',
-        purposes: [
-          1,
-          3
-        ],
-        legIntPurposes: [
-          2,
-          4,
-          7,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
+        purposes: [1, 3],
+        legIntPurposes: [2, 4, 7, 9, 10],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
         specialFeatures: [],
-        policyUrl: 'https://rakutenadvertising.com/legal-notices/services-privacy-policy/'
+        policyUrl:
+          'https://rakutenadvertising.com/legal-notices/services-privacy-policy/'
       },
       '61': {
         id: 61,
         name: 'GumGum, Inc.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7
-        ],
+        purposes: [1, 2, 3, 4, 7],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://gumgum.com/privacy-policy'
@@ -10727,25 +9884,10 @@ const VendorList45 = {data: {
       '62': {
         id: 62,
         name: 'Justpremium BV',
-        purposes: [
-          1,
-          4,
-          5
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          4,
-          7
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [1, 4, 5],
+        legIntPurposes: [2, 7, 10],
+        flexiblePurposes: [2, 4, 7],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'http://justpremium.com/privacy-policy/'
@@ -10753,123 +9895,51 @@ const VendorList45 = {data: {
       '63': {
         id: 63,
         name: 'Avocet Systems Limited',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6
-        ],
-        legIntPurposes: [
-          7,
-          8,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6],
+        legIntPurposes: [7, 8, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://avocet.io/privacy-portal'
       },
       '65': {
         id: 65,
         name: 'Location Sciences AI Ltd',
-        purposes: [
-          1,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://www.locationsciences.ai/privacy-policy/'
       },
       '66': {
         id: 66,
         name: 'adsquare GmbH',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          9,
-          10
-        ],
+        flexiblePurposes: [2, 3, 4, 9, 10],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.adsquare.com/privacy'
       },
       '68': {
         id: 68,
         name: 'Sizmek by Amazon',
-        purposes: [
-          1,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2
-        ],
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 9, 10],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2],
         specialFeatures: [],
         policyUrl: 'https://www.sizmek.com/privacy-policy/'
       },
       '69': {
         id: 69,
         name: 'OpenX',
-        purposes: [
-          1
-        ],
+        purposes: [1],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
@@ -10880,34 +9950,12 @@ const VendorList45 = {data: {
       '70': {
         id: 70,
         name: 'Yieldlab AG',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        flexiblePurposes: [2, 3, 4, 7, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'http://www.yieldlab.de/meta-navigation/datenschutz/',
         overflow: {
           httpGetLimit: 128
@@ -10916,21 +9964,10 @@ const VendorList45 = {data: {
       '72': {
         id: 72,
         name: 'Nano Interactive GmbH',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'http://www.nanointeractive.com/privacy'
@@ -10938,170 +9975,65 @@ const VendorList45 = {data: {
       '73': {
         id: 73,
         name: 'Simplifi Holdings Inc.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4
-        ],
+        flexiblePurposes: [2, 3, 4],
         specialPurposes: [],
-        features: [
-          2
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [2],
+        specialFeatures: [1],
         policyUrl: 'https://simpli.fi/site-privacy-policy/'
       },
       '76': {
         id: 76,
         name: 'PubMatic, Inc.',
-        purposes: [
-          1,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          2,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://pubmatic.com/privacy-policy/'
       },
       '77': {
         id: 77,
         name: 'comScore, Inc.',
-        purposes: [
-          1,
-          7,
-          8,
-          10
-        ],
-        legIntPurposes: [
-          9
-        ],
-        flexiblePurposes: [
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1
-        ],
-        features: [
-          1,
-          2
-        ],
+        purposes: [1, 7, 8, 10],
+        legIntPurposes: [9],
+        flexiblePurposes: [7, 8, 9, 10],
+        specialPurposes: [1],
+        features: [1, 2],
         specialFeatures: [],
-        policyUrl: 'https://www.scorecardresearch.com/privacy.aspx?newlanguage=1'
+        policyUrl:
+          'https://www.scorecardresearch.com/privacy.aspx?newlanguage=1'
       },
       '78': {
         id: 78,
         name: 'Flashtalking, Inc.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7
-        ],
+        purposes: [1, 2, 3, 4, 7],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'http://www.flashtalking.com/privacypolicy/'
       },
       '79': {
         id: 79,
         name: 'MediaMath, Inc.',
-        purposes: [
-          1,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          8,
-          10
-        ],
-        flexiblePurposes: [
-          3,
-          4
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 8, 10],
+        flexiblePurposes: [3, 4],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'http://www.mediamath.com/privacy-policy/'
       },
       '80': {
         id: 80,
         name: 'Sharethrough, Inc',
-        purposes: [
-          1,
-          2,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 4, 7, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          4,
-          7,
-          9,
-          10
-        ],
+        flexiblePurposes: [2, 4, 7, 9, 10],
         specialPurposes: [],
         features: [],
         specialFeatures: [],
@@ -11110,53 +10042,21 @@ const VendorList45 = {data: {
       '82': {
         id: 82,
         name: 'Smaato, Inc.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9
-        ],
-        legIntPurposes: [
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          7,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        purposes: [1, 2, 3, 4, 7, 9],
+        legIntPurposes: [10],
+        flexiblePurposes: [2, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.smaato.com/privacy/'
       },
       '83': {
         id: 83,
         name: 'Visarity Technologies GmbH',
-        purposes: [
-          2,
-          6,
-          7,
-          8
-        ],
+        purposes: [2, 6, 7, 8],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        flexiblePurposes: [2],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'http://primo.design/docs/PrivacyPolicyPrimo.html'
@@ -11164,18 +10064,9 @@ const VendorList45 = {data: {
       '84': {
         id: 84,
         name: 'Semasio GmbH',
-        purposes: [
-          1,
-          3,
-          9,
-          10
-        ],
+        purposes: [1, 3, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          3,
-          9,
-          10
-        ],
+        flexiblePurposes: [3, 9, 10],
         specialPurposes: [],
         features: [],
         specialFeatures: [],
@@ -11184,63 +10075,21 @@ const VendorList45 = {data: {
       '85': {
         id: 85,
         name: 'Crimtan Holdings Limited',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          7,
-          8,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 3],
+        specialFeatures: [1],
         policyUrl: 'https://crimtan.com/privacy/'
       },
       '86': {
         id: 86,
         name: 'Scene Stealer Limited',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          7,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7, 10],
+        flexiblePurposes: [2, 3, 4, 7],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'http://scenestealer.tv/privacy-policy/'
@@ -11248,64 +10097,29 @@ const VendorList45 = {data: {
       '88': {
         id: 88,
         name: 'TreSensa, Inc.',
-        purposes: [
-          1,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          3
-        ],
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 10],
+        flexiblePurposes: [2, 3, 4, 7, 10],
+        specialPurposes: [1, 2],
+        features: [1, 3],
         specialFeatures: [],
         policyUrl: 'https://www.tresensa.com/eu-privacy'
       },
       '89': {
         id: 89,
         name: 'Tapad, Inc.',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          10
-        ],
+        purposes: [1],
+        legIntPurposes: [10],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          2
-        ],
+        features: [2],
         specialFeatures: [],
         policyUrl: 'https://www.tapad.com/eu-privacy-policy'
       },
       '90': {
         id: 90,
         name: 'Teroa S.A.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
@@ -11316,63 +10130,22 @@ const VendorList45 = {data: {
       '91': {
         id: 91,
         name: 'Criteo SA',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7
-        ],
+        purposes: [1, 2, 3, 4, 7],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7
-        ],
+        flexiblePurposes: [2, 3, 4, 7],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://www.criteo.com/privacy/'
       },
       '92': {
         id: 92,
         name: '1plusX AG',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://www.1plusx.com/privacy-policy/'
       },
@@ -11380,13 +10153,9 @@ const VendorList45 = {data: {
         id: 93,
         name: 'Adloox SA',
         purposes: [],
-        legIntPurposes: [
-          7
-        ],
+        legIntPurposes: [7],
         flexiblePurposes: [],
-        specialPurposes: [
-          1
-        ],
+        specialPurposes: [1],
         features: [],
         specialFeatures: [],
         policyUrl: 'http://adloox.com/disclaimer',
@@ -11397,215 +10166,88 @@ const VendorList45 = {data: {
       '94': {
         id: 94,
         name: 'Blis Media Limited',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'http://www.blis.com/privacy/'
       },
       '95': {
         id: 95,
         name: 'Lotame Solutions, inc',
-        purposes: [
-          1,
-          3,
-          5
-        ],
-        legIntPurposes: [
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 3, 5],
+        legIntPurposes: [7, 8, 9, 10],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          2,
-          3
-        ],
+        features: [2, 3],
         specialFeatures: [],
-        policyUrl: 'https://www.lotame.com/about-lotame/privacy/lotame-corporate-websites-privacy-policy/'
+        policyUrl:
+          'https://www.lotame.com/about-lotame/privacy/lotame-corporate-websites-privacy-policy/'
       },
       '97': {
         id: 97,
         name: 'LiveRamp, Inc.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://www.liveramp.com/service-privacy-policy/'
       },
       '98': {
         id: 98,
         name: 'GroupM UK Limited',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6
-        ],
-        legIntPurposes: [
-          7,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2
-        ],
+        purposes: [1, 2, 3, 4, 5, 6],
+        legIntPurposes: [7, 9, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2],
         specialFeatures: [],
         policyUrl: 'https://www.groupm.com/privacy-notice'
       },
       '100': {
         id: 100,
         name: 'Fifty Technology Limited',
-        purposes: [
-          1,
-          2,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4],
+        legIntPurposes: [7, 9, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          2,
-          3
-        ],
+        specialPurposes: [1, 2],
+        features: [2, 3],
         specialFeatures: [],
         policyUrl: 'https://fifty.io/privacy-policy.php'
       },
       '101': {
         id: 101,
         name: 'MiQ',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'http://wearemiq.com/privacy-policy/'
       },
       '104': {
         id: 104,
         name: 'Sonobi, Inc',
-        purposes: [
-          1,
-          2,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          7,
-          8
-        ],
+        purposes: [1, 2, 3, 4],
+        legIntPurposes: [7, 8],
         flexiblePurposes: [],
-        specialPurposes: [
-          2
-        ],
-        features: [
-          1
-        ],
+        specialPurposes: [2],
+        features: [1],
         specialFeatures: [],
         policyUrl: 'http://sonobi.com/privacy-policy/'
       },
       '108': {
         id: 108,
         name: 'Rich Audience',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://richaudience.com/privacy/'
@@ -11613,84 +10255,30 @@ const VendorList45 = {data: {
       '109': {
         id: 109,
         name: 'LoopMe Limited',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8
-        ],
-        legIntPurposes: [
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          9
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2
-        ],
-        specialFeatures: [
-          1
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8],
+        legIntPurposes: [9, 10],
+        flexiblePurposes: [9],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [1],
         policyUrl: 'https://loopme.com/privacy-policy/'
       },
       '111': {
         id: 111,
         name: 'Showheroes SE',
-        purposes: [
-          1,
-          3,
-          4,
-          9,
-          10
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          8
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1
-        ],
+        purposes: [1, 3, 4, 9, 10],
+        legIntPurposes: [2, 7, 8],
+        flexiblePurposes: [2, 3, 4, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1],
         specialFeatures: [],
         policyUrl: 'https://showheroes.com/privacy/'
       },
       '114': {
         id: 114,
         name: 'Sublime',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9
-        ],
-        legIntPurposes: [
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9],
+        legIntPurposes: [10],
         flexiblePurposes: [],
         specialPurposes: [],
         features: [],
@@ -11700,30 +10288,11 @@ const VendorList45 = {data: {
       '115': {
         id: 115,
         name: 'smartclip Europe GmbH',
-        purposes: [
-          1,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          2
-        ],
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 10],
+        flexiblePurposes: [2, 3, 4, 7, 10],
+        specialPurposes: [1, 2],
+        features: [2],
         specialFeatures: [],
         policyUrl: 'https://privacy-portal.smartclip.net/',
         overflow: {
@@ -11733,63 +10302,32 @@ const VendorList45 = {data: {
       '119': {
         id: 119,
         name: 'Fusio by S4M',
-        purposes: [
-          1,
-          10
-        ],
+        purposes: [1, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1
-        ],
+        specialPurposes: [1],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'http://www.s4m.io/privacy-policy/'
       },
       '120': {
         id: 120,
         name: 'Eyeota Pte Ltd',
-        purposes: [
-          1,
-          3,
-          5,
-          9,
-          10
-        ],
+        purposes: [1, 3, 5, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          3,
-          5,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
+        flexiblePurposes: [3, 5, 9, 10],
+        specialPurposes: [1],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://www.eyeota.com/privacy-center'
       },
       '126': {
         id: 126,
         name: 'DoubleVerify Inc.​',
-        purposes: [
-          2,
-          7,
-          10
-        ],
+        purposes: [2, 7, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://www.doubleverify.com/privacy/'
@@ -11797,31 +10335,12 @@ const VendorList45 = {data: {
       '127': {
         id: 127,
         name: 'PIXIMEDIA SAS',
-        purposes: [
-          1,
-          3,
-          4,
-          5,
-          6,
-          9,
-          10
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          8
-        ],
+        purposes: [1, 3, 4, 5, 6, 9, 10],
+        legIntPurposes: [2, 7, 8],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'https://piximedia.com/privacy/',
         overflow: {
           httpGetLimit: 128
@@ -11830,175 +10349,77 @@ const VendorList45 = {data: {
       '128': {
         id: 128,
         name: 'BIDSWITCH GmbH',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [1, 3],
+        specialFeatures: [1],
         policyUrl: 'http://www.bidswitch.com/privacy-policy/'
       },
       '129': {
         id: 129,
         name: 'IPONWEB GmbH',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.iponweb.com/privacy-policy/'
       },
       '130': {
         id: 130,
         name: 'NextRoll, Inc.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2],
         specialFeatures: [],
         policyUrl: 'https://www.nextroll.com/privacy'
       },
       '131': {
         id: 131,
         name: 'ID5 Technology SAS',
-        purposes: [
-          1
-        ],
+        purposes: [1],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          3
-        ],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://www.id5.io/privacy'
       },
       '132': {
         id: 132,
         name: 'Teads ',
-        purposes: [
-          1,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 9, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
+        specialPurposes: [1, 2],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://www.teads.com/privacy-policy/'
       },
       '133': {
         id: 133,
         name: 'digitalAudience',
-        purposes: [
-          1,
-          3,
-          5,
-          9
-        ],
+        purposes: [1, 3, 5, 9],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2
-        ],
+        features: [1, 2],
         specialFeatures: [],
         policyUrl: 'https://digitalaudience.io/legal/privacy-cookies/'
       },
       '134': {
         id: 134,
         name: 'SMARTSTREAM.TV GmbH',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7, 9, 10],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://www.smartstream.tv/en/productprivacy',
         overflow: {
@@ -12008,114 +10429,47 @@ const VendorList45 = {data: {
       '136': {
         id: 136,
         name: 'Ströer SSP GmbH (SSP)',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          7,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 7, 9, 10],
+        flexiblePurposes: [2, 7, 9, 10],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
-        policyUrl: 'https://www.stroeer.de/fileadmin/de/Konvergenz_und_Konzepte/Daten_und_Technologien/Stroeer_SSP/Downloads/Datenschutz_Stroeer_SSP.pdf'
+        policyUrl:
+          'https://www.stroeer.de/fileadmin/de/Konvergenz_und_Konzepte/Daten_und_Technologien/Stroeer_SSP/Downloads/Datenschutz_Stroeer_SSP.pdf'
       },
       '137': {
         id: 137,
         name: 'Ströer SSP GmbH (DSP)',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          9
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2
-        ],
-        specialFeatures: [
-          1
-        ],
-        policyUrl: 'https://www.stroeer.de/fileadmin/de/Konvergenz_und_Konzepte/Daten_und_Technologien/Stroeer_SSP/Downloads/Datenschutz_Stroeer_SSP.pdf'
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7, 9, 10],
+        flexiblePurposes: [2, 3, 4, 9],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [1],
+        policyUrl:
+          'https://www.stroeer.de/fileadmin/de/Konvergenz_und_Konzepte/Daten_und_Technologien/Stroeer_SSP/Downloads/Datenschutz_Stroeer_SSP.pdf'
       },
       '138': {
         id: 138,
         name: 'ConnectAd Realtime GmbH',
-        purposes: [
-          1,
-          3,
-          4,
-          5
-        ],
-        legIntPurposes: [
-          2,
-          7
-        ],
+        purposes: [1, 3, 4, 5],
+        legIntPurposes: [2, 7],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
+        specialPurposes: [1, 2],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'http://connectadrealtime.com/privacy/'
       },
       '139': {
         id: 139,
         name: 'Permodo GmbH',
-        purposes: [
-          1,
-          2,
-          7,
-          8,
-          10
-        ],
+        purposes: [1, 2, 7, 8, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          7,
-          8,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2
-        ],
-        specialFeatures: [
-          1
-        ],
+        flexiblePurposes: [2, 7, 8, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [1],
         policyUrl: 'https://permodo.com/de/privacy.html',
         overflow: {
           httpGetLimit: 32
@@ -12124,78 +10478,36 @@ const VendorList45 = {data: {
       '142': {
         id: 142,
         name: 'Media.net Advertising FZ-LLC',
-        purposes: [
-          1,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          2,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          5,
-          6,
-          8
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [5, 6, 8],
+        specialPurposes: [1, 2],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://www.media.net/en/privacy-policy'
       },
       '143': {
         id: 143,
         name: 'Connatix Native Exchange Inc.',
-        purposes: [
-          1,
-          2,
-          4,
-          6,
-          7,
-          8,
-          10
-        ],
+        purposes: [1, 2, 4, 6, 7, 8, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          3
-        ],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://connatix.com/privacy-policy/'
       },
       '144': {
         id: 144,
         name: 'district m inc.',
-        purposes: [
-          1,
-          2,
-          4,
-          7,
-          10
-        ],
+        purposes: [1, 2, 4, 7, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          2
-        ],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
-        policyUrl: 'https://districtm.net/en/page/platforms-data-and-privacy-policy/',
+        specialPurposes: [2],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl:
+          'https://districtm.net/en/page/platforms-data-and-privacy-policy/',
         overflow: {
           httpGetLimit: 128
         }
@@ -12203,108 +10515,43 @@ const VendorList45 = {data: {
       '147': {
         id: 147,
         name: 'Adacado Technologies Inc. (DBA Adacado)',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        flexiblePurposes: [7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'https://www.adacado.com/privacy-policy-april-25-2018/'
       },
       '149': {
         id: 149,
         name: 'ADman Interactive SLU',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2
-        ],
+        flexiblePurposes: [2],
         specialPurposes: [],
-        features: [
-          2,
-          3
-        ],
+        features: [2, 3],
         specialFeatures: [],
         policyUrl: 'https://admanmedia.com/politica.html?setLng=es'
       },
       '150': {
         id: 150,
         name: 'Inskin Media LTD',
-        purposes: [
-          1,
-          3,
-          4,
-          9,
-          10
-        ],
-        legIntPurposes: [
-          2,
-          7
-        ],
-        flexiblePurposes: [
-          2,
-          7
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
+        purposes: [1, 3, 4, 9, 10],
+        legIntPurposes: [2, 7],
+        flexiblePurposes: [2, 7],
+        specialPurposes: [1, 2],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'http://www.inskinmedia.com/privacy-policy.html'
       },
       '152': {
         id: 152,
         name: 'Meetrics GmbH',
-        purposes: [
-          1,
-          9
-        ],
-        legIntPurposes: [
-          7
-        ],
-        flexiblePurposes: [
-          7
-        ],
-        specialPurposes: [
-          1
-        ],
+        purposes: [1, 9],
+        legIntPurposes: [7],
+        flexiblePurposes: [7],
+        specialPurposes: [1],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://www.meetrics.com/en/data-privacy/'
@@ -12312,31 +10559,12 @@ const VendorList45 = {data: {
       '153': {
         id: 153,
         name: 'MADVERTISE MEDIA',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          5,
-          6,
-          10
-        ],
-        specialPurposes: [
-          2
-        ],
+        flexiblePurposes: [5, 6, 10],
+        specialPurposes: [2],
         features: [],
-        specialFeatures: [
-          1,
-          2
-        ],
+        specialFeatures: [1, 2],
         policyUrl: 'https://madvertise.com/en/gdpr/',
         overflow: {
           httpGetLimit: 128
@@ -12345,40 +10573,18 @@ const VendorList45 = {data: {
       '154': {
         id: 154,
         name: 'YOC AG',
-        purposes: [
-          1,
-          3,
-          4,
-          10
-        ],
-        legIntPurposes: [
-          2,
-          7
-        ],
-        flexiblePurposes: [
-          2,
-          7
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [1, 3, 4, 10],
+        legIntPurposes: [2, 7],
+        flexiblePurposes: [2, 7],
+        specialPurposes: [1, 2],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://yoc.com/privacy/'
       },
       '155': {
         id: 155,
         name: 'AntVoice',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7
-        ],
+        purposes: [1, 2, 3, 4, 7],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
@@ -12389,21 +10595,10 @@ const VendorList45 = {data: {
       '157': {
         id: 157,
         name: 'Seedtag Advertising S.L',
-        purposes: [
-          1,
-          2,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          7,
-          10
-        ],
+        purposes: [1, 2, 3, 4],
+        legIntPurposes: [7, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://www.seedtag.com/en/privacy-policy/'
@@ -12411,30 +10606,12 @@ const VendorList45 = {data: {
       '160': {
         id: 160,
         name: 'Netsprint SA',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://netsprint.eu/privacy.html',
         overflow: {
           httpGetLimit: 32
@@ -12443,140 +10620,53 @@ const VendorList45 = {data: {
       '161': {
         id: 161,
         name: 'Smadex SL',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'http://smadex.com/end-user-privacy-policy/'
       },
       '162': {
         id: 162,
         name: 'Unruly Group Ltd',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://unruly.co/privacy/'
       },
       '163': {
         id: 163,
         name: 'Bombora Inc.',
-        purposes: [
-          1,
-          3,
-          8
-        ],
-        legIntPurposes: [
-          7,
-          10
-        ],
-        flexiblePurposes: [
-          7,
-          10
-        ],
+        purposes: [1, 3, 8],
+        legIntPurposes: [7, 10],
+        flexiblePurposes: [7, 10],
         specialPurposes: [],
-        features: [
-          1
-        ],
+        features: [1],
         specialFeatures: [],
         policyUrl: 'https://bombora.com/privacy'
       },
       '164': {
         id: 164,
         name: 'Outbrain UK Ltd',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          3
-        ],
+        purposes: [1],
+        legIntPurposes: [3, 4, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 3],
         specialFeatures: [],
         policyUrl: 'https://www.outbrain.com/legal/privacy#privacy-policy'
       },
       '165': {
         id: 165,
         name: 'SpotX, Inc.',
-        purposes: [
-          1,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 9, 10],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
         specialPurposes: [],
         features: [],
         specialFeatures: [],
@@ -12588,83 +10678,32 @@ const VendorList45 = {data: {
       '167': {
         id: 167,
         name: 'Audiens S.r.l.',
-        purposes: [
-          1,
-          9
-        ],
+        purposes: [1, 9],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'http://www.audiens.com/privacy'
       },
       '168': {
         id: 168,
         name: 'EASYmedia GmbH',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://login.rtbmarket.com/gdpr'
       },
       '173': {
         id: 173,
         name: 'Yieldmo, Inc.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://www.yieldmo.com/privacy/'
@@ -12673,40 +10712,20 @@ const VendorList45 = {data: {
         id: 174,
         name: 'A Million Ads Ltd',
         purposes: [],
-        legIntPurposes: [
-          2,
-          4
-        ],
-        flexiblePurposes: [
-          2,
-          4
-        ],
+        legIntPurposes: [2, 4],
+        flexiblePurposes: [2, 4],
         specialPurposes: [],
-        features: [
-          3
-        ],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://www.amillionads.com/privacy-policy'
       },
       '177': {
         id: 177,
         name: 'plista GmbH',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          7,
-          8,
-          10
-        ],
-        flexiblePurposes: [
-          7,
-          8,
-          10
-        ],
-        specialPurposes: [
-          2
-        ],
+        purposes: [1],
+        legIntPurposes: [7, 8, 10],
+        flexiblePurposes: [7, 8, 10],
+        specialPurposes: [2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://www.plista.com/about/privacy/'
@@ -12714,28 +10733,10 @@ const VendorList45 = {data: {
       '178': {
         id: 178,
         name: 'Hybrid Theory',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1
-        ],
+        flexiblePurposes: [7, 8, 9, 10],
+        specialPurposes: [1],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://hybridtheory.com/privacy-policy/'
@@ -12743,25 +10744,12 @@ const VendorList45 = {data: {
       '179': {
         id: 179,
         name: 'Collective Europe Ltd.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          9
-        ],
-        legIntPurposes: [
-          7
-        ],
+        purposes: [1, 2, 3, 4, 9],
+        legIntPurposes: [7],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://www.collectiveuk.com/privacy.html',
         overflow: {
           httpGetLimit: 128
@@ -12770,60 +10758,22 @@ const VendorList45 = {data: {
       '184': {
         id: 184,
         name: 'mediarithmics SAS',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          7
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
+        flexiblePurposes: [2, 7],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://www.mediarithmics.com/en-us/content/privacy-policy'
       },
       '185': {
         id: 185,
         name: 'Bidtellect, Inc',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          8
-        ],
-        legIntPurposes: [
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 8],
+        legIntPurposes: [9, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://www.bidtellect.com/privacy-policy/',
         overflow: {
@@ -12834,13 +10784,7 @@ const VendorList45 = {data: {
         id: 190,
         name: 'video intelligence AG',
         purposes: [],
-        legIntPurposes: [
-          2,
-          7,
-          8,
-          9,
-          10
-        ],
+        legIntPurposes: [2, 7, 8, 9, 10],
         flexiblePurposes: [],
         specialPurposes: [],
         features: [],
@@ -12850,9 +10794,7 @@ const VendorList45 = {data: {
       '192': {
         id: 192,
         name: 'remerge GmbH',
-        purposes: [
-          7
-        ],
+        purposes: [7],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
@@ -12863,46 +10805,21 @@ const VendorList45 = {data: {
       '193': {
         id: 193,
         name: 'Mediasmart Mobile S.L.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'http://mediasmart.io/privacy/'
       },
       '194': {
         id: 194,
         name: 'Rezonence Limited',
-        purposes: [
-          1,
-          3,
-          4,
-          9
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          8,
-          10
-        ],
+        purposes: [1, 3, 4, 9],
+        legIntPurposes: [2, 7, 8, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://rezonence.com/privacy-policy/'
@@ -12910,21 +10827,10 @@ const VendorList45 = {data: {
       '195': {
         id: 195,
         name: 'advanced store GmbH',
-        purposes: [
-          1,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          2
-        ],
-        flexiblePurposes: [
-          2
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [1, 3, 4],
+        legIntPurposes: [2],
+        flexiblePurposes: [2],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'http://www.advanced-store.com/de/datenschutz/'
@@ -12932,94 +10838,41 @@ const VendorList45 = {data: {
       '199': {
         id: 199,
         name: 'ADUX',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          6,
-          7,
-          9
-        ],
+        purposes: [1, 2, 3, 4, 6, 7, 9],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          2
-        ],
+        specialPurposes: [2],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://www.adux.com/donnees-personelles/'
       },
       '200': {
         id: 200,
         name: 'Tapjoy, Inc.',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          7
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7],
+        flexiblePurposes: [2, 3, 4, 7],
+        specialPurposes: [1, 2],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://www.tapjoy.com/legal/#privacy-policy'
       },
       '203': {
         id: 203,
         name: 'Revcontent, LLC',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6],
         specialPurposes: [],
         features: [],
         specialFeatures: [],
-        policyUrl: 'https://intercom.help/revcontent2/en/articles/2290675-revcontent-s-privacy-policy'
+        policyUrl:
+          'https://intercom.help/revcontent2/en/articles/2290675-revcontent-s-privacy-policy'
       },
       '205': {
         id: 205,
         name: 'Adssets AB',
-        purposes: [
-          1,
-          2,
-          4,
-          7,
-          8,
-          9
-        ],
+        purposes: [1, 2, 4, 7, 8, 9],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
@@ -13030,147 +10883,54 @@ const VendorList45 = {data: {
       '206': {
         id: 206,
         name: 'Hybrid Adtech GmbH',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://hybrid.ai/data_protection_policy'
       },
       '209': {
         id: 209,
         name: 'Delta Projects AB',
-        purposes: [
-          1,
-          2,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          7,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          7,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [1, 2, 3, 4],
+        legIntPurposes: [7, 10],
+        flexiblePurposes: [2, 7, 10],
+        specialPurposes: [1, 2],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://deltaprojects.com/data-collection-policy'
       },
       '210': {
         id: 210,
         name: 'Zemanta, Inc.',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          3,
-          7,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          3,
-          7,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1
-        ],
+        purposes: [1],
+        legIntPurposes: [3, 7, 9, 10],
+        flexiblePurposes: [3, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1],
         specialFeatures: [],
         policyUrl: 'http://www.zemanta.com/legal/privacy'
       },
       '211': {
         id: 211,
         name: 'AdTheorent, Inc',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'http://adtheorent.com/privacy-policy'
       },
       '212': {
         id: 212,
         name: 'usemax advertisement (Emego GmbH)',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'http://www.usemax.de/?l=privacy'
@@ -13178,51 +10938,19 @@ const VendorList45 = {data: {
       '213': {
         id: 213,
         name: 'emetriq GmbH',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          2
-        ],
-        features: [
-          1,
-          2
-        ],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [2],
+        features: [1, 2],
         specialFeatures: [],
         policyUrl: 'https://www.emetriq.com/datenschutz/'
       },
       '215': {
         id: 215,
         name: 'ARMIS SAS',
-        purposes: [
-          1,
-          2,
-          7
-        ],
-        legIntPurposes: [
-          10
-        ],
+        purposes: [1, 2, 7],
+        legIntPurposes: [10],
         flexiblePurposes: [],
         specialPurposes: [],
         features: [],
@@ -13232,54 +10960,21 @@ const VendorList45 = {data: {
       '216': {
         id: 216,
         name: 'Mindlytix SAS',
-        purposes: [
-          1,
-          2,
-          3,
-          5,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 5, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1
-        ],
-        features: [
-          1,
-          2
-        ],
+        specialPurposes: [1],
+        features: [1, 2],
         specialFeatures: [],
         policyUrl: 'http://mindlytix.com/privacy/'
       },
       '217': {
         id: 217,
         name: '2KDirect, Inc. (dba iPromote)',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7, 9, 10],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://www.ipromote.com/privacy-policy/'
@@ -13287,167 +10982,62 @@ const VendorList45 = {data: {
       '218': {
         id: 218,
         name: 'Bigabid Media ltd',
-        purposes: [
-          1,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          2,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 5, 6, 7, 8, 9, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1
-        ],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'https://www.bigabid.com/privacy-policy'
       },
       '223': {
         id: 223,
         name: 'Audience Trading Platform Ltd.',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          7,
-          8
-        ],
-        flexiblePurposes: [
-          7,
-          8
-        ],
+        purposes: [1],
+        legIntPurposes: [7, 8],
+        flexiblePurposes: [7, 8],
         specialPurposes: [],
-        features: [
-          2
-        ],
+        features: [2],
         specialFeatures: [],
         policyUrl: 'https://atp.io/privacy-policy'
       },
       '224': {
         id: 224,
         name: 'adrule mobile GmbH',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          8
-        ],
-        legIntPurposes: [
-          7
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          8
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [1, 2, 3, 4, 8],
+        legIntPurposes: [7],
+        flexiblePurposes: [2, 3, 4, 7, 8],
+        specialPurposes: [1, 2],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://www.adrule.net/de/datenschutz/'
       },
       '226': {
         id: 226,
         name: 'Publicis Media GmbH',
-        purposes: [
-          1,
-          9
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          10
-        ],
+        purposes: [1, 9],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 10],
         specialPurposes: [],
-        features: [
-          1
-        ],
+        features: [1],
         specialFeatures: [],
         policyUrl: 'https://www.publicismedia.de/datenschutz/'
       },
       '227': {
         id: 227,
         name: 'ORTEC B.V.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.ortecadscience.com/privacy-policy/'
       },
       '228': {
         id: 228,
         name: 'McCann Discipline LTD',
-        purposes: [
-          1,
-          2,
-          5,
-          6,
-          7,
-          8
-        ],
+        purposes: [1, 2, 5, 6, 7, 8],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
@@ -13458,25 +11048,14 @@ const VendorList45 = {data: {
       '231': {
         id: 231,
         name: 'AcuityAds Inc.',
-        purposes: [
-          1,
-          3
-        ],
-        legIntPurposes: [
-          2,
-          4,
-          7,
-          8,
-          10
-        ],
+        purposes: [1, 3],
+        legIntPurposes: [2, 4, 7, 8, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
-        policyUrl: 'https://privacy.acuityads.com/corporate-privacy-policy.html',
+        policyUrl:
+          'https://privacy.acuityads.com/corporate-privacy-policy.html',
         overflow: {
           httpGetLimit: 128
         }
@@ -13484,70 +11063,33 @@ const VendorList45 = {data: {
       '234': {
         id: 234,
         name: 'ZBO Media',
-        purposes: [
-          1,
-          3,
-          4,
-          9
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          10
-        ],
+        purposes: [1, 3, 4, 9],
+        legIntPurposes: [2, 7, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [1],
         specialFeatures: [],
-        policyUrl: 'https://zbo.media/mentions-legales/politique-de-confidentialite-service-publicitaire/'
+        policyUrl:
+          'https://zbo.media/mentions-legales/politique-de-confidentialite-service-publicitaire/'
       },
       '235': {
         id: 235,
         name: 'Bucksense Inc',
-        purposes: [
-          2,
-          3,
-          4,
-          7,
-          9
-        ],
+        purposes: [2, 3, 4, 7, 9],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          9
-        ],
+        flexiblePurposes: [2, 3, 4, 7, 9],
         specialPurposes: [],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'http://www.bucksense.com/platform-privacy-policy/'
       },
       '240': {
         id: 240,
         name: '7Hops.com Inc. (ZergNet)',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          5,
-          6,
-          8,
-          10
-        ],
+        purposes: [1],
+        legIntPurposes: [5, 6, 8, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://zergnet.com/privacy'
@@ -13555,58 +11097,22 @@ const VendorList45 = {data: {
       '241': {
         id: 241,
         name: 'OneTag Limited',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          7
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        flexiblePurposes: [7],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.onetag.com/privacy/'
       },
       '242': {
         id: 242,
         name: 'twiago GmbH',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
+        flexiblePurposes: [2, 3, 4, 7],
+        specialPurposes: [1, 2],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://www.twiago.com/datenschutz/',
         overflow: {
@@ -13616,50 +11122,23 @@ const VendorList45 = {data: {
       '243': {
         id: 243,
         name: 'Cloud Technologies S.A.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
-        policyUrl: 'https://www.cloudtechnologies.pl/en/internet-advertising-privacy-policy'
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl:
+          'https://www.cloudtechnologies.pl/en/internet-advertising-privacy-policy'
       },
       '248': {
         id: 248,
         name: 'Converge-Digital',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2
-        ],
-        flexiblePurposes: [
-          2
-        ],
+        purposes: [1],
+        legIntPurposes: [2],
+        flexiblePurposes: [2],
         specialPurposes: [],
-        features: [
-          3
-        ],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://converge-digital.com/privacy-policy/',
         overflow: {
@@ -13669,59 +11148,21 @@ const VendorList45 = {data: {
       '249': {
         id: 249,
         name: 'Spolecznosci Sp. z o.o. Sp. k.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
+        flexiblePurposes: [2, 3, 4, 5, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://www.spolecznosci.pl/polityka-prywatnosci'
       },
       '250': {
         id: 250,
         name: 'Qriously Ltd',
-        purposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          2
-        ],
+        specialPurposes: [2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://www.brandwatch.com/legal/qriously-privacy-notice/'
@@ -13729,23 +11170,10 @@ const VendorList45 = {data: {
       '251': {
         id: 251,
         name: 'Yieldlove GmbH',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          7,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 7, 10],
+        flexiblePurposes: [2, 7, 10],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'http://www.yieldlove.com/cookie-policy'
@@ -13753,71 +11181,23 @@ const VendorList45 = {data: {
       '252': {
         id: 252,
         name: 'Jaduda GmbH',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'https://www.jadudamobile.com/datenschutzerklaerung/'
       },
       '253': {
         id: 253,
         name: 'Improve Digital BV',
-        purposes: [
-          1,
-          3,
-          4,
-          9
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          7
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        purposes: [1, 3, 4, 9],
+        legIntPurposes: [2, 7, 10],
+        flexiblePurposes: [2, 7],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'https://www.improvedigital.com/platform-privacy-policy',
         overflow: {
           httpGetLimit: 128
@@ -13826,20 +11206,10 @@ const VendorList45 = {data: {
       '255': {
         id: 255,
         name: 'Onnetwork Sp. z o.o.',
-        purposes: [
-          1,
-          5,
-          6
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          8
-        ],
+        purposes: [1, 5, 6],
+        legIntPurposes: [2, 7, 8],
         flexiblePurposes: [],
-        specialPurposes: [
-          2
-        ],
+        specialPurposes: [2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://www.onnetwork.tv/pp_services.php'
@@ -13847,18 +11217,10 @@ const VendorList45 = {data: {
       '256': {
         id: 256,
         name: 'Bounce Exchange, Inc',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          7,
-          10
-        ],
+        purposes: [1],
+        legIntPurposes: [7, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://www.bouncex.com/privacy/'
@@ -13866,126 +11228,54 @@ const VendorList45 = {data: {
       '262': {
         id: 262,
         name: 'Fyber ',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          7
-        ],
+        purposes: [1, 2, 3, 4, 5, 7],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'https://www.fyber.com/legal/privacy-policy/'
       },
       '263': {
         id: 263,
         name: 'Nativo, Inc.',
-        purposes: [
-          1,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 9, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          2
-        ],
+        specialPurposes: [1, 2],
+        features: [2],
         specialFeatures: [],
         policyUrl: 'https://www.nativo.com/interest-based-ads'
       },
       '265': {
         id: 265,
         name: 'Instinctive, Inc.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8
-        ],
-        legIntPurposes: [
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8],
+        legIntPurposes: [9, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'https://instinctive.io/privacy'
       },
       '272': {
         id: 272,
         name: 'A.Mob',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.we-are-adot.com/privacy-policy/'
       },
       '273': {
         id: 273,
         name: 'Bannerflow AB',
-        purposes: [
-          1,
-          4
-        ],
-        legIntPurposes: [
-          7
-        ],
+        purposes: [1, 4],
+        legIntPurposes: [7],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://www.bannerflow.com/privacy '
@@ -13993,27 +11283,11 @@ const VendorList45 = {data: {
       '277': {
         id: 277,
         name: 'Codewise VL Sp. z o.o. Sp. k',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9
-        ],
-        legIntPurposes: [
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9],
+        legIntPurposes: [10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://voluumdsp.com/end-user-privacy-policy/'
       },
@@ -14021,14 +11295,9 @@ const VendorList45 = {data: {
         id: 278,
         name: 'Integral Ad Science, Inc.',
         purposes: [],
-        legIntPurposes: [
-          7,
-          10
-        ],
+        legIntPurposes: [7, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1
-        ],
+        specialPurposes: [1],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://integralads.com/privacy-policy/'
@@ -14036,13 +11305,8 @@ const VendorList45 = {data: {
       '279': {
         id: 279,
         name: 'Mirando GmbH &amp; Co KG',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          7
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 7],
         flexiblePurposes: [],
         specialPurposes: [],
         features: [],
@@ -14052,79 +11316,32 @@ const VendorList45 = {data: {
       '280': {
         id: 280,
         name: 'Spot.IM LTD',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://www.spot.im/privacy/'
       },
       '281': {
         id: 281,
         name: 'Wizaly',
-        purposes: [
-          1,
-          7,
-          8,
-          9
-        ],
+        purposes: [1, 7, 8, 9],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2
-        ],
+        features: [1, 2],
         specialFeatures: [],
         policyUrl: 'https://www.wizaly.com/terms-of-use#privacy-policy'
       },
       '282': {
         id: 282,
         name: 'Welect GmbH',
-        purposes: [
-          10
-        ],
-        legIntPurposes: [
-          2,
-          7
-        ],
+        purposes: [10],
+        legIntPurposes: [2, 7],
         flexiblePurposes: [],
-        specialPurposes: [
-          2
-        ],
+        specialPurposes: [2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://www.welect.de/datenschutz'
@@ -14132,48 +11349,18 @@ const VendorList45 = {data: {
       '284': {
         id: 284,
         name: 'WEBORAMA',
-        purposes: [
-          1,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          2,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2
-        ],
-        specialFeatures: [
-          1
-        ],
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [2, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [1],
         policyUrl: 'https://weborama.com/privacy_en/'
       },
       '285': {
         id: 285,
         name: 'Comcast International France SAS',
-        purposes: [
-          1
-        ],
+        purposes: [1],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
@@ -14184,41 +11371,18 @@ const VendorList45 = {data: {
       '289': {
         id: 289,
         name: 'mobalo GmbH',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [1],
+        specialFeatures: [1],
         policyUrl: 'https://www.mobalo.com/en/privacy/'
       },
       '290': {
         id: 290,
         name: 'Readpeak Oy',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
@@ -14229,62 +11393,23 @@ const VendorList45 = {data: {
       '293': {
         id: 293,
         name: 'SpringServe, LLC',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1
-        ],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          2
-        ],
+        specialPurposes: [1],
+        features: [3],
+        specialFeatures: [2],
         policyUrl: 'https://springserve.com/privacy-policy/'
       },
       '294': {
         id: 294,
         name: 'Jivox Corporation',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          7
-        ],
+        purposes: [1, 2, 3, 4, 5, 7],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          7
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        flexiblePurposes: [2, 3, 4, 5, 7],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.jivox.com/privacy',
         overflow: {
           httpGetLimit: 32
@@ -14293,112 +11418,40 @@ const VendorList45 = {data: {
       '299': {
         id: 299,
         name: 'AdClear GmbH',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          2
-        ],
-        features: [
-          1,
-          2
-        ],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [2],
+        features: [1, 2],
         specialFeatures: [],
         policyUrl: 'https://www.adclear.de/datenschutzerklaerung/'
       },
       '301': {
         id: 301,
         name: 'zeotap GmbH',
-        purposes: [
-          1,
-          3,
-          4,
-          5,
-          6,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 3, 4, 5, 6, 7, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          3,
-          4,
-          5,
-          6,
-          7,
-          9,
-          10
-        ],
+        flexiblePurposes: [3, 4, 5, 6, 7, 9, 10],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://zeotap.com/privacy_policy'
       },
       '302': {
         id: 302,
         name: 'Mobile Professionals BV',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          7,
-          8,
-          9
-        ],
+        purposes: [1, 2, 3, 4, 5, 7, 8, 9],
         legIntPurposes: [],
-        flexiblePurposes: [
-          3,
-          5,
-          7,
-          8
-        ],
+        flexiblePurposes: [3, 5, 7, 8],
         specialPurposes: [],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'https://mobpro.com/privacy.html'
       },
       '303': {
         id: 303,
         name: 'Orion Semantics',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9
-        ],
+        purposes: [1, 2, 3, 4, 7, 9],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
@@ -14409,82 +11462,33 @@ const VendorList45 = {data: {
       '304': {
         id: 304,
         name: 'On Device Research Limited',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://s.on-device.com/privacyPolicy'
       },
       '310': {
         id: 310,
         name: 'Adevinta Spain S.L.U.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          9
-        ],
-        legIntPurposes: [
-          7,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 9],
+        legIntPurposes: [7, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.adevinta.com/about/privacy/'
       },
       '312': {
         id: 312,
         name: 'Exactag GmbH',
-        purposes: [
-          1,
-          3,
-          7,
-          8
-        ],
+        purposes: [1, 3, 7, 8],
         legIntPurposes: [],
-        flexiblePurposes: [
-          3,
-          7,
-          8
-        ],
-        specialPurposes: [
-          1
-        ],
-        features: [
-          2
-        ],
+        flexiblePurposes: [3, 7, 8],
+        specialPurposes: [1],
+        features: [2],
         specialFeatures: [],
         policyUrl: 'https://www.exactag.com/en/data-privacy/',
         overflow: {
@@ -14494,28 +11498,10 @@ const VendorList45 = {data: {
       '314': {
         id: 314,
         name: 'Keymantics',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://www.keymantics.com/assets/privacy-policy.pdf'
@@ -14523,67 +11509,32 @@ const VendorList45 = {data: {
       '315': {
         id: 315,
         name: 'Celtra, Inc.',
-        purposes: [
-          1,
-          2,
-          4,
-          7,
-          10
-        ],
+        purposes: [1, 2, 4, 7, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://www.celtra.com/privacy-policy/'
       },
       '316': {
         id: 316,
         name: 'Gamned',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://www.gamned.com/privacy-policy/'
       },
       '317': {
         id: 317,
         name: 'mainADV Srl',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'http://www.mainad.com/privacy-policy/'
@@ -14591,110 +11542,54 @@ const VendorList45 = {data: {
       '318': {
         id: 318,
         name: 'Accorp Sp. z o.o.',
-        purposes: [
-          1,
-          3,
-          4,
-          9
-        ],
-        legIntPurposes: [
-          7,
-          10
-        ],
+        purposes: [1, 3, 4, 9],
+        legIntPurposes: [7, 10],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          2
-        ],
+        features: [2],
         specialFeatures: [],
         policyUrl: 'http://www.instytut-pollster.pl/privacy-policy/'
       },
       '319': {
         id: 319,
         name: 'Clipcentric, Inc.',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          10
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 7, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://clipcentric.com/privacy.bhtml'
       },
       '325': {
         id: 325,
         name: 'Knorex',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.knorex.com/privacy'
       },
       '328': {
         id: 328,
         name: 'Gemius SA',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          3
-        ],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://www.gemius.com/cookie-policy.html'
       },
       '329': {
         id: 329,
         name: 'Browsi Mobile Ltd',
-        purposes: [
-          1,
-          7,
-          8
-        ],
+        purposes: [1, 7, 8],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'http://gobrowsi.com/browsi-privacy-policy/'
@@ -14702,50 +11597,21 @@ const VendorList45 = {data: {
       '333': {
         id: 333,
         name: 'InMobi Pte Ltd',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          9
-        ],
-        specialPurposes: [
-          1
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        flexiblePurposes: [9],
+        specialPurposes: [1],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.inmobi.com/privacy-policy-for-eea'
       },
       '336': {
         id: 336,
         name: 'Telecoming S.A.',
-        purposes: [
-          2,
-          4
-        ],
-        legIntPurposes: [
-          7,
-          9
-        ],
-        flexiblePurposes: [
-          2,
-          4
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [2, 4],
+        legIntPurposes: [7, 9],
+        flexiblePurposes: [2, 4],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'http://www.telecoming.com/privacy-policy/',
@@ -14756,106 +11622,33 @@ const VendorList45 = {data: {
       '343': {
         id: 343,
         name: 'DIGITEKA Technologies',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://www.ultimedia.com/POLICY.html'
       },
       '345': {
         id: 345,
         name: 'The Kantar Group Limited',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        flexiblePurposes: [2, 3, 4, 7, 8, 9, 10],
+        specialPurposes: [2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'http://www.kantar.com/cookies-policies'
       },
       '350': {
         id: 350,
         name: 'Free Stream Media Corp. dba Samba TV',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://samba.tv/legal/privacy-policy/',
         overflow: {
@@ -14865,38 +11658,11 @@ const VendorList45 = {data: {
       '351': {
         id: 351,
         name: 'Samba TV UK Limited',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://samba.tv/legal/privacy-policy/',
         overflow: {
@@ -14906,24 +11672,10 @@ const VendorList45 = {data: {
       '354': {
         id: 354,
         name: 'Apester Ltd',
-        purposes: [
-          2,
-          4
-        ],
-        legIntPurposes: [
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          7
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [2, 4],
+        legIntPurposes: [6, 7, 8, 9, 10],
+        flexiblePurposes: [7],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://apester.com/privacy-policy/'
@@ -14931,277 +11683,111 @@ const VendorList45 = {data: {
       '358': {
         id: 358,
         name: 'MGID Inc.',
-        purposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.mgid.com/privacy-policy'
       },
       '359': {
         id: 359,
         name: 'AerServ LLC',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          9
-        ],
-        specialPurposes: [
-          1
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        flexiblePurposes: [9],
+        specialPurposes: [1],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.inmobi.com/privacy-policy-for-eea'
       },
       '365': {
         id: 365,
         name: 'Forensiq LLC',
         purposes: [],
-        legIntPurposes: [
-          7
-        ],
+        legIntPurposes: [7],
         flexiblePurposes: [],
-        specialPurposes: [
-          1
-        ],
-        features: [
-          1,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1],
+        features: [1, 3],
+        specialFeatures: [1],
         policyUrl: 'https://impact.com/privacy-policy/'
       },
       '368': {
         id: 368,
         name: 'VECTAURY',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9
-        ],
+        purposes: [1, 2, 3, 4, 7, 9],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.vectaury.io/en/personal-data'
       },
       '371': {
         id: 371,
         name: 'Seeding Alliance GmbH',
         purposes: [],
-        legIntPurposes: [
-          2,
-          7,
-          8
-        ],
-        flexiblePurposes: [
-          7
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        legIntPurposes: [2, 7, 8],
+        flexiblePurposes: [7],
+        specialPurposes: [1, 2],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://seeding-alliance.de/datenschutz'
       },
       '373': {
         id: 373,
         name: 'Nielsen Marketing Cloud',
-        purposes: [
-          1,
-          3,
-          5
-        ],
-        legIntPurposes: [
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 3, 5],
+        legIntPurposes: [7, 8, 9, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
-        policyUrl: 'http://www.nielsen.com/us/en/privacy-statement/exelate-privacy-policy.html'
+        specialPurposes: [1],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl:
+          'http://www.nielsen.com/us/en/privacy-statement/exelate-privacy-policy.html'
       },
       '374': {
         id: 374,
         name: 'Bmind a Sales Maker Company, S.L.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2
-        ],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2],
         specialFeatures: [],
         policyUrl: 'http://www.bmind.es/legal-notice/'
       },
       '377': {
         id: 377,
         name: 'AddApptr GmbH',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          7,
-          10
-        ],
-        flexiblePurposes: [
-          7,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [1],
+        legIntPurposes: [7, 10],
+        flexiblePurposes: [7, 10],
+        specialPurposes: [1, 2],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://www.addapptr.com/data-privacy'
       },
       '381': {
         id: 381,
         name: 'Solocal',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://frontend.adhslx.com/privacy.html?'
       },
       '382': {
         id: 382,
         name: 'The Reach Group GmbH',
-        purposes: [
-          1,
-          3,
-          4,
-          5,
-          6,
-          9
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          8
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
+        purposes: [1, 3, 4, 5, 6, 9],
+        legIntPurposes: [2, 7, 8],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9],
+        specialPurposes: [1, 2],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://trg.de/en/privacy-statement/',
         overflow: {
@@ -15211,104 +11797,55 @@ const VendorList45 = {data: {
       '385': {
         id: 385,
         name: 'Oracle Data Cloud',
-        purposes: [
-          1,
-          3,
-          5,
-          9,
-          10
-        ],
-        legIntPurposes: [
-          7
-        ],
+        purposes: [1, 3, 5, 9, 10],
+        legIntPurposes: [7],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2
-        ],
+        features: [1, 2],
         specialFeatures: [],
-        policyUrl: 'https://www.oracle.com/legal/privacy/marketing-cloud-data-cloud-privacy-policy.html'
+        policyUrl:
+          'https://www.oracle.com/legal/privacy/marketing-cloud-data-cloud-privacy-policy.html'
       },
       '387': {
         id: 387,
         name: 'Triapodi Ltd.',
-        purposes: [
-          2,
-          3,
-          4,
-          7
-        ],
+        purposes: [2, 3, 4, 7],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          3
-        ],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://appreciate.mobi/page.html#/end-user-privacy-policy'
       },
       '394': {
         id: 394,
         name: 'AudienceProject Aps',
-        purposes: [
-          1,
-          3,
-          4,
-          5,
-          6
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          8,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          7,
-          8,
-          9
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2
-        ],
+        purposes: [1, 3, 4, 5, 6],
+        legIntPurposes: [2, 7, 8, 9, 10],
+        flexiblePurposes: [2, 7, 8, 9],
+        specialPurposes: [1, 2],
+        features: [1, 2],
         specialFeatures: [],
         policyUrl: 'https://privacy.audienceproject.com'
       },
       '402': {
         id: 402,
         name: 'Effiliation',
-        purposes: [
-          1,
-          7
-        ],
+        purposes: [1, 7],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
         features: [],
         specialFeatures: [],
-        policyUrl: 'https://inter.effiliation.com/politique-confidentialite.html'
+        policyUrl:
+          'https://inter.effiliation.com/politique-confidentialite.html'
       },
       '408': {
         id: 408,
         name: 'Fidelity Media',
-        purposes: [
-          1,
-          2,
-          7
-        ],
+        purposes: [1, 2, 7],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          7
-        ],
+        flexiblePurposes: [2, 7],
         specialPurposes: [],
         features: [],
         specialFeatures: [],
@@ -15317,110 +11854,44 @@ const VendorList45 = {data: {
       '409': {
         id: 409,
         name: 'Arrivalist Co.',
-        purposes: [
-          1,
-          9
-        ],
-        legIntPurposes: [
-          7,
-          8
-        ],
+        purposes: [1, 9],
+        legIntPurposes: [7, 8],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://www.arrivalist.com/privacy'
       },
       '410': {
         id: 410,
         name: 'Adtelligent Inc.',
-        purposes: [
-          1,
-          7,
-          10
-        ],
+        purposes: [1, 7, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'https://adtelligent.com/privacy-policy/'
       },
       '412': {
         id: 412,
         name: 'Cxense ASA',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.cxense.com/about-us/privacy-policy'
       },
       '413': {
         id: 413,
         name: 'Eulerian Technologies',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://www.eulerian.com/en/privacy/'
       },
@@ -15430,9 +11901,7 @@ const VendorList45 = {data: {
         purposes: [],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          2
-        ],
+        specialPurposes: [2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://seenthis.co/privacy-notice-2018-04-18.pdf'
@@ -15440,106 +11909,54 @@ const VendorList45 = {data: {
       '416': {
         id: 416,
         name: 'Commanders Act',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://www.commandersact.com/en/privacy/'
       },
       '418': {
         id: 418,
         name: 'PROXISTORE',
-        purposes: [
-          1,
-          2,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 4, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          2
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        features: [2],
+        specialFeatures: [1, 2],
         policyUrl: 'https://www.proxistore.com/common/en/cgv'
       },
       '422': {
         id: 422,
         name: 'Brand Metrics Sweden AB',
-        purposes: [
-          1,
-          6,
-          7,
-          8,
-          9
-        ],
+        purposes: [1, 6, 7, 8, 9],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
         features: [],
         specialFeatures: [],
-        policyUrl: 'https://collector.brandmetrics.com/brandmetrics_privacypolicy.pdf'
+        policyUrl:
+          'https://collector.brandmetrics.com/brandmetrics_privacypolicy.pdf'
       },
       '423': {
         id: 423,
         name: 'travel audience GmbH',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [1, 2],
+        specialFeatures: [1],
         policyUrl: 'https://travelaudience.com/product-privacy-policy/'
       },
       '424': {
         id: 424,
         name: 'KUPONA GmbH',
-        purposes: [
-          4,
-          7
-        ],
+        purposes: [4, 7],
         legIntPurposes: [],
-        flexiblePurposes: [
-          4
-        ],
+        flexiblePurposes: [4],
         specialPurposes: [],
         features: [],
         specialFeatures: [],
@@ -15548,24 +11965,10 @@ const VendorList45 = {data: {
       '428': {
         id: 428,
         name: 'Internet BillBoard a.s.',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          7
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7],
+        flexiblePurposes: [2, 3, 4],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'http://www.ibillboard.com/en/privacy-information/'
@@ -15573,157 +11976,66 @@ const VendorList45 = {data: {
       '429': {
         id: 429,
         name: 'Signals',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://signalsdata.com/platform-cookie-policy/'
       },
       '431': {
         id: 431,
         name: 'White Ops, Inc.',
         purposes: [],
-        legIntPurposes: [
-          7,
-          9,
-          10
-        ],
+        legIntPurposes: [7, 9, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          3
-        ],
-        specialFeatures: [
-          2
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 3],
+        specialFeatures: [2],
         policyUrl: 'https://www.whiteops.com/privacy'
       },
       '436': {
         id: 436,
         name: 'INVIBES GROUP',
-        purposes: [
-          1,
-          3,
-          4,
-          5,
-          6,
-          9
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          8,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          10
-        ],
+        purposes: [1, 3, 4, 5, 6, 9],
+        legIntPurposes: [2, 7, 8, 10],
+        flexiblePurposes: [2, 10],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'http://www.invibes.com/terms'
       },
       '438': {
         id: 438,
         name: 'INVIDI technologies AB',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
         specialPurposes: [],
-        features: [
-          1,
-          2
-        ],
+        features: [1, 2],
         specialFeatures: [],
-        policyUrl: 'http://www.invidi.com/wp-content/uploads/2020/02/ad-tech-services-privacy-policy.pdf'
+        policyUrl:
+          'http://www.invidi.com/wp-content/uploads/2020/02/ad-tech-services-privacy-policy.pdf'
       },
       '439': {
         id: 439,
         name: 'Bit Q Holdings Limited',
-        purposes: [
-          1,
-          7,
-          9
-        ],
+        purposes: [1, 7, 9],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'https://www.rippll.com/privacy'
       },
       '440': {
         id: 440,
         name: 'DEFINE MEDIA GMBH',
-        purposes: [
-          1,
-          4
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          4,
-          7,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [1, 4],
+        legIntPurposes: [2, 7, 9, 10],
+        flexiblePurposes: [2, 4, 7, 9, 10],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'http://www.definemedia.de/datenschutz-conative/'
@@ -15731,30 +12043,10 @@ const VendorList45 = {data: {
       '444': {
         id: 444,
         name: 'Playbuzz Ltd (aka EX.CO)',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          5,
-          6
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 5, 6],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://ex.co/privacy-policy/'
@@ -15762,54 +12054,23 @@ const VendorList45 = {data: {
       '447': {
         id: 447,
         name: 'Adludio Ltd',
-        purposes: [
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [1],
+        specialFeatures: [1],
         policyUrl: 'https://www.adludio.com/privacy-policy/'
       },
       '450': {
         id: 450,
         name: 'Neodata Group srl',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.neodatagroup.com/en/security-policy',
         overflow: {
           httpGetLimit: 32
@@ -15818,35 +12079,12 @@ const VendorList45 = {data: {
       '455': {
         id: 455,
         name: 'GDMServices, Inc. d/b/a FiksuDSP',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          10
-        ],
-        legIntPurposes: [
-          7,
-          8
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        purposes: [1, 2, 3, 4, 10],
+        legIntPurposes: [7, 8],
+        flexiblePurposes: [2, 3, 4, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://fiksu.com/privacy-policy/'
       },
       '466': {
@@ -15863,94 +12101,43 @@ const VendorList45 = {data: {
       '467': {
         id: 467,
         name: 'Haensel AMS GmbH',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          7
-        ],
-        flexiblePurposes: [
-          7
-        ],
+        purposes: [1],
+        legIntPurposes: [7],
+        flexiblePurposes: [7],
         specialPurposes: [],
-        features: [
-          2
-        ],
+        features: [2],
         specialFeatures: [],
         policyUrl: 'https://haensel-ams.com/data-privacy/'
       },
       '475': {
         id: 475,
         name: 'TAPTAP Digital SL',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7
-        ],
-        legIntPurposes: [
-          8,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7],
+        legIntPurposes: [8, 10],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'http://www.taptapnetworks.com/privacy_policy/'
       },
       '479': {
         id: 479,
         name: 'INFINIA MOBILE S.L.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'http://www.infiniamobile.com/privacy_policy'
       },
       '484': {
         id: 484,
         name: 'STRIATUM SAS',
         purposes: [],
-        legIntPurposes: [
-          7,
-          10
-        ],
+        legIntPurposes: [7, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1
-        ],
+        specialPurposes: [1],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://adledge.com/data-privacy/'
@@ -15959,16 +12146,9 @@ const VendorList45 = {data: {
         id: 486,
         name: 'Madington',
         purposes: [],
-        legIntPurposes: [
-          7,
-          8,
-          10
-        ],
+        legIntPurposes: [7, 8, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://delivered-by-madington.com/dat-privacy-policy/'
@@ -15976,25 +12156,10 @@ const VendorList45 = {data: {
       '488': {
         id: 488,
         name: 'Opinary GmbH',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          8,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          7,
-          8,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 7, 8, 10],
+        flexiblePurposes: [2, 7, 8, 10],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://opinary.com/privacy-policy/'
@@ -16002,23 +12167,9 @@ const VendorList45 = {data: {
       '490': {
         id: 490,
         name: 'PLAYGROUND XYZ EMEA LTD',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7
-        ],
+        flexiblePurposes: [2, 3, 4, 7],
         specialPurposes: [],
         features: [],
         specialFeatures: [],
@@ -16027,45 +12178,24 @@ const VendorList45 = {data: {
       '491': {
         id: 491,
         name: 'Triboo Data Analytics',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
         features: [],
         specialFeatures: [],
-        policyUrl: 'https://www.shinystat.com/it/informativa_privacy_generale.html'
+        policyUrl:
+          'https://www.shinystat.com/it/informativa_privacy_generale.html'
       },
       '495': {
         id: 495,
         name: 'Arcspire Limited',
-        purposes: [
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'https://public.arcspire.io/privacy.pdf',
         overflow: {
           httpGetLimit: 128
@@ -16074,71 +12204,33 @@ const VendorList45 = {data: {
       '498': {
         id: 498,
         name: 'Dr. Banner',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8
-        ],
-        legIntPurposes: [
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8],
+        legIntPurposes: [9, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 3],
+        specialFeatures: [1],
         policyUrl: 'https://drbanner.com/privacypolicy_en/'
       },
       '501': {
         id: 501,
         name: 'Alliance Gravity Data Media',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9
-        ],
+        purposes: [1, 2, 3, 4, 7, 9],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2
-        ],
+        features: [1, 2],
         specialFeatures: [],
-        policyUrl: 'https://www.alliancegravity.com/politiquedeprotectiondesdonneespersonnelles'
+        policyUrl:
+          'https://www.alliancegravity.com/politiquedeprotectiondesdonneespersonnelles'
       },
       '502': {
         id: 502,
         name: 'NEXD',
-        purposes: [
-          1,
-          7,
-          10
-        ],
-        legIntPurposes: [
-          9
-        ],
+        purposes: [1, 7, 10],
+        legIntPurposes: [9],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://nexd.com/privacy-policy',
@@ -16149,89 +12241,34 @@ const VendorList45 = {data: {
       '505': {
         id: 505,
         name: 'Shopalyst Inc',
-        purposes: [
-          1,
-          7,
-          8
-        ],
+        purposes: [1, 7, 8],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://www.shortlyst.com/eu/privacy_terms.html'
       },
       '507': {
         id: 507,
         name: 'AdsWizz Inc.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://www.adswizz.com/our-privacy-policy/'
       },
       '511': {
         id: 511,
         name: 'Admixer EU GmbH',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          7,
-          9
-        ],
-        legIntPurposes: [
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 7, 9],
+        legIntPurposes: [10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [1],
         policyUrl: 'https://admixer.com/privacy/',
         overflow: {
           httpGetLimit: 128
@@ -16240,41 +12277,18 @@ const VendorList45 = {data: {
       '512': {
         id: 512,
         name: 'PubNative GmbH',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          8,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 8, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          2
-        ],
+        features: [3],
+        specialFeatures: [2],
         policyUrl: 'https://pubnative.net/privacy-notice/'
       },
       '516': {
         id: 516,
         name: 'Pexi B.V.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
@@ -16285,79 +12299,40 @@ const VendorList45 = {data: {
       '517': {
         id: 517,
         name: 'SunMedia ',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
+        specialPurposes: [1, 2],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://www.sunmedia.tv/en/cookies'
       },
       '521': {
         id: 521,
         name: 'netzeffekt GmbH',
-        purposes: [
-          1,
-          7
-        ],
+        purposes: [1, 7],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://www.netzeffekt.de/en/imprint'
       },
       '524': {
         id: 524,
         name: 'The Ozone Project Limited',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://ozoneproject.com/privacy-policy'
       },
       '527': {
         id: 527,
         name: 'Jampp LTD',
-        purposes: [
-          1,
-          2,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 4, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
@@ -16368,61 +12343,23 @@ const VendorList45 = {data: {
       '528': {
         id: 528,
         name: 'Kayzen',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          9,
-          10
-        ],
-        legIntPurposes: [
-          7
-        ],
+        purposes: [1, 2, 3, 4, 9, 10],
+        legIntPurposes: [7],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [1],
         specialFeatures: [],
         policyUrl: 'https://kayzen.io/data-privacy-policy'
       },
       '530': {
         id: 530,
         name: 'Near Pte Ltd',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          9,
-          10
-        ],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 9, 10],
         specialPurposes: [],
-        features: [
-          1,
-          2
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [1, 2],
+        specialFeatures: [1],
         policyUrl: 'https://near.co/privacy',
         overflow: {
           httpGetLimit: 128
@@ -16431,118 +12368,52 @@ const VendorList45 = {data: {
       '531': {
         id: 531,
         name: 'Smartclip Hispania SL',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [2, 3],
+        specialFeatures: [1],
         policyUrl: 'http://rgpd-smartclip.com/'
       },
       '535': {
         id: 535,
         name: 'INNITY',
-        purposes: [
-          1,
-          2,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2],
         specialFeatures: [],
         policyUrl: 'https://www.innity.com/privacy-policy.php'
       },
       '536': {
         id: 536,
         name: 'GlobalWebIndex',
-        purposes: [
-          1,
-          7,
-          8,
-          9
-        ],
+        purposes: [1, 7, 8, 9],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'http://legal.trendstream.net/non-panellist_privacy_policy'
       },
       '539': {
         id: 539,
         name: 'AdDefend GmbH',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          7
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7],
+        flexiblePurposes: [2, 3, 4, 7],
+        specialPurposes: [1, 2],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://www.addefend.com/en/privacy-policy/'
       },
       '543': {
         id: 543,
         name: 'PaperG, Inc. dba Thunder Industries',
-        purposes: [
-          1,
-          3,
-          4,
-          5,
-          6
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          8
-        ],
+        purposes: [1, 3, 4, 5, 6],
+        legIntPurposes: [2, 7, 8],
         flexiblePurposes: [],
         specialPurposes: [],
         features: [],
@@ -16553,86 +12424,39 @@ const VendorList45 = {data: {
         id: 544,
         name: 'Kochava Inc.',
         purposes: [],
-        legIntPurposes: [
-          7
-        ],
+        legIntPurposes: [7],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://www.kochava.com/support-privacy/'
       },
       '545': {
         id: 545,
         name: 'Reignn Platform Ltd',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          8,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 8, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
-        specialFeatures: [
-          2
-        ],
+        specialFeatures: [2],
         policyUrl: 'http://reignn.com/user-privacy-policy'
       },
       '546': {
         id: 546,
         name: 'Smart Traffik',
-        purposes: [
-          1,
-          8
-        ],
-        legIntPurposes: [
-          7
-        ],
-        flexiblePurposes: [
-          7,
-          8
-        ],
+        purposes: [1, 8],
+        legIntPurposes: [7],
+        flexiblePurposes: [7, 8],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://smart-traffik.io/politique-de-confidentialite'
       },
       '549': {
         id: 549,
         name: 'Bandsintown Amplified LLC',
-        purposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
@@ -16643,165 +12467,77 @@ const VendorList45 = {data: {
       '550': {
         id: 550,
         name: 'Happydemics',
-        purposes: [
-          7
-        ],
+        purposes: [7],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          3
-        ],
+        features: [1, 3],
         specialFeatures: [],
         policyUrl: 'https://www.iubenda.com/privacy-policy/69056167/full-legal'
       },
       '553': {
         id: 553,
         name: 'Adhese',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9
-        ],
+        purposes: [1, 2, 3, 4, 7, 9],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [1],
         policyUrl: 'https://adhese.com/privacy-and-cookie-policy'
       },
       '554': {
         id: 554,
         name: 'RMSi Radio Marketing Service interactive GmbH',
-        purposes: [
-          1,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          9
-        ],
-        flexiblePurposes: [
-          2
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 9],
+        flexiblePurposes: [2],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://www.rms.de/datenschutz/'
       },
       '556': {
         id: 556,
         name: 'adhood.com',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
         features: [],
-        specialFeatures: [
-          1
-        ],
-        policyUrl: 'http://v3.adhood.com/en/site/politikavekurallar/gizlilik.php?lang=en'
+        specialFeatures: [1],
+        policyUrl:
+          'http://v3.adhood.com/en/site/politikavekurallar/gizlilik.php?lang=en'
       },
       '559': {
         id: 559,
         name: 'Otto (GmbH &amp; Co KG)',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          2,
-          3
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7, 9, 10],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [2, 3],
         specialFeatures: [],
         policyUrl: 'https://www.otto.de/shoppages/service/datenschutz'
       },
       '561': {
         id: 561,
         name: 'AuDigent',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          9
-        ],
+        purposes: [1, 2, 3, 4, 9],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          2,
-          3
-        ],
+        features: [2, 3],
         specialFeatures: [],
         policyUrl: 'http://audigent.com/platform-privacy-policy'
       },
       '565': {
         id: 565,
         name: 'Adobe Audience Manager',
-        purposes: [
-          1,
-          10
-        ],
+        purposes: [1, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1
-        ],
+        specialPurposes: [1],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://www.adobe.com/privacy/policy.html'
@@ -16809,84 +12545,33 @@ const VendorList45 = {data: {
       '568': {
         id: 568,
         name: 'Jointag S.r.l.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        features: [3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://www.jointag.com/privacy/kariboo/publisher/third/'
       },
       '571': {
         id: 571,
         name: 'ViewPay',
-        purposes: [
-          1,
-          2,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        flexiblePurposes: [2, 4, 5, 6, 7, 8, 9, 10],
         specialPurposes: [],
-        features: [
-          3
-        ],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'http://viewpay.tv/mentions-legales/'
       },
       '573': {
         id: 573,
         name: 'Dailymotion SA',
-        purposes: [
-          1,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          2,
-          5,
-          6,
-          7,
-          8,
-          10
-        ],
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 5, 6, 7, 8, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          2
-        ],
+        specialPurposes: [1, 2],
+        features: [2],
         specialFeatures: [],
         policyUrl: 'https://www.dailymotion.com/legal/privacy',
         overflow: {
@@ -16896,126 +12581,43 @@ const VendorList45 = {data: {
       '574': {
         id: 574,
         name: 'Realeyes OU',
-        purposes: [
-          1,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [1],
         specialFeatures: [],
         policyUrl: 'https://realview.realeyesit.com/privacy'
       },
       '577': {
         id: 577,
         name: 'Neustar on behalf of The Procter & Gamble Company',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          6,
-          9
-        ],
-        legIntPurposes: [
-          5,
-          7,
-          8
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9
-        ],
+        purposes: [1, 2, 3, 4, 6, 9],
+        legIntPurposes: [5, 7, 8],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://www.pg.com/privacy/english/privacy_statement.shtml'
       },
       '580': {
         id: 580,
         name: 'Goldbach Group AG',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://goldbach.com/ch/de/datenschutz'
       },
       '587': {
         id: 587,
         name: 'Localsensor B.V.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        flexiblePurposes: [2, 3, 4, 7, 10],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://www.localsensor.com/privacy.html'
@@ -17023,17 +12625,10 @@ const VendorList45 = {data: {
       '591': {
         id: 591,
         name: 'Consumable, Inc.',
-        purposes: [
-          1,
-          2,
-          4,
-          7
-        ],
+        purposes: [1, 2, 4, 7],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          2
-        ],
+        specialPurposes: [2],
         features: [],
         specialFeatures: [],
         policyUrl: 'http://consumable.com/privacy-policy.html'
@@ -17041,119 +12636,54 @@ const VendorList45 = {data: {
       '593': {
         id: 593,
         name: 'Programatica de publicidad S.L.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://datmean.com/politica-privacidad/'
       },
       '596': {
         id: 596,
         name: 'InsurAds Technologies SA.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          9,
-          10
-        ],
-        legIntPurposes: [
-          7,
-          8
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 9, 10],
+        legIntPurposes: [7, 8],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://www.insurads.com/privacy.html'
       },
       '598': {
         id: 598,
         name: 'audio content &amp; control GmbH',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          9
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 7, 9],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://www.audio-cc.com/audiocc_privacy_policy.pdf'
       },
       '599': {
         id: 599,
         name: 'Maximus Live LLC',
         purposes: [],
-        legIntPurposes: [
-          7,
-          8
-        ],
+        legIntPurposes: [7, 8],
         flexiblePurposes: [],
-        specialPurposes: [
-          1
-        ],
+        specialPurposes: [1],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://maximusx.com/privacy-policy/'
       },
       '601': {
         id: 601,
         name: 'WebAds B.V',
-        purposes: [
-          1,
-          2
-        ],
+        purposes: [1, 2],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          2
-        ],
+        specialPurposes: [2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://privacy.webads.eu/'
@@ -17161,27 +12691,11 @@ const VendorList45 = {data: {
       '602': {
         id: 602,
         name: 'Online Solution Int Limited',
-        purposes: [
-          2,
-          7,
-          8,
-          10
-        ],
+        purposes: [2, 7, 8, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          7,
-          8,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2
-        ],
+        flexiblePurposes: [2, 7, 8, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2],
         specialFeatures: [],
         policyUrl: 'https://adsafety.net/privacy.html',
         overflow: {
@@ -17191,33 +12705,10 @@ const VendorList45 = {data: {
       '606': {
         id: 606,
         name: 'Impactify ',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          2
-        ],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://impactify.io/privacy-policy/'
@@ -17225,63 +12716,23 @@ const VendorList45 = {data: {
       '607': {
         id: 607,
         name: 'ucfunnel Co., Ltd.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.ucfunnel.com/privacy-policy'
       },
       '609': {
         id: 609,
         name: 'Predicio',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'http://www.predic.io/privacy',
         overflow: {
           httpGetLimit: 128
@@ -17290,36 +12741,12 @@ const VendorList45 = {data: {
       '610': {
         id: 610,
         name: 'Azerion Holding B.V.',
-        purposes: [
-          1,
-          3,
-          4,
-          9
-        ],
-        legIntPurposes: [
-          2,
-          5,
-          6,
-          7,
-          8,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          5,
-          6
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        purposes: [1, 3, 4, 9],
+        legIntPurposes: [2, 5, 6, 7, 8, 10],
+        flexiblePurposes: [2, 5, 6],
+        specialPurposes: [1, 2],
+        features: [2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://azerion.com/business/privacy.html',
         overflow: {
           httpGetLimit: 128
@@ -17328,15 +12755,10 @@ const VendorList45 = {data: {
       '612': {
         id: 612,
         name: 'Adnami Aps',
-        purposes: [
-          1
-        ],
+        purposes: [1],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://www.adnami.io/privacy',
@@ -17345,20 +12767,10 @@ const VendorList45 = {data: {
       '613': {
         id: 613,
         name: 'Adserve.zone / Artworx AS',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          7
-        ],
-        flexiblePurposes: [
-          2
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 7],
+        flexiblePurposes: [2],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'http://adserve.zone/adserveprivacypolicy.html'
@@ -17366,30 +12778,12 @@ const VendorList45 = {data: {
       '614': {
         id: 614,
         name: 'Market Resource Partners LLC',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          2
-        ],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [2],
         policyUrl: 'https://www.mrpfd.com/privacy-policy/'
       },
       '615': {
@@ -17398,10 +12792,7 @@ const VendorList45 = {data: {
         purposes: [],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://www.adsolutions.com/privacy-policy/'
@@ -17409,197 +12800,87 @@ const VendorList45 = {data: {
       '617': {
         id: 617,
         name: 'Onfocus (Adagio)',
-        purposes: [
-          1,
-          2
-        ],
-        legIntPurposes: [
-          7
-        ],
+        purposes: [1, 2],
+        legIntPurposes: [7],
         flexiblePurposes: [],
         specialPurposes: [],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://adagio.io/privacy'
       },
       '618': {
         id: 618,
         name: 'BEINTOO SPA',
-        purposes: [
-          1,
-          2,
-          9,
-          10
-        ],
+        purposes: [1, 2, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [1],
+        specialFeatures: [1],
         policyUrl: 'http://www.beintoo.com/privacy-cookie-policy/'
       },
       '620': {
         id: 620,
         name: 'Blue',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [2, 3],
+        specialFeatures: [1],
         policyUrl: 'http://www.getblue.io/privacy/'
       },
       '625': {
         id: 625,
         name: 'BILENDI SA',
-        purposes: [
-          1,
-          6,
-          7,
-          8,
-          9
-        ],
+        purposes: [1, 6, 7, 8, 9],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1
-        ],
+        features: [1],
         specialFeatures: [],
         policyUrl: 'https://www.maximiles.com/privacy-policy'
       },
       '626': {
         id: 626,
         name: 'Hivestack Inc.',
-        purposes: [
-          1,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://hivestack.com/privacy-policy'
       },
       '628': {
         id: 628,
         name: ': Tappx',
-        purposes: [
-          1,
-          2,
-          4,
-          7,
-          10
-        ],
+        purposes: [1, 2, 4, 7, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          2
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
+        features: [2],
+        specialFeatures: [1, 2],
         policyUrl: 'https://www.tappx.com/en/privacy-policy/'
       },
       '630': {
         id: 630,
         name: 'Contact Impact GmbH',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          7,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7, 10],
+        flexiblePurposes: [2, 3, 4, 7, 10],
+        specialPurposes: [1, 2],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://contactimpact.de/privacy'
       },
       '631': {
         id: 631,
         name: 'Relay42 Netherlands B.V.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          2
-        ],
+        specialPurposes: [2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://relay42.com/privacy'
@@ -17607,55 +12888,23 @@ const VendorList45 = {data: {
       '639': {
         id: 639,
         name: 'Smile Wanted Group',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
         features: [],
-        specialFeatures: [
-          2
-        ],
+        specialFeatures: [2],
         policyUrl: 'https://www.smilewanted.com/privacy.php'
       },
       '645': {
         id: 645,
         name: 'Noster Finance S.L.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          9,
-          10
-        ],
-        legIntPurposes: [
-          7,
-          8
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 9, 10],
+        legIntPurposes: [7, 8],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://www.finect.com/terminos-legales/politica-de-cookies'
       },
       '646': {
@@ -17665,178 +12914,83 @@ const VendorList45 = {data: {
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1
-        ],
+        features: [1],
         specialFeatures: [],
         policyUrl: 'https://notify-group.com/en/mentions-legales/'
       },
       '647': {
         id: 647,
         name: 'Axel Springer Teaser Ad GmbH',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          7,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7, 10],
+        flexiblePurposes: [2, 3, 4, 7, 10],
+        specialPurposes: [1, 2],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://www.adup-tech.com/privacy'
       },
       '648': {
         id: 648,
         name: 'TrueData Solutions, Inc.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://www.truedata.co/privacy-policy/'
       },
       '649': {
         id: 649,
         name: 'adality GmbH',
         purposes: [],
-        legIntPurposes: [
-          2
-        ],
+        legIntPurposes: [2],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1
-        ],
+        features: [1],
         specialFeatures: [],
         policyUrl: 'https://adality.de/en/privacy/'
       },
       '650': {
         id: 650,
         name: 'Telefonica Investigación y Desarrollo S.A.U',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'http://www.cognitivemarketing.tid.es/'
       },
       '652': {
         id: 652,
         name: 'Skaze',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'http://www.skaze.fr/rgpd/'
       },
       '653': {
         id: 653,
         name: 'Smartme Analytics',
-        purposes: [
-          7,
-          8,
-          9
-        ],
+        purposes: [7, 8, 9],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          3
-        ],
+        features: [1, 3],
         specialFeatures: [],
         policyUrl: 'http://smartmeapp.com/info/smartme/aviso_legal.php'
       },
       '656': {
         id: 656,
         name: 'Think Clever Media',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          9
-        ],
-        legIntPurposes: [
-          7,
-          8,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 9],
+        legIntPurposes: [7, 8, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://www.contentignite.com/privacy-policy/'
@@ -17844,236 +12998,95 @@ const VendorList45 = {data: {
       '657': {
         id: 657,
         name: 'GP One GmbH',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4],
+        flexiblePurposes: [2, 3, 4],
+        specialPurposes: [1, 2],
         features: [],
-        specialFeatures: [
-          1,
-          2
-        ],
+        specialFeatures: [1, 2],
         policyUrl: 'https://www.gsi-one.org/de/privacy-policy.html'
       },
       '659': {
         id: 659,
         name: 'Research and Analysis of Media in Sweden AB',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          7,
-          8,
-          9
-        ],
+        purposes: [1],
+        legIntPurposes: [7, 8, 9],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          2
-        ],
+        features: [2],
         specialFeatures: [],
         policyUrl: 'https://www2.rampanel.com/privacy-policy/'
       },
       '662': {
         id: 662,
         name: 'SoundCast',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://soundcast.fm/en/data-privacy'
       },
       '663': {
         id: 663,
         name: 'Mobsuccess',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9
-        ],
+        purposes: [1, 2, 3, 4, 7, 9],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          7
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1
-        ],
+        flexiblePurposes: [2, 7],
+        specialPurposes: [1, 2],
+        features: [1],
         specialFeatures: [],
         policyUrl: 'https://www.mobsuccess.com/en/privacy'
       },
       '664': {
         id: 664,
         name: 'adMarketplace, Inc.',
-        purposes: [
-          1,
-          2,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          7,
-          10
-        ],
+        purposes: [1, 2, 3, 4],
+        legIntPurposes: [7, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://www.admarketplace.com/privacy-policy/'
       },
       '665': {
         id: 665,
         name: 'Digital East GmbH',
-        purposes: [
-          2,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [2, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        flexiblePurposes: [2, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'https://www.digitaleast.mobi/en/legal/privacy-policy/'
       },
       '667': {
         id: 667,
         name: 'Liftoff Mobile, Inc.',
-        purposes: [
-          1,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          2,
-          5,
-          6,
-          7,
-          8,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 5, 6, 7, 8, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 10],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'https://liftoff.io/privacy-policy/'
       },
       '668': {
         id: 668,
         name: 'WhatRocks Inc. ',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          2
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        features: [2],
+        specialFeatures: [1, 2],
         policyUrl: 'https://www.whatrocks.co/en/privacy-policy '
       },
       '674': {
         id: 674,
         name: 'Duration Media, LLC.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
@@ -18084,17 +13097,10 @@ const VendorList45 = {data: {
       '675': {
         id: 675,
         name: 'Instreamatic inc.',
-        purposes: [
-          2,
-          3,
-          4,
-          7
-        ],
+        purposes: [2, 3, 4, 7],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          2
-        ],
+        specialPurposes: [2],
         features: [],
         specialFeatures: [],
         policyUrl: 'http://instreamatic.com/privacy-policy/'
@@ -18102,56 +13108,24 @@ const VendorList45 = {data: {
       '676': {
         id: 676,
         name: 'BusinessClick',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2
-        ],
-        specialFeatures: [
-          1
-        ],
-        policyUrl: 'https://www.businessclick.com/documents/RegulaminProgramuBusinessClick-2019.pdf'
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [1],
+        policyUrl:
+          'https://www.businessclick.com/documents/RegulaminProgramuBusinessClick-2019.pdf'
       },
       '678': {
         id: 678,
         name: 'Axonix LTD',
-        purposes: [
-          2
-        ],
-        legIntPurposes: [
-          7,
-          10
-        ],
-        flexiblePurposes: [
-          2
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        purposes: [2],
+        legIntPurposes: [7, 10],
+        flexiblePurposes: [2],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'https://axonix.com/privacy-cookie-policy/',
         overflow: {
           httpGetLimit: 128
@@ -18160,44 +13134,23 @@ const VendorList45 = {data: {
       '681': {
         id: 681,
         name: 'MyTraffic',
-        purposes: [
-          1,
-          9
-        ],
+        purposes: [1, 9],
         legIntPurposes: [],
-        flexiblePurposes: [
-          9
-        ],
+        flexiblePurposes: [9],
         specialPurposes: [],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://www.mytraffic.io/en/privacy'
       },
       '682': {
         id: 682,
         name: 'Radio Net Media Limited',
-        purposes: [
-          1,
-          2,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          7
-        ],
+        purposes: [1, 2, 3, 4],
+        legIntPurposes: [7],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://www.adtonos.com/service-privacy-policy/',
         overflow: {
           httpGetLimit: 128
@@ -18206,37 +13159,21 @@ const VendorList45 = {data: {
       '683': {
         id: 683,
         name: 'Cookie Market LTD',
-        purposes: [
-          1,
-          3,
-          4,
-          9
-        ],
+        purposes: [1, 3, 4, 9],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [2, 3],
+        specialFeatures: [1],
         policyUrl: 'http://cookie.market/privacyPolicy.php'
       },
       '684': {
         id: 684,
         name: 'Blue Billywig BV',
         purposes: [],
-        legIntPurposes: [
-          7
-        ],
-        flexiblePurposes: [
-          7
-        ],
-        specialPurposes: [
-          2
-        ],
+        legIntPurposes: [7],
+        flexiblePurposes: [7],
+        specialPurposes: [2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://www.bluebillywig.com/privacy-statement/'
@@ -18244,48 +13181,21 @@ const VendorList45 = {data: {
       '686': {
         id: 686,
         name: 'The MediaGrid Inc.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2
-        ],
+        features: [1, 2],
         specialFeatures: [],
         policyUrl: 'https://www.themediagrid.com/privacy-policy/'
       },
       '687': {
         id: 687,
         name: 'MISSENA',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2
-        ],
-        specialPurposes: [
-          2
-        ],
+        flexiblePurposes: [2],
+        specialPurposes: [2],
         features: [],
         specialFeatures: [],
         policyUrl: 'http://missena.com/confidentialite/'
@@ -18294,13 +13204,8 @@ const VendorList45 = {data: {
         id: 688,
         name: 'Effinity',
         purposes: [],
-        legIntPurposes: [
-          2
-        ],
-        flexiblePurposes: [
-          2,
-          7
-        ],
+        legIntPurposes: [2],
+        flexiblePurposes: [2, 7],
         specialPurposes: [],
         features: [],
         specialFeatures: [],
@@ -18312,35 +13217,18 @@ const VendorList45 = {data: {
       '690': {
         id: 690,
         name: 'Go.pl sp. z o.o.',
-        purposes: [
-          1,
-          2,
-          3,
-          4
-        ],
+        purposes: [1, 2, 3, 4],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://go.pl/polityka-prywatnosci/'
       },
       '691': {
         id: 691,
         name: 'Lifesight Pte. Ltd.',
-        purposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
@@ -18351,26 +13239,11 @@ const VendorList45 = {data: {
       '694': {
         id: 694,
         name: 'Snapupp Technologies SL',
-        purposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          9
-        ],
-        legIntPurposes: [
-          7,
-          8,
-          10
-        ],
-        flexiblePurposes: [
-          10
-        ],
+        purposes: [2, 3, 4, 5, 6, 9],
+        legIntPurposes: [7, 8, 10],
+        flexiblePurposes: [10],
         specialPurposes: [],
-        features: [
-          3
-        ],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://www.enterprise.noddus.com/privacy-policy',
         overflow: {
@@ -18380,269 +13253,108 @@ const VendorList45 = {data: {
       '699': {
         id: 699,
         name: 'HyperTV Inc.',
-        purposes: [
-          1,
-          2,
-          4,
-          9
-        ],
-        legIntPurposes: [
-          7,
-          10
-        ],
+        purposes: [1, 2, 4, 9],
+        legIntPurposes: [7, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          2
-        ],
-        features: [
-          1
-        ],
+        specialPurposes: [2],
+        features: [1],
         specialFeatures: [],
         policyUrl: 'https://www.hypertvx.com/privacy/'
       },
       '702': {
         id: 702,
         name: 'Kwanko',
-        purposes: [
-          1,
-          2,
-          7,
-          8
-        ],
+        purposes: [1, 2, 7, 8],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          7,
-          8
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
+        flexiblePurposes: [2, 7, 8],
+        specialPurposes: [1, 2],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://www.kwanko.com/fr/rgpd/'
       },
       '703': {
         id: 703,
         name: 'MindTake Research GmbH',
-        purposes: [
-          1,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1
-        ],
-        features: [
-          2,
-          3
-        ],
+        specialPurposes: [1],
+        features: [2, 3],
         specialFeatures: [],
         policyUrl: 'https://www.mindtake.com/en/reppublika-privacy-policy'
       },
       '707': {
         id: 707,
         name: 'Dentsu Aegis Network Italia SpA',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
-        policyUrl: 'https://www.dentsuaegisnetwork.com/it/it/policies/info-cookie'
+        specialPurposes: [1],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl:
+          'https://www.dentsuaegisnetwork.com/it/it/policies/info-cookie'
       },
       '708': {
         id: 708,
         name: 'Dugout Limited ',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://dugout.com/privacy-policy'
       },
       '709': {
         id: 709,
         name: 'NC Audience Exchange, LLC (NewsIQ)',
-        purposes: [
-          1,
-          3,
-          4,
-          5
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          8,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
+        purposes: [1, 3, 4, 5],
+        legIntPurposes: [2, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 5, 7, 8, 9, 10],
+        specialPurposes: [2],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://www.ncaudienceexchange.com/privacy/'
       },
       '711': {
         id: 711,
         name: 'SITU8ED SA',
-        purposes: [
-          1,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          10
-        ],
+        purposes: [1, 3, 4, 5, 6, 7, 8, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'https://www.situ8ed.com/privacy-policy/'
       },
       '712': {
         id: 712,
         name: 'Inspired Mobile Limited',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://byinspired.com/privacypolicy.pdf'
       },
       '713': {
         id: 713,
         name: 'Dataseat Ltd',
-        purposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9
-        ],
+        purposes: [2, 3, 4, 5, 6, 7, 8, 9],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          7,
-          8
-        ],
+        flexiblePurposes: [2, 7, 8],
         specialPurposes: [],
-        features: [
-          3
-        ],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://dataseat.com/privacy-policy'
       },
       '714': {
         id: 714,
         name: 'Survata Inc.',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          7,
-          9
-        ],
+        purposes: [1],
+        legIntPurposes: [7, 9],
         flexiblePurposes: [],
         specialPurposes: [],
         features: [],
@@ -18655,82 +13367,34 @@ const VendorList45 = {data: {
       '716': {
         id: 716,
         name: 'OnAudience Ltd',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
-        policyUrl: 'https://www.onaudience.com/internet-advertising-privacy-policy'
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl:
+          'https://www.onaudience.com/internet-advertising-privacy-policy'
       },
       '719': {
         id: 719,
         name: 'Online Advertising Network Sp. z o.o.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.oan.pl/en/privacy-policy'
       },
       '720': {
         id: 720,
         name: 'AAX LLC',
-        purposes: [
-          1,
-          3,
-          4
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          10
-        ],
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
+        specialPurposes: [1, 2],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://aax.media/privacy/',
         overflow: {
@@ -18740,34 +13404,11 @@ const VendorList45 = {data: {
       '721': {
         id: 721,
         name: 'Beaconspark Ltd',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          7
-        ],
-        legIntPurposes: [
-          6,
-          8
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1
-        ],
+        purposes: [1, 2, 3, 4, 5, 7],
+        legIntPurposes: [6, 8],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8],
+        specialPurposes: [1, 2],
+        features: [1],
         specialFeatures: [],
         policyUrl: 'https://www.engageya.com/privacy'
       },
@@ -18775,50 +13416,21 @@ const VendorList45 = {data: {
         id: 722,
         name: 'agof services gmbh',
         purposes: [],
-        legIntPurposes: [
-          3,
-          5,
-          7,
-          8,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          5,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          2
-        ],
+        legIntPurposes: [3, 5, 7, 8, 9, 10],
+        flexiblePurposes: [5, 8, 9, 10],
+        specialPurposes: [1],
+        features: [1, 2, 3],
+        specialFeatures: [2],
         policyUrl: 'http://www.agof.de/datenschutz/'
       },
       '723': {
         id: 723,
         name: 'Adzymic Pte Ltd',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          8
-        ],
+        purposes: [1, 2, 3, 4, 7, 8],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          2
-        ],
+        features: [2],
         specialFeatures: [],
         policyUrl: 'http://www.adzymic.co/privacy',
         overflow: {
@@ -18828,28 +13440,11 @@ const VendorList45 = {data: {
       '725': {
         id: 725,
         name: 'Pubfinity LLC',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          2,
-          3
-        ],
+        specialPurposes: [1, 2],
+        features: [2, 3],
         specialFeatures: [],
         policyUrl: 'https://pubfinity.com/privacy-policy/',
         overflow: {
@@ -18859,80 +13454,31 @@ const VendorList45 = {data: {
       '727': {
         id: 727,
         name: 'Pinpoll GmbH (Private Limited)',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1
-        ],
+        specialPurposes: [1, 2],
+        features: [1],
         specialFeatures: [],
         policyUrl: 'https://www.pinpoll.com/#data_protection_declaration'
       },
       '728': {
         id: 728,
         name: 'Appier PTE Ltd',
-        purposes: [
-          1,
-          3,
-          4,
-          5,
-          6,
-          9
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          8,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        purposes: [1, 3, 4, 5, 6, 9],
+        legIntPurposes: [2, 7, 8, 10],
+        flexiblePurposes: [2, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://www.appier.com/privacy-policy/'
       },
       '729': {
         id: 729,
         name: 'Cavai AS & UK ',
         purposes: [],
-        legIntPurposes: [
-          7,
-          8
-        ],
-        flexiblePurposes: [
-          7,
-          8
-        ],
+        legIntPurposes: [7, 8],
+        flexiblePurposes: [7, 8],
         specialPurposes: [],
         features: [],
         specialFeatures: [],
@@ -18941,15 +13487,9 @@ const VendorList45 = {data: {
       '730': {
         id: 730,
         name: 'INFOnline GmbH',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          8
-        ],
-        flexiblePurposes: [
-          8
-        ],
+        purposes: [1],
+        legIntPurposes: [8],
+        flexiblePurposes: [8],
         specialPurposes: [],
         features: [],
         specialFeatures: [],
@@ -18969,69 +13509,41 @@ const VendorList45 = {data: {
       '733': {
         id: 733,
         name: 'Anzu Virtual reality LTD',
-        purposes: [
-          1,
-          2,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 4, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1,
-          2
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [1, 2],
+        specialFeatures: [1],
         policyUrl: 'https://anzu.io/privacy/'
       },
       '734': {
         id: 734,
         name: 'Cint AB',
-        purposes: [
-          1,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1
-        ],
+        features: [1],
         specialFeatures: [],
         policyUrl: 'https://www.cint.com/participant-privacy-notice'
       },
       '735': {
         id: 735,
         name: 'Deutsche Post AG',
-        purposes: [
-          1,
-          7
-        ],
+        purposes: [1, 7],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1
-        ],
+        features: [1],
         specialFeatures: [],
-        policyUrl: 'https://www.deutschepost.de/de/c/consentric/datenschutz.html'
+        policyUrl:
+          'https://www.deutschepost.de/de/c/consentric/datenschutz.html'
       },
       '737': {
         id: 737,
         name: 'Monet Engine Inc',
-        purposes: [
-          1,
-          2,
-          7
-        ],
+        purposes: [1, 2, 7],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
@@ -19042,44 +13554,18 @@ const VendorList45 = {data: {
       '738': {
         id: 738,
         name: 'adbility media GmbH',
-        purposes: [
-          2,
-          3,
-          4,
-          9
-        ],
-        legIntPurposes: [
-          7
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          9
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        purposes: [2, 3, 4, 9],
+        legIntPurposes: [7],
+        flexiblePurposes: [2, 3, 4, 9],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://www.adbility-media.com/datenschutzerklaerung/'
       },
       '739': {
         id: 739,
         name: 'Blingby LLC',
-        purposes: [
-          1,
-          8,
-          10
-        ],
+        purposes: [1, 8, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
@@ -19090,33 +13576,11 @@ const VendorList45 = {data: {
       '740': {
         id: 740,
         name: '6Sense Insights, Inc.',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          5,
-          7,
-          8,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          7,
-          8,
-          10
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 7, 8, 10],
+        flexiblePurposes: [2, 3, 4, 5, 7, 8, 10],
         specialPurposes: [],
-        features: [
-          1,
-          2,
-          3
-        ],
+        features: [1, 2, 3],
         specialFeatures: [],
         policyUrl: 'https://6sense.com/privacy-policy/',
         overflow: {
@@ -19126,41 +13590,18 @@ const VendorList45 = {data: {
       '741': {
         id: 741,
         name: 'Brand Advance Limited',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        features: [2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://www.wearebrandadvance.com/website-privacy-policy'
       },
       '742': {
         id: 742,
         name: 'Audiencerate LTD',
-        purposes: [
-          1,
-          2,
-          3,
-          5,
-          6
-        ],
+        purposes: [1, 2, 3, 5, 6],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
@@ -19171,28 +13612,12 @@ const VendorList45 = {data: {
       '743': {
         id: 743,
         name: 'MOVIads Sp. z o.o. Sp. k.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [2, 3],
+        specialFeatures: [1],
         policyUrl: 'https://moviads.pl/polityka-prywatnosci/',
         overflow: {
           httpGetLimit: 128
@@ -19201,30 +13626,12 @@ const VendorList45 = {data: {
       '744': {
         id: 744,
         name: 'Vidazoo Ltd',
-        purposes: [
-          3,
-          4
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          8,
-          10
-        ],
-        flexiblePurposes: [
-          3,
-          4
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          2
-        ],
-        specialFeatures: [
-          2
-        ],
+        purposes: [3, 4],
+        legIntPurposes: [2, 7, 8, 10],
+        flexiblePurposes: [3, 4],
+        specialPurposes: [1, 2],
+        features: [2],
+        specialFeatures: [2],
         policyUrl: 'https://vidazoo.gitbook.io/vidazoo-legal/privacy-policy',
         overflow: {
           httpGetLimit: 128
@@ -19233,150 +13640,55 @@ const VendorList45 = {data: {
       '745': {
         id: 745,
         name: 'Justtag Sp. z o.o.',
-        purposes: [
-          1,
-          3,
-          4,
-          9
-        ],
-        legIntPurposes: [
-          7
-        ],
+        purposes: [1, 3, 4, 9],
+        legIntPurposes: [7],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
-        policyUrl: 'https://www.justtag.com/pdf/PRIVACY_POLICY_Koalametrics_english.pdf'
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl:
+          'https://www.justtag.com/pdf/PRIVACY_POLICY_Koalametrics_english.pdf'
       },
       '746': {
         id: 746,
         name: 'Adxperience SAS',
-        purposes: [
-          4
-        ],
-        legIntPurposes: [
-          2,
-          7
-        ],
+        purposes: [4],
+        legIntPurposes: [2, 7],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://adxperience.com/privacy-policy/'
       },
       '747': {
         id: 747,
         name: 'Kairion GmbH',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
         specialPurposes: [],
-        features: [
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        features: [2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://kairion.de/datenschutzbestimmungen/'
       },
       '748': {
         id: 748,
         name: 'AUDIOMOB LTD',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          8,
-          9
-        ],
+        purposes: [1, 2, 3, 4, 7, 8, 9],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          8,
-          9
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2
-        ],
-        specialFeatures: [
-          1
-        ],
+        flexiblePurposes: [2, 3, 4, 7, 8, 9],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [1],
         policyUrl: 'https://www.audiomob.io/privacy'
       },
       '749': {
         id: 749,
         name: 'Good-Loop Ltd',
-        purposes: [
-          1,
-          3,
-          4,
-          5,
-          6
-        ],
-        legIntPurposes: [
-          2,
-          7,
-          8,
-          9,
-          10
-        ],
-        flexiblePurposes: [
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [1, 3, 4, 5, 6],
+        legIntPurposes: [2, 7, 8, 9, 10],
+        flexiblePurposes: [7, 8, 9, 10],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://doc.good-loop.com/policy/privacy-policy.html'
@@ -19384,61 +13696,22 @@ const VendorList45 = {data: {
       '750': {
         id: 750,
         name: 'THE NEWCO S.R.L.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
-        policyUrl: 'https://www.thenewco.it/privacy_policy_servizi_prodotti.html'
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl:
+          'https://www.thenewco.it/privacy_policy_servizi_prodotti.html'
       },
       '751': {
         id: 751,
         name: 'Kiosked Ltd',
         purposes: [],
-        legIntPurposes: [
-          2,
-          7
-        ],
-        flexiblePurposes: [
-          2,
-          7
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        legIntPurposes: [2, 7],
+        flexiblePurposes: [2, 7],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://kiosked.com/privacy-policy/'
@@ -19446,72 +13719,32 @@ const VendorList45 = {data: {
       '753': {
         id: 753,
         name: 'ScaleMonk Inc.',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://www.scalemonk.com/privacy-policy/index.html'
       },
       '754': {
         id: 754,
         name: 'DistroScale, Inc.',
-        purposes: [
-          1,
-          2
-        ],
+        purposes: [1, 2],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2
-        ],
-        specialPurposes: [
-          2
-        ],
-        features: [
-          3
-        ],
+        flexiblePurposes: [2],
+        specialPurposes: [2],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'http://www.distroscale.com/privacy-policy/'
       },
       '757': {
         id: 757,
         name: 'UAB Meazy',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          7,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 7, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://meazy.co/privacy-policy'
@@ -19519,46 +13752,22 @@ const VendorList45 = {data: {
       '758': {
         id: 758,
         name: 'GfK Netherlands B.V.',
-        purposes: [
-          1,
-          7,
-          8,
-          9
-        ],
+        purposes: [1, 7, 8, 9],
         legIntPurposes: [],
-        flexiblePurposes: [
-          7,
-          8,
-          9
-        ],
+        flexiblePurposes: [7, 8, 9],
         specialPurposes: [],
-        features: [
-          1
-        ],
+        features: [1],
         specialFeatures: [],
         policyUrl: 'https://gfkpanel.nl/privacy'
       },
       '759': {
         id: 759,
         name: 'RevJet',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1
-        ],
+        features: [1],
         specialFeatures: [],
         policyUrl: 'https://www.revjet.com/privacy',
         overflow: {
@@ -19568,95 +13777,43 @@ const VendorList45 = {data: {
       '760': {
         id: 760,
         name: 'VEXPRO TECHNOLOGIES LTD',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          2
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [2],
         policyUrl: 'https://onedash.com/privacy-policy.html'
       },
       '761': {
         id: 761,
         name: 'Digiseg ApS',
-        purposes: [
-          1,
-          3,
-          5,
-          7,
-          8,
-          9
-        ],
+        purposes: [1, 3, 5, 7, 8, 9],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          1
-        ],
+        features: [1],
         specialFeatures: [],
         policyUrl: 'https://digiseg.io/privacy-center/'
       },
       '762': {
         id: 762,
         name: 'Protected Media LTD',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          3,
-          5,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1],
+        legIntPurposes: [3, 5, 7, 8, 9, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1
-        ],
-        features: [
-          3
-        ],
+        specialPurposes: [1],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://www.protected.media/privacy-policy/'
       },
       '764': {
         id: 764,
         name: 'Lucidity',
-        purposes: [
-          1,
-          2,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 2, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://golucidity.com/privacy-policy/'
@@ -19664,38 +13821,20 @@ const VendorList45 = {data: {
       '765': {
         id: 765,
         name: 'Grabit Interactive Media Inc dba KERV Interctive',
-        purposes: [
-          2,
-          3,
-          4,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [2, 3, 4, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          2
-        ],
+        specialPurposes: [1, 2],
+        features: [2],
         specialFeatures: [],
         policyUrl: 'https://kervit.com/privacy-policy/'
       },
       '766': {
         id: 766,
         name: 'ADCELL | Firstlead GmbH',
-        purposes: [
-          1,
-          2
-        ],
+        purposes: [1, 2],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2
-        ],
+        flexiblePurposes: [2],
         specialPurposes: [],
         features: [],
         specialFeatures: [],
@@ -19704,39 +13843,18 @@ const VendorList45 = {data: {
       '768': {
         id: 768,
         name: 'Global Media & Entertainment Limited',
-        purposes: [
-          1,
-          2,
-          3,
-          4,
-          7,
-          9,
-          10
-        ],
+        purposes: [1, 2, 3, 4, 7, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
         policyUrl: 'http://global.com/privacy-policy/'
       },
       '769': {
         id: 769,
         name: 'MEDIAMETRIE',
-        purposes: [
-          1,
-          8
-        ],
+        purposes: [1, 8],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
@@ -19747,94 +13865,45 @@ const VendorList45 = {data: {
       '770': {
         id: 770,
         name: 'MARKETPERF CORP',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          10
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          5,
-          6
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          1,
-          2,
-          3
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
         specialFeatures: [],
-        policyUrl: 'https://www.marketperf.com/assets/images/app/marketperf/pdf/privacy-policy.pdf'
+        policyUrl:
+          'https://www.marketperf.com/assets/images/app/marketperf/pdf/privacy-policy.pdf'
       },
       '771': {
         id: 771,
         name: 'bam! interactive marketing GmbH ',
-        purposes: [
-          1,
-          7,
-          8,
-          9,
-          10
-        ],
+        purposes: [1, 7, 8, 9, 10],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1,
-          2
-        ],
+        features: [3],
+        specialFeatures: [1, 2],
         policyUrl: 'https://bam-interactive.de/privacy-policy/'
       },
       '772': {
         id: 772,
         name: 'Oracle Data Cloud - Moat',
         purposes: [],
-        legIntPurposes: [
-          7,
-          8,
-          10
-        ],
+        legIntPurposes: [7, 8, 10],
         flexiblePurposes: [],
-        specialPurposes: [
-          1
-        ],
+        specialPurposes: [1],
         features: [],
         specialFeatures: [],
-        policyUrl: 'https://www.oracle.com/legal/privacy/services-privacy-policy.html'
+        policyUrl:
+          'https://www.oracle.com/legal/privacy/services-privacy-policy.html'
       },
       '774': {
         id: 774,
         name: 'Wagawin GmbH',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          7
-        ],
-        flexiblePurposes: [
-          2
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 7],
+        flexiblePurposes: [2],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://www.wagawin.com/privacy-en/#productprivacy'
@@ -19842,32 +13911,20 @@ const VendorList45 = {data: {
       '775': {
         id: 775,
         name: 'SelectMedia International LTD',
-        purposes: [
-          1,
-          2
-        ],
+        purposes: [1, 2],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          1,
-          2
-        ],
-        features: [
-          3
-        ],
+        specialPurposes: [1, 2],
+        features: [3],
         specialFeatures: [],
         policyUrl: 'https://www.selectmedia.asia/terms-and-privacy/'
       },
       '776': {
         id: 776,
         name: 'Mars Media Group',
-        purposes: [
-          2
-        ],
+        purposes: [2],
         legIntPurposes: [],
-        flexiblePurposes: [
-          2
-        ],
+        flexiblePurposes: [2],
         specialPurposes: [],
         features: [],
         specialFeatures: [],
@@ -19876,25 +13933,10 @@ const VendorList45 = {data: {
       '777': {
         id: 777,
         name: 'One Planet Only',
-        purposes: [
-          1
-        ],
-        legIntPurposes: [
-          2,
-          3,
-          4,
-          7
-        ],
-        flexiblePurposes: [
-          2,
-          3,
-          4,
-          7
-        ],
-        specialPurposes: [
-          1,
-          2
-        ],
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7],
+        flexiblePurposes: [2, 3, 4, 7],
+        specialPurposes: [1, 2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://oneplanetonly.com/files/PRIVACY%20POLICY.pdf',
@@ -19905,11500 +13947,5316 @@ const VendorList45 = {data: {
       '778': {
         id: 778,
         name: 'Discover-Tech ltd',
-        purposes: [
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9
-        ],
+        purposes: [2, 3, 4, 5, 6, 7, 8, 9],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
         features: [],
-        specialFeatures: [
-          1
-        ],
+        specialFeatures: [1],
         policyUrl: 'https://discover-tech.io/dsp-privacy-policy/'
       },
       '779': {
         id: 779,
         name: 'Adtarget Medya A.S.',
-        purposes: [
-          1,
-          7
-        ],
+        purposes: [1, 7],
         legIntPurposes: [],
         flexiblePurposes: [],
         specialPurposes: [],
-        features: [
-          3
-        ],
-        specialFeatures: [
-          1
-        ],
+        features: [3],
+        specialFeatures: [1],
         policyUrl: 'https://adtarget.com.tr/adtarget-privacy-policy-2020.pdf'
       },
       '780': {
         id: 780,
         name: 'Aniview LTD',
-        purposes: [
-          1,
-          2,
-          7,
-          8
-        ],
+        purposes: [1, 2, 7, 8],
         legIntPurposes: [],
         flexiblePurposes: [],
-        specialPurposes: [
-          2
-        ],
+        specialPurposes: [2],
         features: [],
         specialFeatures: [],
         policyUrl: 'https://www.aniview.com/privacy-policy/'
       }
     }
-  }}
+  }
+}
 
-const VendorList46 = {data:{
-  gvlSpecificationVersion: 2,
-  vendorListVersion: 46,
-  tcfPolicyVersion: 2,
-  lastUpdated: '2020-07-09T16:05:42Z',
-  purposes: {
-    '1': {
-      id: 1,
-      name: 'Almacenar o acceder a información en un dispositivo',
-      description: 'Se puede almacenar o acceder a cookies, identificadores de dispositivo u otra información en su dispositivo para las finalidades que se le presentan.',
-      descriptionLegal: 'Los proveedores pueden:\n* Almacenar y/o acceder a información en el dispositivo a través de cookies e identificadores de dispositivo ejecutados/instalados en el equipo del usuario.'
-    },
-    '2': {
-      id: 2,
-      name: 'Seleccionar anuncios básicos',
-      description: 'Los anuncios se pueden mostrar en función del contenido que se esté visualizando, la aplicación que se esté utilizando, su localización aproximada o su tipo de dispositivo.',
-      descriptionLegal: 'Para realizar la selección de anuncios básicos, los proveedores pueden:\n* Utilizar información en tiempo real sobre el contexto en el que se mostrará el anuncio, para mostrar el anuncio, incluida la información sobre el contenido y el dispositivo, como por ejemplo: tipo de dispositivo y sus funcionalidades, agente de usuario, URL, dirección IP \n* Utilizar los datos de localización geográfica de aproximada\n* Controlar la frecuencia con la que se muestran los anuncios a un usuario.\n* Secuenciar el orden en el que se muestran los anuncios a un usuario.\n* Evitar que un anuncio se sirva o envíe en un contexto editorial inadecuado (Brand safety)\nLos Proveedores no pueden:\n* Crear un perfil publicitario personalizado utilizando esta información para la selección de anuncios futuros sin una base jurídica separada cuya finalidad específica fuera crear un perfil publicitario personalizados.\nNota: Aproximada significa que se permite solamente una localización aproximada de, como máximo, dentro de un radio de 500 metros.\n'
-    },
-    '3': {
-      id: 3,
-      name: 'Crear un perfil publicitario personalizado',
-      description: 'Se puede elaborar un perfil sobre usted y sus intereses para mostrarle anuncios personalizados que sean pertinentes para usted.',
-      descriptionLegal: 'Para crear un perfil publicitario personalizado, los proveedores pueden:\n* Recoger información sobre un usuario, (incluyendo la actividad anterior del usuario, sus intereses, páginas web o aplicaciones visitadas con anterioridad, ubicación o información demográfica) a fin de crear o editar un perfil de usuario para su uso en publicidad personalizada.\n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones, a fin de crear o editar un perfil de usuario para su uso en publicidad personalizada\n'
-    },
-    '4': {
-      id: 4,
-      name: 'Seleccionar anuncios personalizados',
-      description: 'Se pueden mostrar anuncios personalizados basándose en su perfil.',
-      descriptionLegal: 'Para seleccionar anuncios personalizados, los proveedores pueden:\n* Seleccionar anuncios personalizados basándose en un perfil de usuario u otros datos históricos del usuario, incluida la actividad anterior de un usuario, sus intereses, visitas a sitios web o aplicaciones, ubicación o información demográfica.\n'
-    },
-    '5': {
-      id: 5,
-      name: 'Crear un perfil para la personalización de contenidos',
-      description: 'Se puede crear un perfil sobre usted y sus intereses para mostrarle contenido personalizado que le fuera pertinente.',
-      descriptionLegal: 'Para crear un un perfil para la personalización de contenidos, los proveedores pueden:\n* Recoger información sobre un usuario, incluida la actividad de un usuario, sus intereses, visitas a sitios o aplicaciones, información demográfica o ubicación, a fin de crear o editar un perfil de usuario para personalizar el contenido.\n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones, a fin de crear o editar un perfil de usuario para personalizar el contenido.\n'
-    },
-    '6': {
-      id: 6,
-      name: 'Seleccionar contenido personalizado',
-      description: 'Se puede mostrar contenido personalizado basado en su perfil.',
-      descriptionLegal: 'Para seleccionar contenido personalizado, los proveedores pueden:\n* Seleccionar contenido personalizado basándose en un perfil de usuario u otros datos históricos de usuarios, incluida la actividad anterior del usuario, sus intereses, visitas a sitios web o aplicaciones, ubicación o información demográfica.'
-    },
-    '7': {
-      id: 7,
-      name: 'Medir el rendimiento de los anuncios',
-      description: 'Se puede medir el rendimiento y eficacia de los anuncios que usted ve o con los que interactúa.',
-      descriptionLegal: 'Para medir el rendimiento de los anuncios, los proveedores pueden:\n* Medir si los anuncios fueron suministrados a un usuario y cómo este interactuó con ellos\n* Elaborar informes sobre anuncios, incluida su eficacia y rendimiento\n* Elaborar informes sobre los usuarios que interactuaron con los anuncios utilizando datos observados durante el curso de la interacción del usuario con ese anuncio\n* Elaborar informes para los editores sobre los anuncios mostrados en sus sitios web o propiedad digital\n* Medir si un anuncio sirve en un contexto editorial adecuado (seguro para la marca)\n* Determinar el porcentaje del anuncio que se tuvo la oportunidad de ser visto y la duración de esa oportunidad \n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones.\nLos proveedores no pueden:\n* Aplicar datos de información sobre el público basados en un panel de usuarios o similares a los datos de medición de anuncios sin una base jurídica independiente para utilizar estudios de mercado a fin de generar información sobre el público.\n'
-    },
-    '8': {
-      id: 8,
-      name: 'Medir el rendimiento del contenido',
-      description: 'Se puede medir el rendimiento y la eficacia del contenido que ve o con el que interactúa.',
-      descriptionLegal: 'Para medir el rendimiento del contenido, los proveedores pueden:\n* Medir e informar sobre cómo se entregó el contenido y cómo interactuaron con él los usuarios.\n* Elaborar informes, utilizando información directamente medible o conocida, sobre los usuarios que interactuaron con el contenido\n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones.\nLos proveedores no pueden:\n* Medir si los anuncios (incluida la publicidad nativa) fueron suministrados a un usuario y si este interactuó con ellos sin tener una base jurídica alternativa que lo permita.\n* Aplicar datos de información sobre el público, basados en un panel de usuarios o similares, a los datos de medición de anuncios sin una base jurídica independiente para utilizar estudios de mercado a fin de generar información sobre el público.\n'
-    },
-    '9': {
-      id: 9,
-      name: 'Utilizar estudios de mercado a fin de generar información sobre el público',
-      description: 'La investigación de mercado puede utilizarse para obtener más información sobre el público que visita sitios webs/aplicaciones y visualiza los anuncios.',
-      descriptionLegal: 'Para utilizar estudios de mercado a fin de generar información sobre el público, los proveedores pueden:\n* Elaborar informes agregados para los anunciantes o sus representantes sobre el público alcanzado por sus anuncios, a través de información basada en paneles de audiencia u obtenida de manera similar.\n* Elaborar informes agregados para los editores sobre el público al que se le mostraron contenidos y/o anuncios o que interactuaron con ellos en su propiedad, aplicando información basada en paneles de audiencia u obtenida de manera similar\n* Asociar datos off line con un usuario on line para finalidades de estudios de mercado a fin de generar información sobre el público si los proveedores han declarado que cotejan y combinan fuentes de datos off line \n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones.\nLos proveedores no pueden: \n* Medir el rendimiento y la eficacia de los anuncios que se mostraron a un usuario específico o con los que interactuó, sin una base jurídica independiente para medir el rendimiento de los anuncios.\n• Medir qué contenido se mostró a un usuario específico y cómo interactuó con el mismo, sin una base jurídica independiente para medir el rendimiento del contenido.\n'
-    },
-    '10': {
-      id: 10,
-      name: 'Desarrollar y mejorar productos',
-      description: 'Sus datos pueden utilizarse para mejorar los sistemas y/o el software existente, así como para desarrollar nuevos productos.',
-      descriptionLegal: 'Para desarrollar nuevos productos y mejorar los productos, los proveedores pueden:\n* Utilizar información para mejorar sus productos existentes con nuevas funcionalidades/características y desarrollar nuevos productos\n* Crear nuevos modelos y algoritmos mediante machine learning\nLos proveedores no pueden:\n* A partir de esta finalidad no se puede llevar a cabo ninguna otra operación de tratamiento de datos permitida en virtud de una finalidad distinta.\n'
-    }
-  },
-  specialPurposes: {
-    '1': {
-      id: 1,
-      name: 'Garantizar la seguridad, evitar fraudes y depurar errores',
-      description: 'Sus datos pueden utilizarse para supervisar y evitar actividades fraudulentas, y para asegurar que los sistemas y procesos funcionen de forma correcta y segura.',
-      descriptionLegal: 'Para garantizar la seguridad, evitar fraudes y depurar errores, los proveedores pueden:\n* Asegurarse de que los datos se transmitan de forma segura \n* Detectar y evitar actividades maliciosas, fraudulentas, inaceptables o ilegales.\n* Asegurar el funcionamiento correcto y eficaz de los sistemas y procesos, lo que incluye supervisar y mejorar el rendimiento de los sistemas y procesos empleados en las finalidades permitidas\nLos proveedores no pueden:\n* Llevar a cabo ninguna otra operación de tratamiento de datos permitida en virtud de una finalidad distinta.\nNota: Los datos recopilados y utilizados para garantizar la seguridad, evitar el fraude y depurar errores pueden incluir características del dispositivo enviadas automáticamente para su identificación, datos de geolocalización precisos y datos obtenidos analizando de forma activa las características del dispositivo para su identificación sin que sea necesario revelar más información y/o una aceptación independiente.  \n'
-    },
-    '2': {
-      id: 2,
-      name: 'Servir técnicamente anuncios o contenido',
-      description: 'Su dispositivo puede recibir y enviar información que le permita ver e interactuar con anuncios y contenido.',
-      descriptionLegal: 'Para servir información y responder a solicitudes técnicas, los proveedores pueden:\n* Utilizar la dirección IP de un usuario para entregar un anuncio a través de Internet\n* Responder a la interacción de un usuario con un anuncio enviando al usuario a una página de destino\n* Utilizar la dirección IP de un usuario para entregar contenido a través de Internet\n* Responder a la interacción de un usuario con el contenido enviando al usuario a una página de destino\n* Utilizar información sobre el tipo de dispositivo y sus capacidades para entregar anuncios o contenido, por ejemplo, para entregar el archivo publicitario o de vídeo de tamaño adecuado en un formato compatible con el dispositivo\nLos proveedores no pueden:\n* Llevar a cabo, según esta finalidad, ninguna otra operación de tratamiento de datos permitida en virtud de una finalidad distinta.\n'
-    }
-  },
-  features: {
-    '1': {
-      id: 1,
-      name: 'Cotejar y combinar fuentes de datos off line',
-      description: 'Los datos obtenidos de fuentes de datos off line pueden combinarse con su actividad on line para respaldar una o más finalidades.',
-      descriptionLegal: 'Los proveedores pueden: \n* Combinar los datos obtenidos off line con los datos recogidos on line en apoyo de una o más Finalidades o Finalidades especiales.'
-    },
-    '2': {
-      id: 2,
-      name: 'Vincular diferentes dispositivos',
-      description: 'Se puede determinar que diferentes dispositivos pertenecen a usted o a su hogar para una o más finalidades.',
-      descriptionLegal: 'Los proveedores pueden:\n* Determinar de forma determinista que dos o más dispositivos pertenecen al mismo usuario u hogar\n* Determinar de forma probabilística que dos o más dispositivos pertenecen al mismo usuario u hogar\n* Analizar activamente las características del dispositivo para encontrar su identificación probabilística si los usuarios han permitido a los proveedores analizar activamente las características del dispositivo para su identificación (Funcionalidad especial 2)\n'
-    },
-    '3': {
-      id: 3,
-      name: 'Recibir y utilizar para su identificación las características del dispositivo que    se envían automáticamente',
-      description: 'Su dispositivo puede distinguirse de otros dispositivos a partir de la información que envía automáticamente, como la dirección IP o el tipo de navegador.',
-      descriptionLegal: 'Los proveedores pueden:\n* Crear un identificador utilizando los datos recopilados automáticamente en un dispositivo para características específicas, por ejemplo, dirección IP o la cadena de agente de usuario.\n* Utilizar este identificador para intentar volver a identificar un dispositivo.\nLos proveedores no pueden:\n* Crear un identificador utilizando datos recogidos mediante el análisis activo de un dispositivo para hallar funcionalidads específicas, por ejemplo, fuentes instaladas o resolución de pantalla sin aceptación independiente del usuario para analizar de forma activa las características del dispositivo para su identificación.\n* Utilizar este identificador para volver a identificar un dispositivo.\n'
-    }
-  },
-  specialFeatures: {
-    '1': {
-      id: 1,
-      name: 'Utilizar datos de localización geográfica precisa',
-      description: 'Sus datos de localización geográfica precisa se pueden utilizar para una o más finalidades. Esto significa que su ubicación puede tener una precisión de varios metros.',
-      descriptionLegal: 'Los proveedores pueden:\n* Recoger y tratar datos de localización geográfica precisa para una o más finalidades.\nNota: La localización geográfica precisa significa que no existen restricciones sobre la precisión de la ubicación de un usuario; esto puede tener una precisión de varios metros.\n'
-    },
-    '2': {
-      id: 2,
-      name: 'Analizar activamente las características del dispositivo para su identificación',
-      description: 'Su dispositivo puede identificarse basándose en un análisis de la combinación única de las características de su dispositivo.',
-      descriptionLegal: 'Los proveedores pueden:\n* Crear un identificador utilizando datos recogidos mediante el análisis activo de un dispositivo para hallar características específicas, por ejemplo, fuentes instaladas o resolución de pantalla. \n* Utilizar este identificador para volver a identificar un dispositivo.\n'
-    }
-  },
-  stacks: {
-    '1': {
-      id: 1,
-      purposes: [],
-      specialFeatures: [
-        1,
-        2
-      ],
-      name: 'Datos de localización geográfica precisa e identificación mediante las características de dispositivos',
-      description: 'Se puede utilizar la localización geográfica precisa y la información sobre las características del dispositivo.'
-    },
-    '2': {
-      id: 2,
-      purposes: [
-        2,
-        7
-      ],
-      specialFeatures: [],
-      name: 'Anuncios básicos y medición de anuncios',
-      description: 'Se pueden mostrar anuncios básicos. Se puede medir el rendimiento de los anuncios.'
-    },
-    '3': {
-      id: 3,
-      purposes: [
-        2,
-        3,
-        4
-      ],
-      specialFeatures: [],
-      name: 'Anuncios personalizados',
-      description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios.'
-    },
-    '4': {
-      id: 4,
-      purposes: [
-        2,
-        7,
-        9
-      ],
-      specialFeatures: [],
-      name: 'Anuncios básicos y medición de anuncios',
-      description: 'Se pueden mostrar anuncios básicos. Se puede medir el rendimiento de los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
-    },
-    '5': {
-      id: 5,
-      purposes: [
-        2,
-        3,
-        7
-      ],
-      specialFeatures: [],
-      name: 'Anuncios básicos, creación de perfil publicitario personalizado y medición de anuncios',
-      description: 'Se pueden mostrar anuncios básicos. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios.'
-    },
-    '6': {
-      id: 6,
-      purposes: [
-        2,
-        4,
-        7
-      ],
-      specialFeatures: [],
-      name: 'Mostrar anuncios personalizados y medición de anuncios',
-      description: 'Los anuncios pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios.'
-    },
-    '7': {
-      id: 7,
-      purposes: [
-        2,
-        4,
-        7,
-        9
-      ],
-      specialFeatures: [],
-      name: 'Mostrar anuncios personalizados, medición de anuncios e información sobre el público',
-      description: 'Los anuncios pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
-    },
-    '8': {
-      id: 8,
-      purposes: [
-        2,
-        3,
-        4,
-        7
-      ],
-      specialFeatures: [],
-      name: 'Anuncios personalizados y medición de anuncios',
-      description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios.'
-    },
-    '9': {
-      id: 9,
-      purposes: [
-        2,
-        3,
-        4,
-        7,
-        9
-      ],
-      specialFeatures: [],
-      name: 'Anuncios personalizados, medición de anuncios e información sobre el público',
-      description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
-    },
-    '10': {
-      id: 10,
-      purposes: [
-        3,
-        4
-      ],
-      specialFeatures: [],
-      name: 'Perfil y muestra de anuncios personalizados',
-      description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios.'
-    },
-    '11': {
-      id: 11,
-      purposes: [
-        5,
-        6
-      ],
-      specialFeatures: [],
-      name: 'Contenido personalizado',
-      description: 'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido.'
-    },
-    '12': {
-      id: 12,
-      purposes: [
-        6,
-        8
-      ],
-      specialFeatures: [],
-      name: 'Muestra de contenido personalizado y medición de contenido',
-      description: 'El contenido puede personalizarse basándose en un perfil. Se puede medir el rendimiento del contenido.'
-    },
-    '13': {
-      id: 13,
-      purposes: [
-        6,
-        8,
-        9
-      ],
-      specialFeatures: [],
-      name: 'Presentación de contenido personalizado, medición del contenido e información sobre el público',
-      description: 'El contenido puede personalizarse basándose en un perfil. Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
-    },
-    '14': {
-      id: 14,
-      purposes: [
-        5,
-        6,
-        8
-      ],
-      specialFeatures: [],
-      name: 'Contenido personalizado y medición del contenido',
-      description: 'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido.'
-    },
-    '15': {
-      id: 15,
-      purposes: [
-        5,
-        6,
-        8,
-        9
-      ],
-      specialFeatures: [],
-      name: 'Contenido personalizado, medición del contenido e información sobre el público',
-      description: 'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
-    },
-    '16': {
-      id: 16,
-      purposes: [
-        5,
-        6,
-        8,
-        9,
-        10
-      ],
-      specialFeatures: [],
-      name: 'Contenido personalizado, medición del contenido, información sobre el público y desarrollo de productos',
-      description: 'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido. Se puede inducir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software'
-    },
-    '17': {
-      id: 17,
-      purposes: [
-        7,
-        8,
-        9
-      ],
-      specialFeatures: [],
-      name: 'Medición de anuncios y del contenido e información sobre el público',
-      description: 'Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
-    },
-    '18': {
-      id: 18,
-      purposes: [
-        7,
-        8
-      ],
-      specialFeatures: [],
-      name: 'Medición de anuncios y del contenido',
-      description: 'Se puede medir el rendimiento de los anuncios y del contenido.'
-    },
-    '19': {
-      id: 19,
-      purposes: [
-        7,
-        9
-      ],
-      specialFeatures: [],
-      name: 'Medición de anuncios e información sobre el público',
-      description: 'Se pueden medir los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
-    },
-    '20': {
-      id: 20,
-      purposes: [
-        7,
-        8,
-        9,
-        10
-      ],
-      specialFeatures: [],
-      name: 'Medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
-      description: 'Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
-    },
-    '21': {
-      id: 21,
-      purposes: [
-        8,
-        9,
-        10
-      ],
-      specialFeatures: [],
-      name: 'Medición del contenido, información sobre el público y desarrollo de productos.',
-      description: 'Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
-    },
-    '22': {
-      id: 22,
-      purposes: [
-        8,
-        10
-      ],
-      specialFeatures: [],
-      name: 'Medición del contenido y desarrollo de productos',
-      description: 'Se puede medir el rendimiento del contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
-    },
-    '23': {
-      id: 23,
-      purposes: [
-        2,
-        4,
-        6,
-        7,
-        8
-      ],
-      specialFeatures: [],
-      name: 'Presentación de anuncios y contenido personalizados, medición de anuncios y del contenido',
-      description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios y del contenido.'
-    },
-    '24': {
-      id: 24,
-      purposes: [
-        2,
-        4,
-        6,
-        7,
-        8,
-        9
-      ],
-      specialFeatures: [],
-      name: 'Presentación de anuncios y contenido personalizados, medición de anuncios y del contenido e información sobre el público',
-      description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
-    },
-    '25': {
-      id: 25,
-      purposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8
-      ],
-      specialFeatures: [],
-      name: 'Anuncios y contenido personalizados, medición de anuncios y del contenido',
-      description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios y el contenido. Se puede medir el rendimiento de los anuncios y del contenido.'
-    },
-    '26': {
-      id: 26,
-      purposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9
-      ],
-      specialFeatures: [],
-      name: 'Anuncios y contenido personalizados, medición de anuncios y del contenido e información sobre el público',
-      description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios y el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
-    },
-    '27': {
-      id: 27,
-      purposes: [
-        3,
-        5
-      ],
-      specialFeatures: [],
-      name: 'Anuncios personalizados y contenido personalizado',
-      description: 'Se pueden añadir más datos para personalizar los anuncios y el contenido.'
-    },
-    '28': {
-      id: 28,
-      purposes: [
-        2,
-        4,
-        6
-      ],
-      specialFeatures: [],
-      name: 'Muestra de anuncios y contenido personalizados',
-      description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil.'
-    },
-    '29': {
-      id: 29,
-      purposes: [
-        2,
-        7,
-        8,
-        9
-      ],
-      specialFeatures: [],
-      name: 'Anuncios básicos, medición de anuncios y del contenido e información sobre el público',
-      description: 'Se pueden mostrar anuncios básicos. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
-    },
-    '30': {
-      id: 30,
-      purposes: [
-        2,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9
-      ],
-      specialFeatures: [],
-      name: 'Muestra de anuncios personalizados, contenido personalizado, medición de anuncios y del contenido e información sobre el público',
-      description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
-    },
-    '31': {
-      id: 31,
-      purposes: [
-        2,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialFeatures: [],
-      name: 'Muestra de anuncios personalizados, contenido personalizado, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
-      description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
-    },
-    '32': {
-      id: 32,
-      purposes: [
-        2,
-        5,
-        6,
-        7,
-        8,
-        9
-      ],
-      specialFeatures: [],
-      name: 'Anuncios básicos, contenido personalizado, medición de anuncios y del contenido e información sobre el público',
-      description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
-    },
-    '33': {
-      id: 33,
-      purposes: [
-        2,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialFeatures: [],
-      name: 'Anuncios básicos, contenido personalizado, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
-      description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
-    },
-    '34': {
-      id: 34,
-      purposes: [
-        2,
-        5,
-        6,
-        8,
-        9
-      ],
-      specialFeatures: [],
-      name: 'Anuncios básicos, contenido personalizado, medición del contenido e información sobre el público',
-      description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
-    },
-    '35': {
-      id: 35,
-      purposes: [
-        2,
-        5,
-        6,
-        8,
-        9,
-        10
-      ],
-      specialFeatures: [],
-      name: 'Anuncios básicos, contenido personalizado, medición del contenido, información sobre el público y desarrollo de productos',
-      description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
-    },
-    '36': {
-      id: 36,
-      purposes: [
-        2,
-        5,
-        6,
-        7
-      ],
-      specialFeatures: [],
-      name: 'Anuncios básicos, contenido personalizado y medición de anuncios',
-      description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios.'
-    },
-    '37': {
-      id: 37,
-      purposes: [
-        2,
-        5,
-        6,
-        7,
-        10
-      ],
-      specialFeatures: [],
-      name: 'Anuncios básicos, contenido personalizado, medición de anuncios y desarrollo de productos',
-      description: 'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
-    },
-    '38': {
-      id: 38,
-      purposes: [
-        2,
-        3,
-        4,
-        7,
-        10
-      ],
-      specialFeatures: [],
-      name: 'Anuncios personalizados, medición de anuncios y desarrollo de productos',
-      description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
-    },
-    '39': {
-      id: 39,
-      purposes: [
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      specialFeatures: [],
-      name: 'Anuncios personalizados, medición de anuncios, información sobre el público y desarrollo de productos',
-      description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
-    },
-    '40': {
-      id: 40,
-      purposes: [
-        2,
-        3,
-        4,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialFeatures: [],
-      name: 'Anuncios personalizados, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
-      description: 'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios y del contenido. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
-    },
-    '41': {
-      id: 41,
-      purposes: [
-        2,
-        3,
-        4,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialFeatures: [],
-      name: 'Anuncios personalizados, muestra de contenido personalizado, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
-      description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios y del contenido. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
-    },
-    '42': {
-      id: 42,
-      purposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialFeatures: [],
-      name: 'Anuncios y contenido personalizados, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
-      description: 'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios y el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
-    }
-  },
-  vendors: {
-    '1': {
-      id: 1,
-      name: 'Exponential Interactive, Inc d/b/a VDX.tv',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://vdx.tv/privacy/'
-    },
-    '2': {
-      id: 2,
-      name: 'Captify Technologies Limited',
-      purposes: [
-        1,
-        2,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        7,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2
-      ],
-      specialPurposes: [],
-      features: [
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'http://www.captify.co.uk/privacy-policy/'
-    },
-    '4': {
-      id: 4,
-      name: 'Roq.ad Inc.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.roq.ad/privacy-policy'
-    },
-    '6': {
-      id: 6,
-      name: 'AdSpirit GmbH',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        9
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'http://www.adspirit.de/privacy',
-      overflow: {
-        httpGetLimit: 32
+const VendorList46 = {
+  data: {
+    gvlSpecificationVersion: 2,
+    vendorListVersion: 46,
+    tcfPolicyVersion: 2,
+    lastUpdated: '2020-07-09T16:05:42Z',
+    purposes: {
+      '1': {
+        id: 1,
+        name: 'Almacenar o acceder a información en un dispositivo',
+        description:
+          'Se puede almacenar o acceder a cookies, identificadores de dispositivo u otra información en su dispositivo para las finalidades que se le presentan.',
+        descriptionLegal:
+          'Los proveedores pueden:\n* Almacenar y/o acceder a información en el dispositivo a través de cookies e identificadores de dispositivo ejecutados/instalados en el equipo del usuario.'
+      },
+      '2': {
+        id: 2,
+        name: 'Seleccionar anuncios básicos',
+        description:
+          'Los anuncios se pueden mostrar en función del contenido que se esté visualizando, la aplicación que se esté utilizando, su localización aproximada o su tipo de dispositivo.',
+        descriptionLegal:
+          'Para realizar la selección de anuncios básicos, los proveedores pueden:\n* Utilizar información en tiempo real sobre el contexto en el que se mostrará el anuncio, para mostrar el anuncio, incluida la información sobre el contenido y el dispositivo, como por ejemplo: tipo de dispositivo y sus funcionalidades, agente de usuario, URL, dirección IP \n* Utilizar los datos de localización geográfica de aproximada\n* Controlar la frecuencia con la que se muestran los anuncios a un usuario.\n* Secuenciar el orden en el que se muestran los anuncios a un usuario.\n* Evitar que un anuncio se sirva o envíe en un contexto editorial inadecuado (Brand safety)\nLos Proveedores no pueden:\n* Crear un perfil publicitario personalizado utilizando esta información para la selección de anuncios futuros sin una base jurídica separada cuya finalidad específica fuera crear un perfil publicitario personalizados.\nNota: Aproximada significa que se permite solamente una localización aproximada de, como máximo, dentro de un radio de 500 metros.\n'
+      },
+      '3': {
+        id: 3,
+        name: 'Crear un perfil publicitario personalizado',
+        description:
+          'Se puede elaborar un perfil sobre usted y sus intereses para mostrarle anuncios personalizados que sean pertinentes para usted.',
+        descriptionLegal:
+          'Para crear un perfil publicitario personalizado, los proveedores pueden:\n* Recoger información sobre un usuario, (incluyendo la actividad anterior del usuario, sus intereses, páginas web o aplicaciones visitadas con anterioridad, ubicación o información demográfica) a fin de crear o editar un perfil de usuario para su uso en publicidad personalizada.\n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones, a fin de crear o editar un perfil de usuario para su uso en publicidad personalizada\n'
+      },
+      '4': {
+        id: 4,
+        name: 'Seleccionar anuncios personalizados',
+        description:
+          'Se pueden mostrar anuncios personalizados basándose en su perfil.',
+        descriptionLegal:
+          'Para seleccionar anuncios personalizados, los proveedores pueden:\n* Seleccionar anuncios personalizados basándose en un perfil de usuario u otros datos históricos del usuario, incluida la actividad anterior de un usuario, sus intereses, visitas a sitios web o aplicaciones, ubicación o información demográfica.\n'
+      },
+      '5': {
+        id: 5,
+        name: 'Crear un perfil para la personalización de contenidos',
+        description:
+          'Se puede crear un perfil sobre usted y sus intereses para mostrarle contenido personalizado que le fuera pertinente.',
+        descriptionLegal:
+          'Para crear un un perfil para la personalización de contenidos, los proveedores pueden:\n* Recoger información sobre un usuario, incluida la actividad de un usuario, sus intereses, visitas a sitios o aplicaciones, información demográfica o ubicación, a fin de crear o editar un perfil de usuario para personalizar el contenido.\n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones, a fin de crear o editar un perfil de usuario para personalizar el contenido.\n'
+      },
+      '6': {
+        id: 6,
+        name: 'Seleccionar contenido personalizado',
+        description:
+          'Se puede mostrar contenido personalizado basado en su perfil.',
+        descriptionLegal:
+          'Para seleccionar contenido personalizado, los proveedores pueden:\n* Seleccionar contenido personalizado basándose en un perfil de usuario u otros datos históricos de usuarios, incluida la actividad anterior del usuario, sus intereses, visitas a sitios web o aplicaciones, ubicación o información demográfica.'
+      },
+      '7': {
+        id: 7,
+        name: 'Medir el rendimiento de los anuncios',
+        description:
+          'Se puede medir el rendimiento y eficacia de los anuncios que usted ve o con los que interactúa.',
+        descriptionLegal:
+          'Para medir el rendimiento de los anuncios, los proveedores pueden:\n* Medir si los anuncios fueron suministrados a un usuario y cómo este interactuó con ellos\n* Elaborar informes sobre anuncios, incluida su eficacia y rendimiento\n* Elaborar informes sobre los usuarios que interactuaron con los anuncios utilizando datos observados durante el curso de la interacción del usuario con ese anuncio\n* Elaborar informes para los editores sobre los anuncios mostrados en sus sitios web o propiedad digital\n* Medir si un anuncio sirve en un contexto editorial adecuado (seguro para la marca)\n* Determinar el porcentaje del anuncio que se tuvo la oportunidad de ser visto y la duración de esa oportunidad \n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones.\nLos proveedores no pueden:\n* Aplicar datos de información sobre el público basados en un panel de usuarios o similares a los datos de medición de anuncios sin una base jurídica independiente para utilizar estudios de mercado a fin de generar información sobre el público.\n'
+      },
+      '8': {
+        id: 8,
+        name: 'Medir el rendimiento del contenido',
+        description:
+          'Se puede medir el rendimiento y la eficacia del contenido que ve o con el que interactúa.',
+        descriptionLegal:
+          'Para medir el rendimiento del contenido, los proveedores pueden:\n* Medir e informar sobre cómo se entregó el contenido y cómo interactuaron con él los usuarios.\n* Elaborar informes, utilizando información directamente medible o conocida, sobre los usuarios que interactuaron con el contenido\n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones.\nLos proveedores no pueden:\n* Medir si los anuncios (incluida la publicidad nativa) fueron suministrados a un usuario y si este interactuó con ellos sin tener una base jurídica alternativa que lo permita.\n* Aplicar datos de información sobre el público, basados en un panel de usuarios o similares, a los datos de medición de anuncios sin una base jurídica independiente para utilizar estudios de mercado a fin de generar información sobre el público.\n'
+      },
+      '9': {
+        id: 9,
+        name:
+          'Utilizar estudios de mercado a fin de generar información sobre el público',
+        description:
+          'La investigación de mercado puede utilizarse para obtener más información sobre el público que visita sitios webs/aplicaciones y visualiza los anuncios.',
+        descriptionLegal:
+          'Para utilizar estudios de mercado a fin de generar información sobre el público, los proveedores pueden:\n* Elaborar informes agregados para los anunciantes o sus representantes sobre el público alcanzado por sus anuncios, a través de información basada en paneles de audiencia u obtenida de manera similar.\n* Elaborar informes agregados para los editores sobre el público al que se le mostraron contenidos y/o anuncios o que interactuaron con ellos en su propiedad, aplicando información basada en paneles de audiencia u obtenida de manera similar\n* Asociar datos off line con un usuario on line para finalidades de estudios de mercado a fin de generar información sobre el público si los proveedores han declarado que cotejan y combinan fuentes de datos off line \n* Combinar esta información con otra información previamente recabada, incluido entre diferentes sitios web o aplicaciones.\nLos proveedores no pueden: \n* Medir el rendimiento y la eficacia de los anuncios que se mostraron a un usuario específico o con los que interactuó, sin una base jurídica independiente para medir el rendimiento de los anuncios.\n• Medir qué contenido se mostró a un usuario específico y cómo interactuó con el mismo, sin una base jurídica independiente para medir el rendimiento del contenido.\n'
+      },
+      '10': {
+        id: 10,
+        name: 'Desarrollar y mejorar productos',
+        description:
+          'Sus datos pueden utilizarse para mejorar los sistemas y/o el software existente, así como para desarrollar nuevos productos.',
+        descriptionLegal:
+          'Para desarrollar nuevos productos y mejorar los productos, los proveedores pueden:\n* Utilizar información para mejorar sus productos existentes con nuevas funcionalidades/características y desarrollar nuevos productos\n* Crear nuevos modelos y algoritmos mediante machine learning\nLos proveedores no pueden:\n* A partir de esta finalidad no se puede llevar a cabo ninguna otra operación de tratamiento de datos permitida en virtud de una finalidad distinta.\n'
       }
     },
-    '8': {
-      id: 8,
-      name: 'Emerse Sverige AB',
-      purposes: [
-        1,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        8,
-        9
-      ],
-      flexiblePurposes: [
-        2,
-        9
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.emerse.com/privacy-policy/'
-    },
-    '9': {
-      id: 9,
-      name: 'AdMaxim Inc.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://www.admaxim.com/admaxim-privacy-policy/',
-      deletedDate: '2020-06-17T00:00:00Z'
-    },
-    '10': {
-      id: 10,
-      name: 'Index Exchange, Inc. ',
-      purposes: [
-        1,
-        2,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        7
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.indexexchange.com/privacy'
-    },
-    '11': {
-      id: 11,
-      name: 'Quantcast International Limited',
-      purposes: [
-        1,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.quantcast.com/privacy/'
-    },
-    '12': {
-      id: 12,
-      name: 'BeeswaxIO Corporation',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.beeswax.com/privacy/'
-    },
-    '13': {
-      id: 13,
-      name: 'Sovrn Holdings Inc',
-      purposes: [
-        1,
-        2,
-        3,
-        5,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.sovrn.com/sovrn-privacy/'
-    },
-    '14': {
-      id: 14,
-      name: 'Adkernel LLC',
-      purposes: [
-        1,
-        7
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        9
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://adkernel.com/privacy-policy/',
-      overflow: {
-        httpGetLimit: 32
+    specialPurposes: {
+      '1': {
+        id: 1,
+        name: 'Garantizar la seguridad, evitar fraudes y depurar errores',
+        description:
+          'Sus datos pueden utilizarse para supervisar y evitar actividades fraudulentas, y para asegurar que los sistemas y procesos funcionen de forma correcta y segura.',
+        descriptionLegal:
+          'Para garantizar la seguridad, evitar fraudes y depurar errores, los proveedores pueden:\n* Asegurarse de que los datos se transmitan de forma segura \n* Detectar y evitar actividades maliciosas, fraudulentas, inaceptables o ilegales.\n* Asegurar el funcionamiento correcto y eficaz de los sistemas y procesos, lo que incluye supervisar y mejorar el rendimiento de los sistemas y procesos empleados en las finalidades permitidas\nLos proveedores no pueden:\n* Llevar a cabo ninguna otra operación de tratamiento de datos permitida en virtud de una finalidad distinta.\nNota: Los datos recopilados y utilizados para garantizar la seguridad, evitar el fraude y depurar errores pueden incluir características del dispositivo enviadas automáticamente para su identificación, datos de geolocalización precisos y datos obtenidos analizando de forma activa las características del dispositivo para su identificación sin que sea necesario revelar más información y/o una aceptación independiente.  \n'
+      },
+      '2': {
+        id: 2,
+        name: 'Servir técnicamente anuncios o contenido',
+        description:
+          'Su dispositivo puede recibir y enviar información que le permita ver e interactuar con anuncios y contenido.',
+        descriptionLegal:
+          'Para servir información y responder a solicitudes técnicas, los proveedores pueden:\n* Utilizar la dirección IP de un usuario para entregar un anuncio a través de Internet\n* Responder a la interacción de un usuario con un anuncio enviando al usuario a una página de destino\n* Utilizar la dirección IP de un usuario para entregar contenido a través de Internet\n* Responder a la interacción de un usuario con el contenido enviando al usuario a una página de destino\n* Utilizar información sobre el tipo de dispositivo y sus capacidades para entregar anuncios o contenido, por ejemplo, para entregar el archivo publicitario o de vídeo de tamaño adecuado en un formato compatible con el dispositivo\nLos proveedores no pueden:\n* Llevar a cabo, según esta finalidad, ninguna otra operación de tratamiento de datos permitida en virtud de una finalidad distinta.\n'
       }
     },
-    '15': {
-      id: 15,
-      name: 'Adikteev',
-      purposes: [
-        1,
-        3,
-        4,
-        5,
-        6,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [
-        2,
-        7
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.adikteev.com/privacy-policy-eng/'
-    },
-    '16': {
-      id: 16,
-      name: 'RTB House S.A.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.rtbhouse.com/privacy-center/services-privacy-policy/'
-    },
-    '18': {
-      id: 18,
-      name: 'Widespace AB',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7
-      ],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.widespace.com/legal/privacy-policy-notice/'
-    },
-    '21': {
-      id: 21,
-      name: 'The Trade Desk',
-      purposes: [
-        1,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        7,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.thetradedesk.com/general/privacy-policy'
-    },
-    '22': {
-      id: 22,
-      name: 'admetrics GmbH',
-      purposes: [
-        2,
-        7,
-        8,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://admetrics.io/en/privacy_policy/'
-    },
-    '23': {
-      id: 23,
-      name: 'Amobee, Inc. ',
-      purposes: [
-        1,
-        2,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        7,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.amobee.com/trust/privacy-guidelines'
-    },
-    '24': {
-      id: 24,
-      name: 'Epsilon',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.conversantmedia.eu/legal/privacy-policy'
-    },
-    '25': {
-      id: 25,
-      name: 'Verizon Media EMEA Limited',
-      purposes: [
-        1,
-        3,
-        4,
-        5,
-        6
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.verizonmedia.com/policies/ie/en/verizonmedia/privacy/index.html'
-    },
-    '28': {
-      id: 28,
-      name: 'TripleLift, Inc.',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://triplelift.com/privacy/',
-      overflow: {
-        httpGetLimit: 32
+    features: {
+      '1': {
+        id: 1,
+        name: 'Cotejar y combinar fuentes de datos off line',
+        description:
+          'Los datos obtenidos de fuentes de datos off line pueden combinarse con su actividad on line para respaldar una o más finalidades.',
+        descriptionLegal:
+          'Los proveedores pueden: \n* Combinar los datos obtenidos off line con los datos recogidos on line en apoyo de una o más Finalidades o Finalidades especiales.'
+      },
+      '2': {
+        id: 2,
+        name: 'Vincular diferentes dispositivos',
+        description:
+          'Se puede determinar que diferentes dispositivos pertenecen a usted o a su hogar para una o más finalidades.',
+        descriptionLegal:
+          'Los proveedores pueden:\n* Determinar de forma determinista que dos o más dispositivos pertenecen al mismo usuario u hogar\n* Determinar de forma probabilística que dos o más dispositivos pertenecen al mismo usuario u hogar\n* Analizar activamente las características del dispositivo para encontrar su identificación probabilística si los usuarios han permitido a los proveedores analizar activamente las características del dispositivo para su identificación (Funcionalidad especial 2)\n'
+      },
+      '3': {
+        id: 3,
+        name:
+          'Recibir y utilizar para su identificación las características del dispositivo que    se envían automáticamente',
+        description:
+          'Su dispositivo puede distinguirse de otros dispositivos a partir de la información que envía automáticamente, como la dirección IP o el tipo de navegador.',
+        descriptionLegal:
+          'Los proveedores pueden:\n* Crear un identificador utilizando los datos recopilados automáticamente en un dispositivo para características específicas, por ejemplo, dirección IP o la cadena de agente de usuario.\n* Utilizar este identificador para intentar volver a identificar un dispositivo.\nLos proveedores no pueden:\n* Crear un identificador utilizando datos recogidos mediante el análisis activo de un dispositivo para hallar funcionalidads específicas, por ejemplo, fuentes instaladas o resolución de pantalla sin aceptación independiente del usuario para analizar de forma activa las características del dispositivo para su identificación.\n* Utilizar este identificador para volver a identificar un dispositivo.\n'
       }
     },
-    '30': {
-      id: 30,
-      name: 'BidTheatre AB',
-      purposes: [
-        1,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2
-      ],
-      flexiblePurposes: [
-        2
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.bidtheatre.com/privacy-policy'
-    },
-    '31': {
-      id: 31,
-      name: 'Ogury Ltd.',
-      purposes: [
-        1,
-        3,
-        4,
-        9
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.ogury.com/privacy-policy/'
-    },
-    '32': {
-      id: 32,
-      name: 'Xandr, Inc.',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        7,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        2
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.xandr.com/privacy/platform-privacy-policy/'
-    },
-    '33': {
-      id: 33,
-      name: 'ShareThis, Inc',
-      purposes: [
-        1,
-        3,
-        5,
-        6
-      ],
-      legIntPurposes: [
-        9,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://sharethis.com/privacy/'
-    },
-    '34': {
-      id: 34,
-      name: 'NEORY GmbH',
-      purposes: [
-        1,
-        3,
-        4,
-        5,
-        6,
-        9
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        8
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.neory.com/privacy.html',
-      overflow: {
-        httpGetLimit: 128
+    specialFeatures: {
+      '1': {
+        id: 1,
+        name: 'Utilizar datos de localización geográfica precisa',
+        description:
+          'Sus datos de localización geográfica precisa se pueden utilizar para una o más finalidades. Esto significa que su ubicación puede tener una precisión de varios metros.',
+        descriptionLegal:
+          'Los proveedores pueden:\n* Recoger y tratar datos de localización geográfica precisa para una o más finalidades.\nNota: La localización geográfica precisa significa que no existen restricciones sobre la precisión de la ubicación de un usuario; esto puede tener una precisión de varios metros.\n'
+      },
+      '2': {
+        id: 2,
+        name:
+          'Analizar activamente las características del dispositivo para su identificación',
+        description:
+          'Su dispositivo puede identificarse basándose en un análisis de la combinación única de las características de su dispositivo.',
+        descriptionLegal:
+          'Los proveedores pueden:\n* Crear un identificador utilizando datos recogidos mediante el análisis activo de un dispositivo para hallar características específicas, por ejemplo, fuentes instaladas o resolución de pantalla. \n* Utilizar este identificador para volver a identificar un dispositivo.\n'
       }
     },
-    '36': {
-      id: 36,
-      name: 'RhythmOne DBA Unruly Group Ltd',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.rhythmone.com/privacy-policy'
-    },
-    '37': {
-      id: 37,
-      name: 'NEURAL.ONE',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        7,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://web.neural.one/privacy-policy/'
-    },
-    '39': {
-      id: 39,
-      name: 'ADITION technologies AG',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.adition.com/datenschutz'
-    },
-    '40': {
-      id: 40,
-      name: 'Active Agent (ADITION technologies AG)',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://www.active-agent.com/de/unternehmen/datenschutzerklaerung/'
-    },
-    '41': {
-      id: 41,
-      name: 'Adverline',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.adverline.com/privacy/',
-      overflow: {
-        httpGetLimit: 128
+    stacks: {
+      '1': {
+        id: 1,
+        purposes: [],
+        specialFeatures: [1, 2],
+        name:
+          'Datos de localización geográfica precisa e identificación mediante las características de dispositivos',
+        description:
+          'Se puede utilizar la localización geográfica precisa y la información sobre las características del dispositivo.'
+      },
+      '2': {
+        id: 2,
+        purposes: [2, 7],
+        specialFeatures: [],
+        name: 'Anuncios básicos y medición de anuncios',
+        description:
+          'Se pueden mostrar anuncios básicos. Se puede medir el rendimiento de los anuncios.'
+      },
+      '3': {
+        id: 3,
+        purposes: [2, 3, 4],
+        specialFeatures: [],
+        name: 'Anuncios personalizados',
+        description:
+          'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios.'
+      },
+      '4': {
+        id: 4,
+        purposes: [2, 7, 9],
+        specialFeatures: [],
+        name: 'Anuncios básicos y medición de anuncios',
+        description:
+          'Se pueden mostrar anuncios básicos. Se puede medir el rendimiento de los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '5': {
+        id: 5,
+        purposes: [2, 3, 7],
+        specialFeatures: [],
+        name:
+          'Anuncios básicos, creación de perfil publicitario personalizado y medición de anuncios',
+        description:
+          'Se pueden mostrar anuncios básicos. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios.'
+      },
+      '6': {
+        id: 6,
+        purposes: [2, 4, 7],
+        specialFeatures: [],
+        name: 'Mostrar anuncios personalizados y medición de anuncios',
+        description:
+          'Los anuncios pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios.'
+      },
+      '7': {
+        id: 7,
+        purposes: [2, 4, 7, 9],
+        specialFeatures: [],
+        name:
+          'Mostrar anuncios personalizados, medición de anuncios e información sobre el público',
+        description:
+          'Los anuncios pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '8': {
+        id: 8,
+        purposes: [2, 3, 4, 7],
+        specialFeatures: [],
+        name: 'Anuncios personalizados y medición de anuncios',
+        description:
+          'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios.'
+      },
+      '9': {
+        id: 9,
+        purposes: [2, 3, 4, 7, 9],
+        specialFeatures: [],
+        name:
+          'Anuncios personalizados, medición de anuncios e información sobre el público',
+        description:
+          'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '10': {
+        id: 10,
+        purposes: [3, 4],
+        specialFeatures: [],
+        name: 'Perfil y muestra de anuncios personalizados',
+        description:
+          'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios.'
+      },
+      '11': {
+        id: 11,
+        purposes: [5, 6],
+        specialFeatures: [],
+        name: 'Contenido personalizado',
+        description:
+          'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido.'
+      },
+      '12': {
+        id: 12,
+        purposes: [6, 8],
+        specialFeatures: [],
+        name: 'Muestra de contenido personalizado y medición de contenido',
+        description:
+          'El contenido puede personalizarse basándose en un perfil. Se puede medir el rendimiento del contenido.'
+      },
+      '13': {
+        id: 13,
+        purposes: [6, 8, 9],
+        specialFeatures: [],
+        name:
+          'Presentación de contenido personalizado, medición del contenido e información sobre el público',
+        description:
+          'El contenido puede personalizarse basándose en un perfil. Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '14': {
+        id: 14,
+        purposes: [5, 6, 8],
+        specialFeatures: [],
+        name: 'Contenido personalizado y medición del contenido',
+        description:
+          'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido.'
+      },
+      '15': {
+        id: 15,
+        purposes: [5, 6, 8, 9],
+        specialFeatures: [],
+        name:
+          'Contenido personalizado, medición del contenido e información sobre el público',
+        description:
+          'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '16': {
+        id: 16,
+        purposes: [5, 6, 8, 9, 10],
+        specialFeatures: [],
+        name:
+          'Contenido personalizado, medición del contenido, información sobre el público y desarrollo de productos',
+        description:
+          'El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido. Se puede inducir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software'
+      },
+      '17': {
+        id: 17,
+        purposes: [7, 8, 9],
+        specialFeatures: [],
+        name:
+          'Medición de anuncios y del contenido e información sobre el público',
+        description:
+          'Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '18': {
+        id: 18,
+        purposes: [7, 8],
+        specialFeatures: [],
+        name: 'Medición de anuncios y del contenido',
+        description:
+          'Se puede medir el rendimiento de los anuncios y del contenido.'
+      },
+      '19': {
+        id: 19,
+        purposes: [7, 9],
+        specialFeatures: [],
+        name: 'Medición de anuncios e información sobre el público',
+        description:
+          'Se pueden medir los anuncios. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '20': {
+        id: 20,
+        purposes: [7, 8, 9, 10],
+        specialFeatures: [],
+        name:
+          'Medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+        description:
+          'Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '21': {
+        id: 21,
+        purposes: [8, 9, 10],
+        specialFeatures: [],
+        name:
+          'Medición del contenido, información sobre el público y desarrollo de productos.',
+        description:
+          'Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '22': {
+        id: 22,
+        purposes: [8, 10],
+        specialFeatures: [],
+        name: 'Medición del contenido y desarrollo de productos',
+        description:
+          'Se puede medir el rendimiento del contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '23': {
+        id: 23,
+        purposes: [2, 4, 6, 7, 8],
+        specialFeatures: [],
+        name:
+          'Presentación de anuncios y contenido personalizados, medición de anuncios y del contenido',
+        description:
+          'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios y del contenido.'
+      },
+      '24': {
+        id: 24,
+        purposes: [2, 4, 6, 7, 8, 9],
+        specialFeatures: [],
+        name:
+          'Presentación de anuncios y contenido personalizados, medición de anuncios y del contenido e información sobre el público',
+        description:
+          'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '25': {
+        id: 25,
+        purposes: [2, 3, 4, 5, 6, 7, 8],
+        specialFeatures: [],
+        name:
+          'Anuncios y contenido personalizados, medición de anuncios y del contenido',
+        description:
+          'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios y el contenido. Se puede medir el rendimiento de los anuncios y del contenido.'
+      },
+      '26': {
+        id: 26,
+        purposes: [2, 3, 4, 5, 6, 7, 8, 9],
+        specialFeatures: [],
+        name:
+          'Anuncios y contenido personalizados, medición de anuncios y del contenido e información sobre el público',
+        description:
+          'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios y el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '27': {
+        id: 27,
+        purposes: [3, 5],
+        specialFeatures: [],
+        name: 'Anuncios personalizados y contenido personalizado',
+        description:
+          'Se pueden añadir más datos para personalizar los anuncios y el contenido.'
+      },
+      '28': {
+        id: 28,
+        purposes: [2, 4, 6],
+        specialFeatures: [],
+        name: 'Muestra de anuncios y contenido personalizados',
+        description:
+          'Los anuncios y el contenido pueden personalizarse basándose en un perfil.'
+      },
+      '29': {
+        id: 29,
+        purposes: [2, 7, 8, 9],
+        specialFeatures: [],
+        name:
+          'Anuncios básicos, medición de anuncios y del contenido e información sobre el público',
+        description:
+          'Se pueden mostrar anuncios básicos. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '30': {
+        id: 30,
+        purposes: [2, 4, 5, 6, 7, 8, 9],
+        specialFeatures: [],
+        name:
+          'Muestra de anuncios personalizados, contenido personalizado, medición de anuncios y del contenido e información sobre el público',
+        description:
+          'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '31': {
+        id: 31,
+        purposes: [2, 4, 5, 6, 7, 8, 9, 10],
+        specialFeatures: [],
+        name:
+          'Muestra de anuncios personalizados, contenido personalizado, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+        description:
+          'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '32': {
+        id: 32,
+        purposes: [2, 5, 6, 7, 8, 9],
+        specialFeatures: [],
+        name:
+          'Anuncios básicos, contenido personalizado, medición de anuncios y del contenido e información sobre el público',
+        description:
+          'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '33': {
+        id: 33,
+        purposes: [2, 5, 6, 7, 8, 9, 10],
+        specialFeatures: [],
+        name:
+          'Anuncios básicos, contenido personalizado, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+        description:
+          'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '34': {
+        id: 34,
+        purposes: [2, 5, 6, 8, 9],
+        specialFeatures: [],
+        name:
+          'Anuncios básicos, contenido personalizado, medición del contenido e información sobre el público',
+        description:
+          'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido.'
+      },
+      '35': {
+        id: 35,
+        purposes: [2, 5, 6, 8, 9, 10],
+        specialFeatures: [],
+        name:
+          'Anuncios básicos, contenido personalizado, medición del contenido, información sobre el público y desarrollo de productos',
+        description:
+          'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento del contenido. Se puede inferir información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '36': {
+        id: 36,
+        purposes: [2, 5, 6, 7],
+        specialFeatures: [],
+        name:
+          'Anuncios básicos, contenido personalizado y medición de anuncios',
+        description:
+          'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios.'
+      },
+      '37': {
+        id: 37,
+        purposes: [2, 5, 6, 7, 10],
+        specialFeatures: [],
+        name:
+          'Anuncios básicos, contenido personalizado, medición de anuncios y desarrollo de productos',
+        description:
+          'Se pueden mostrar anuncios básicos. El contenido puede personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor el contenido. Se puede medir el rendimiento de los anuncios. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '38': {
+        id: 38,
+        purposes: [2, 3, 4, 7, 10],
+        specialFeatures: [],
+        name:
+          'Anuncios personalizados, medición de anuncios y desarrollo de productos',
+        description:
+          'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '39': {
+        id: 39,
+        purposes: [2, 3, 4, 7, 9, 10],
+        specialFeatures: [],
+        name:
+          'Anuncios personalizados, medición de anuncios, información sobre el público y desarrollo de productos',
+        description:
+          'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '40': {
+        id: 40,
+        purposes: [2, 3, 4, 7, 8, 9, 10],
+        specialFeatures: [],
+        name:
+          'Anuncios personalizados, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+        description:
+          'Los anuncios pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios y del contenido. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '41': {
+        id: 41,
+        purposes: [2, 3, 4, 6, 7, 8, 9, 10],
+        specialFeatures: [],
+        name:
+          'Anuncios personalizados, muestra de contenido personalizado, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+        description:
+          'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios. Se puede medir el rendimiento de los anuncios y del contenido. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
+      },
+      '42': {
+        id: 42,
+        purposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialFeatures: [],
+        name:
+          'Anuncios y contenido personalizados, medición de anuncios y del contenido, información sobre el público y desarrollo de productos',
+        description:
+          'Los anuncios y el contenido pueden personalizarse basándose en un perfil. Se pueden añadir más datos para personalizar mejor los anuncios y el contenido. Se puede medir el rendimiento de los anuncios y del contenido. Se puede derivar información sobre el público que vio los anuncios y el contenido. Los datos pueden utilizarse para elaborar o mejorar la experiencia del usuario, los sistemas y el software.'
       }
     },
-    '42': {
-      id: 42,
-      name: 'Taboola Europe Limited',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.taboola.com/privacy-policy'
-    },
-    '44': {
-      id: 44,
-      name: 'The ADEX GmbH',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://theadex.com/privacy-opt-out/'
-    },
-    '45': {
-      id: 45,
-      name: 'Smart Adserver',
-      purposes: [
-        1,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        7
-      ],
-      flexiblePurposes: [
-        2,
-        7
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://smartadserver.com/end-user-privacy-policy/'
-    },
-    '47': {
-      id: 47,
-      name: 'ADMAN - Phaistos Networks, S.A.',
-      purposes: [
-        1,
-        2,
-        4,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://www.adman.gr/privacy'
-    },
-    '49': {
-      id: 49,
-      name: 'TRADELAB',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6
-      ],
-      legIntPurposes: [
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://tradelab.com/en/privacy/',
-      overflow: {
-        httpGetLimit: 32
+    vendors: {
+      '1': {
+        id: 1,
+        name: 'Exponential Interactive, Inc d/b/a VDX.tv',
+        purposes: [1, 2, 3, 4, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 3],
+        specialFeatures: [],
+        policyUrl: 'https://vdx.tv/privacy/'
+      },
+      '2': {
+        id: 2,
+        name: 'Captify Technologies Limited',
+        purposes: [1, 2, 3, 4],
+        legIntPurposes: [7, 9, 10],
+        flexiblePurposes: [2],
+        specialPurposes: [],
+        features: [2],
+        specialFeatures: [],
+        policyUrl: 'http://www.captify.co.uk/privacy-policy/'
+      },
+      '4': {
+        id: 4,
+        name: 'Roq.ad Inc.',
+        purposes: [1, 2, 3, 4, 7, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.roq.ad/privacy-policy'
+      },
+      '6': {
+        id: 6,
+        name: 'AdSpirit GmbH',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 7, 9],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'http://www.adspirit.de/privacy',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '8': {
+        id: 8,
+        name: 'Emerse Sverige AB',
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 8, 9],
+        flexiblePurposes: [2, 9],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [],
+        policyUrl: 'https://www.emerse.com/privacy-policy/'
+      },
+      '9': {
+        id: 9,
+        name: 'AdMaxim Inc.',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'http://www.admaxim.com/admaxim-privacy-policy/',
+        deletedDate: '2020-06-17T00:00:00Z'
+      },
+      '10': {
+        id: 10,
+        name: 'Index Exchange, Inc. ',
+        purposes: [1, 2, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 7],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.indexexchange.com/privacy'
+      },
+      '11': {
+        id: 11,
+        name: 'Quantcast International Limited',
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.quantcast.com/privacy/'
+      },
+      '12': {
+        id: 12,
+        name: 'BeeswaxIO Corporation',
+        purposes: [1, 2, 3, 4, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.beeswax.com/privacy/'
+      },
+      '13': {
+        id: 13,
+        name: 'Sovrn Holdings Inc',
+        purposes: [1, 2, 3, 5, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.sovrn.com/sovrn-privacy/'
+      },
+      '14': {
+        id: 14,
+        name: 'Adkernel LLC',
+        purposes: [1, 7],
+        legIntPurposes: [2, 3, 4, 9],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'http://adkernel.com/privacy-policy/',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '15': {
+        id: 15,
+        name: 'Adikteev',
+        purposes: [1, 3, 4, 5, 6, 8, 9, 10],
+        legIntPurposes: [2, 7],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [2],
+        specialFeatures: [],
+        policyUrl: 'https://www.adikteev.com/privacy-policy-eng/'
+      },
+      '16': {
+        id: 16,
+        name: 'RTB House S.A.',
+        purposes: [1, 2, 3, 4, 7, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1],
+        features: [],
+        specialFeatures: [],
+        policyUrl:
+          'https://www.rtbhouse.com/privacy-center/services-privacy-policy/'
+      },
+      '18': {
+        id: 18,
+        name: 'Widespace AB',
+        purposes: [1, 2, 3, 4, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 7],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.widespace.com/legal/privacy-policy-notice/'
+      },
+      '21': {
+        id: 21,
+        name: 'The Trade Desk',
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 10],
+        flexiblePurposes: [2, 7, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [1],
+        policyUrl: 'https://www.thetradedesk.com/general/privacy-policy'
+      },
+      '22': {
+        id: 22,
+        name: 'admetrics GmbH',
+        purposes: [2, 7, 8, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://admetrics.io/en/privacy_policy/'
+      },
+      '23': {
+        id: 23,
+        name: 'Amobee, Inc. ',
+        purposes: [1, 2, 3, 4],
+        legIntPurposes: [7, 9, 10],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.amobee.com/trust/privacy-guidelines'
+      },
+      '24': {
+        id: 24,
+        name: 'Epsilon',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.conversantmedia.eu/legal/privacy-policy'
+      },
+      '25': {
+        id: 25,
+        name: 'Verizon Media EMEA Limited',
+        purposes: [1, 3, 4, 5, 6],
+        legIntPurposes: [2, 7, 8, 9, 10],
+        flexiblePurposes: [2, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl:
+          'https://www.verizonmedia.com/policies/ie/en/verizonmedia/privacy/index.html'
+      },
+      '28': {
+        id: 28,
+        name: 'TripleLift, Inc.',
+        purposes: [1],
+        legIntPurposes: [2, 7, 9, 10],
+        flexiblePurposes: [2, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://triplelift.com/privacy/',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '30': {
+        id: 30,
+        name: 'BidTheatre AB',
+        purposes: [1, 3, 4],
+        legIntPurposes: [2],
+        flexiblePurposes: [2],
+        specialPurposes: [1, 2],
+        features: [2],
+        specialFeatures: [],
+        policyUrl: 'https://www.bidtheatre.com/privacy-policy'
+      },
+      '31': {
+        id: 31,
+        name: 'Ogury Ltd.',
+        purposes: [1, 3, 4, 9],
+        legIntPurposes: [2, 7, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [2],
+        specialFeatures: [],
+        policyUrl: 'https://www.ogury.com/privacy-policy/'
+      },
+      '32': {
+        id: 32,
+        name: 'Xandr, Inc.',
+        purposes: [1],
+        legIntPurposes: [2, 7, 10],
+        flexiblePurposes: [2, 7, 10],
+        specialPurposes: [1, 2],
+        features: [2],
+        specialFeatures: [1],
+        policyUrl: 'https://www.xandr.com/privacy/platform-privacy-policy/'
+      },
+      '33': {
+        id: 33,
+        name: 'ShareThis, Inc',
+        purposes: [1, 3, 5, 6],
+        legIntPurposes: [9, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://sharethis.com/privacy/'
+      },
+      '34': {
+        id: 34,
+        name: 'NEORY GmbH',
+        purposes: [1, 3, 4, 5, 6, 9],
+        legIntPurposes: [2, 7, 8],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://www.neory.com/privacy.html',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '36': {
+        id: 36,
+        name: 'RhythmOne DBA Unruly Group Ltd',
+        purposes: [1, 2, 3, 4, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.rhythmone.com/privacy-policy'
+      },
+      '37': {
+        id: 37,
+        name: 'NEURAL.ONE',
+        purposes: [1, 2, 3, 4, 5, 7, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://web.neural.one/privacy-policy/'
+      },
+      '39': {
+        id: 39,
+        name: 'ADITION technologies AG',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.adition.com/datenschutz'
+      },
+      '40': {
+        id: 40,
+        name: 'Active Agent (ADITION technologies AG)',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl:
+          'http://www.active-agent.com/de/unternehmen/datenschutzerklaerung/'
+      },
+      '41': {
+        id: 41,
+        name: 'Adverline',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.adverline.com/privacy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '42': {
+        id: 42,
+        name: 'Taboola Europe Limited',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.taboola.com/privacy-policy'
+      },
+      '44': {
+        id: 44,
+        name: 'The ADEX GmbH',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://theadex.com/privacy-opt-out/'
+      },
+      '45': {
+        id: 45,
+        name: 'Smart Adserver',
+        purposes: [1, 4],
+        legIntPurposes: [2, 7],
+        flexiblePurposes: [2, 7],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'https://smartadserver.com/end-user-privacy-policy/'
+      },
+      '47': {
+        id: 47,
+        name: 'ADMAN - Phaistos Networks, S.A.',
+        purposes: [1, 2, 4, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.adman.gr/privacy'
+      },
+      '49': {
+        id: 49,
+        name: 'TRADELAB',
+        purposes: [1, 2, 3, 4, 5, 6],
+        legIntPurposes: [7, 8, 9, 10],
+        flexiblePurposes: [7, 8, 9, 10],
+        specialPurposes: [],
+        features: [1, 2],
+        specialFeatures: [1],
+        policyUrl: 'https://tradelab.com/en/privacy/',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '50': {
+        id: 50,
+        name: 'Adform',
+        purposes: [1, 2, 3, 4, 7, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 7, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [],
+        policyUrl:
+          'https://site.adform.com/privacy-center/platform-privacy/product-and-services-privacy-policy/',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '51': {
+        id: 51,
+        name: 'xAd, Inc. dba GroundTruth',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.groundtruth.com/privacy-policy/'
+      },
+      '52': {
+        id: 52,
+        name: 'The Rubicon Project, Inc. ',
+        purposes: [1],
+        legIntPurposes: [2, 7, 10],
+        flexiblePurposes: [2, 7, 10],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [1],
+        policyUrl:
+          'http://www.rubiconproject.com/rubicon-project-yield-optimization-privacy-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '53': {
+        id: 53,
+        name: 'Sirdata',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.sirdata.com/privacy/'
+      },
+      '57': {
+        id: 57,
+        name: 'ADARA MEDIA UNLIMITED',
+        purposes: [1, 2, 3, 4],
+        legIntPurposes: [7, 9, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://adara.com/privacy-promise/'
+      },
+      '58': {
+        id: 58,
+        name: '33Across',
+        purposes: [1, 2, 4, 7, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [2],
+        specialFeatures: [],
+        policyUrl: 'http://www.33across.com/privacy-policy'
+      },
+      '59': {
+        id: 59,
+        name: 'Sift Media, Inc',
+        purposes: [2],
+        legIntPurposes: [],
+        flexiblePurposes: [2],
+        specialPurposes: [],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.sift.co/privacy'
+      },
+      '60': {
+        id: 60,
+        name: 'Rakuten Marketing LLC',
+        purposes: [1, 3],
+        legIntPurposes: [2, 4, 7, 9, 10],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl:
+          'https://rakutenadvertising.com/legal-notices/services-privacy-policy/'
+      },
+      '61': {
+        id: 61,
+        name: 'GumGum, Inc.',
+        purposes: [1, 2, 3, 4, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://gumgum.com/privacy-policy'
+      },
+      '62': {
+        id: 62,
+        name: 'Justpremium BV',
+        purposes: [1, 4, 5, 10],
+        legIntPurposes: [2, 7],
+        flexiblePurposes: [2, 4, 7, 10],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://justpremium.com/privacy-policy/'
+      },
+      '63': {
+        id: 63,
+        name: 'Avocet Systems Limited',
+        purposes: [1, 2, 3, 4, 5, 6],
+        legIntPurposes: [7, 8, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://avocet.io/privacy-portal'
+      },
+      '65': {
+        id: 65,
+        name: 'Location Sciences AI Ltd',
+        purposes: [1, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [7, 8],
+        specialPurposes: [1],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://www.locationsciences.ai/privacy-policy/'
+      },
+      '66': {
+        id: 66,
+        name: 'adsquare GmbH',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 9, 10],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.adsquare.com/privacy'
+      },
+      '68': {
+        id: 68,
+        name: 'Sizmek by Amazon',
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 9, 10],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [],
+        policyUrl: 'https://www.sizmek.com/privacy-policy/'
+      },
+      '69': {
+        id: 69,
+        name: 'OpenX',
+        purposes: [1],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.openx.com/legal/privacy-policy/'
+      },
+      '70': {
+        id: 70,
+        name: 'Yieldlab AG',
+        purposes: [1, 2, 3, 4, 7, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 7, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'http://www.yieldlab.de/meta-navigation/datenschutz/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '72': {
+        id: 72,
+        name: 'Nano Interactive GmbH',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.nanointeractive.com/privacy'
+      },
+      '73': {
+        id: 73,
+        name: 'Simplifi Holdings Inc.',
+        purposes: [1, 2, 3, 4, 7, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4],
+        specialPurposes: [],
+        features: [2],
+        specialFeatures: [1],
+        policyUrl: 'https://simpli.fi/site-privacy-policy/'
+      },
+      '76': {
+        id: 76,
+        name: 'PubMatic, Inc.',
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://pubmatic.com/privacy-policy/'
+      },
+      '77': {
+        id: 77,
+        name: 'comScore, Inc.',
+        purposes: [1, 7, 8, 10],
+        legIntPurposes: [9],
+        flexiblePurposes: [7, 8, 9, 10],
+        specialPurposes: [1],
+        features: [1, 2],
+        specialFeatures: [],
+        policyUrl:
+          'https://www.scorecardresearch.com/privacy.aspx?newlanguage=1'
+      },
+      '78': {
+        id: 78,
+        name: 'Flashtalking, Inc.',
+        purposes: [1, 2, 3, 4, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'http://www.flashtalking.com/privacypolicy/'
+      },
+      '79': {
+        id: 79,
+        name: 'MediaMath, Inc.',
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 10],
+        flexiblePurposes: [3, 4],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'http://www.mediamath.com/privacy-policy/'
+      },
+      '80': {
+        id: 80,
+        name: 'Sharethrough, Inc',
+        purposes: [1, 2, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 4, 7, 9, 10],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://platform-cdn.sharethrough.com/privacy-policy'
+      },
+      '82': {
+        id: 82,
+        name: 'Smaato, Inc.',
+        purposes: [1, 2, 3, 4, 7, 9],
+        legIntPurposes: [10],
+        flexiblePurposes: [2, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.smaato.com/privacy/'
+      },
+      '83': {
+        id: 83,
+        name: 'Visarity Technologies GmbH',
+        purposes: [2, 6, 7, 8],
+        legIntPurposes: [],
+        flexiblePurposes: [2],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://primo.design/docs/PrivacyPolicyPrimo.html'
+      },
+      '84': {
+        id: 84,
+        name: 'Semasio GmbH',
+        purposes: [1, 3, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [3, 9, 10],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.semasio.com/privacy-policy/'
+      },
+      '85': {
+        id: 85,
+        name: 'Crimtan Holdings Limited',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://crimtan.com/privacy/'
+      },
+      '86': {
+        id: 86,
+        name: 'Scene Stealer Limited',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7, 10],
+        flexiblePurposes: [2, 3, 4, 7],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://scenestealer.tv/privacy-policy/'
+      },
+      '88': {
+        id: 88,
+        name: 'TreSensa, Inc.',
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 10],
+        flexiblePurposes: [2, 3, 4, 7, 10],
+        specialPurposes: [1, 2],
+        features: [1, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.tresensa.com/eu-privacy'
+      },
+      '89': {
+        id: 89,
+        name: 'Tapad, Inc.',
+        purposes: [1],
+        legIntPurposes: [10],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [2],
+        specialFeatures: [],
+        policyUrl: 'https://www.tapad.com/eu-privacy-policy'
+      },
+      '90': {
+        id: 90,
+        name: 'Teroa S.A.',
+        purposes: [1, 2, 3, 4, 5, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.e-planning.net/en/privacy.html'
+      },
+      '91': {
+        id: 91,
+        name: 'Criteo SA',
+        purposes: [1, 2, 3, 4, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 7],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.criteo.com/privacy/'
+      },
+      '92': {
+        id: 92,
+        name: '1plusX AG',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.1plusx.com/privacy-policy/'
+      },
+      '93': {
+        id: 93,
+        name: 'Adloox SA',
+        purposes: [],
+        legIntPurposes: [7],
+        flexiblePurposes: [],
+        specialPurposes: [1],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://adloox.com/disclaimer',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '94': {
+        id: 94,
+        name: 'Blis Media Limited',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'http://www.blis.com/privacy/'
+      },
+      '95': {
+        id: 95,
+        name: 'Lotame Solutions, inc',
+        purposes: [1, 3, 5],
+        legIntPurposes: [7, 8, 9, 10],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [2, 3],
+        specialFeatures: [],
+        policyUrl:
+          'https://www.lotame.com/about-lotame/privacy/lotame-corporate-websites-privacy-policy/'
+      },
+      '97': {
+        id: 97,
+        name: 'LiveRamp, Inc.',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.liveramp.com/service-privacy-policy/'
+      },
+      '98': {
+        id: 98,
+        name: 'GroupM UK Limited',
+        purposes: [1, 2, 3, 4, 5, 6],
+        legIntPurposes: [7, 9, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [],
+        policyUrl: 'https://www.groupm.com/privacy-notice'
+      },
+      '100': {
+        id: 100,
+        name: 'Fifty Technology Limited',
+        purposes: [1, 2, 3, 4],
+        legIntPurposes: [7, 9, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://fifty.io/privacy-policy.php'
+      },
+      '101': {
+        id: 101,
+        name: 'MiQ',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'http://wearemiq.com/privacy-policy/'
+      },
+      '104': {
+        id: 104,
+        name: 'Sonobi, Inc',
+        purposes: [1, 2, 3, 4],
+        legIntPurposes: [7, 8],
+        flexiblePurposes: [],
+        specialPurposes: [2],
+        features: [1],
+        specialFeatures: [],
+        policyUrl: 'http://sonobi.com/privacy-policy/'
+      },
+      '108': {
+        id: 108,
+        name: 'Rich Audience',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://richaudience.com/privacy/'
+      },
+      '109': {
+        id: 109,
+        name: 'LoopMe Limited',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8],
+        legIntPurposes: [9, 10],
+        flexiblePurposes: [9],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [1],
+        policyUrl: 'https://loopme.com/privacy-policy/'
+      },
+      '110': {
+        id: 110,
+        name: 'Dynata LLC',
+        purposes: [1, 7, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2],
+        specialFeatures: [],
+        policyUrl: 'https://www.opinionoutpost.co.uk/en-gb/policies/privacy'
+      },
+      '111': {
+        id: 111,
+        name: 'Showheroes SE',
+        purposes: [1, 3, 4, 9, 10],
+        legIntPurposes: [2, 7, 8],
+        flexiblePurposes: [2, 3, 4, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1],
+        specialFeatures: [],
+        policyUrl: 'https://showheroes.com/privacy/'
+      },
+      '114': {
+        id: 114,
+        name: 'Sublime',
+        purposes: [1, 2, 3, 4, 7, 9],
+        legIntPurposes: [10],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://ayads.co/privacy.php'
+      },
+      '115': {
+        id: 115,
+        name: 'smartclip Europe GmbH',
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 10],
+        flexiblePurposes: [2, 3, 4, 7, 10],
+        specialPurposes: [1, 2],
+        features: [2],
+        specialFeatures: [],
+        policyUrl: 'https://privacy-portal.smartclip.net/',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '119': {
+        id: 119,
+        name: 'Fusio by S4M',
+        purposes: [1, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'http://www.s4m.io/privacy-policy/'
+      },
+      '120': {
+        id: 120,
+        name: 'Eyeota Pte Ltd',
+        purposes: [1, 3, 5, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [3, 5, 9, 10],
+        specialPurposes: [1],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.eyeota.com/privacy-center'
+      },
+      '126': {
+        id: 126,
+        name: 'DoubleVerify Inc.​',
+        purposes: [2, 7, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.doubleverify.com/privacy/'
+      },
+      '127': {
+        id: 127,
+        name: 'PIXIMEDIA SAS',
+        purposes: [1, 3, 4, 5, 6, 9, 10],
+        legIntPurposes: [2, 7, 8],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'https://piximedia.com/privacy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '128': {
+        id: 128,
+        name: 'BIDSWITCH GmbH',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 3],
+        specialFeatures: [1],
+        policyUrl: 'http://www.bidswitch.com/privacy-policy/'
+      },
+      '129': {
+        id: 129,
+        name: 'IPONWEB GmbH',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.iponweb.com/privacy-policy/'
+      },
+      '130': {
+        id: 130,
+        name: 'NextRoll, Inc.',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [],
+        policyUrl: 'https://www.nextroll.com/privacy'
+      },
+      '131': {
+        id: 131,
+        name: 'ID5 Technology SAS',
+        purposes: [1],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://www.id5.io/privacy'
+      },
+      '132': {
+        id: 132,
+        name: 'Teads ',
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 9, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://www.teads.com/privacy-policy/'
+      },
+      '133': {
+        id: 133,
+        name: 'digitalAudience',
+        purposes: [1, 3, 5, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2],
+        specialFeatures: [],
+        policyUrl: 'https://digitalaudience.io/legal/privacy-cookies/'
+      },
+      '134': {
+        id: 134,
+        name: 'SMARTSTREAM.TV GmbH',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7, 9, 10],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.smartstream.tv/en/productprivacy',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '136': {
+        id: 136,
+        name: 'Ströer SSP GmbH (SSP)',
+        purposes: [1],
+        legIntPurposes: [2, 7, 9, 10],
+        flexiblePurposes: [2, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl:
+          'https://www.stroeer.de/fileadmin/de/Konvergenz_und_Konzepte/Daten_und_Technologien/Stroeer_SSP/Downloads/Datenschutz_Stroeer_SSP.pdf'
+      },
+      '137': {
+        id: 137,
+        name: 'Ströer SSP GmbH (DSP)',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7, 9, 10],
+        flexiblePurposes: [2, 3, 4, 9],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [1],
+        policyUrl:
+          'https://www.stroeer.de/fileadmin/de/Konvergenz_und_Konzepte/Daten_und_Technologien/Stroeer_SSP/Downloads/Datenschutz_Stroeer_SSP.pdf'
+      },
+      '138': {
+        id: 138,
+        name: 'ConnectAd Realtime GmbH',
+        purposes: [1, 3, 4, 5],
+        legIntPurposes: [2, 7],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'http://connectadrealtime.com/privacy/'
+      },
+      '139': {
+        id: 139,
+        name: 'Permodo GmbH',
+        purposes: [1, 2, 7, 8, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 7, 8, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [1],
+        policyUrl: 'https://permodo.com/de/privacy.html',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '142': {
+        id: 142,
+        name: 'Media.net Advertising FZ-LLC',
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [5, 6, 8],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://www.media.net/en/privacy-policy'
+      },
+      '143': {
+        id: 143,
+        name: 'Connatix Native Exchange Inc.',
+        purposes: [1, 2, 4, 6, 7, 8, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://connatix.com/privacy-policy/'
+      },
+      '144': {
+        id: 144,
+        name: 'district m inc.',
+        purposes: [1, 2, 4, 7, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [2],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl:
+          'https://districtm.net/en/page/platforms-data-and-privacy-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '147': {
+        id: 147,
+        name: 'Adacado Technologies Inc. (DBA Adacado)',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.adacado.com/privacy-policy-april-25-2018/'
+      },
+      '149': {
+        id: 149,
+        name: 'ADman Interactive SLU',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2],
+        specialPurposes: [],
+        features: [2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://admanmedia.com/politica.html?setLng=es'
+      },
+      '150': {
+        id: 150,
+        name: 'Inskin Media LTD',
+        purposes: [1, 3, 4, 9, 10],
+        legIntPurposes: [2, 7],
+        flexiblePurposes: [2, 7],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'http://www.inskinmedia.com/privacy-policy.html'
+      },
+      '152': {
+        id: 152,
+        name: 'Meetrics GmbH',
+        purposes: [1, 9],
+        legIntPurposes: [7],
+        flexiblePurposes: [7],
+        specialPurposes: [1],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.meetrics.com/en/data-privacy/'
+      },
+      '153': {
+        id: 153,
+        name: 'MADVERTISE MEDIA',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [5, 6, 10],
+        specialPurposes: [2],
+        features: [],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://madvertise.com/en/gdpr/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '154': {
+        id: 154,
+        name: 'YOC AG',
+        purposes: [1, 3, 4, 10],
+        legIntPurposes: [2, 7],
+        flexiblePurposes: [2, 7],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://yoc.com/privacy/'
+      },
+      '155': {
+        id: 155,
+        name: 'AntVoice',
+        purposes: [1, 2, 3, 4, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.antvoice.com/en/privacypolicy/'
+      },
+      '157': {
+        id: 157,
+        name: 'Seedtag Advertising S.L',
+        purposes: [1, 2, 3, 4],
+        legIntPurposes: [7, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.seedtag.com/en/privacy-policy/'
+      },
+      '160': {
+        id: 160,
+        name: 'Netsprint SA',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://netsprint.eu/privacy.html',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '161': {
+        id: 161,
+        name: 'Smadex SL',
+        purposes: [1, 2, 3, 4, 7, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'http://smadex.com/end-user-privacy-policy/'
+      },
+      '162': {
+        id: 162,
+        name: 'Unruly Group Ltd',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://unruly.co/privacy/'
+      },
+      '163': {
+        id: 163,
+        name: 'Bombora Inc.',
+        purposes: [1, 3, 8],
+        legIntPurposes: [7, 10],
+        flexiblePurposes: [7, 10],
+        specialPurposes: [],
+        features: [1],
+        specialFeatures: [],
+        policyUrl: 'https://bombora.com/privacy'
+      },
+      '164': {
+        id: 164,
+        name: 'Outbrain UK Ltd',
+        purposes: [1],
+        legIntPurposes: [3, 4, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.outbrain.com/legal/privacy#privacy-policy'
+      },
+      '165': {
+        id: 165,
+        name: 'SpotX, Inc.',
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 9, 10],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.spotx.tv/privacy-policy/',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '167': {
+        id: 167,
+        name: 'Audiens S.r.l.',
+        purposes: [1, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'http://www.audiens.com/privacy'
+      },
+      '168': {
+        id: 168,
+        name: 'EASYmedia GmbH',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://login.rtbmarket.com/gdpr'
+      },
+      '173': {
+        id: 173,
+        name: 'Yieldmo, Inc.',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.yieldmo.com/privacy/'
+      },
+      '174': {
+        id: 174,
+        name: 'A Million Ads Ltd',
+        purposes: [],
+        legIntPurposes: [2, 4],
+        flexiblePurposes: [2, 4],
+        specialPurposes: [],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://www.amillionads.com/privacy-policy'
+      },
+      '177': {
+        id: 177,
+        name: 'plista GmbH',
+        purposes: [1],
+        legIntPurposes: [7, 8, 10],
+        flexiblePurposes: [7, 8, 10],
+        specialPurposes: [2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.plista.com/about/privacy/'
+      },
+      '178': {
+        id: 178,
+        name: 'Hybrid Theory',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [7, 8, 9, 10],
+        specialPurposes: [1],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://hybridtheory.com/privacy-policy/'
+      },
+      '179': {
+        id: 179,
+        name: 'Collective Europe Ltd.',
+        purposes: [1, 2, 3, 4, 9],
+        legIntPurposes: [7],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://www.collectiveuk.com/privacy.html',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '184': {
+        id: 184,
+        name: 'mediarithmics SAS',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 7],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.mediarithmics.com/en-us/content/privacy-policy'
+      },
+      '185': {
+        id: 185,
+        name: 'Bidtellect, Inc',
+        purposes: [1, 2, 3, 4, 7, 8],
+        legIntPurposes: [9, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.bidtellect.com/privacy-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '190': {
+        id: 190,
+        name: 'video intelligence AG',
+        purposes: [],
+        legIntPurposes: [2, 7, 8, 9, 10],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.vi.ai/privacy-policy/'
+      },
+      '192': {
+        id: 192,
+        name: 'remerge GmbH',
+        purposes: [7],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://remerge.io/privacy-policy.html'
+      },
+      '193': {
+        id: 193,
+        name: 'Mediasmart Mobile S.L.',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'http://mediasmart.io/privacy/'
+      },
+      '194': {
+        id: 194,
+        name: 'Rezonence Limited',
+        purposes: [1, 3, 4, 9],
+        legIntPurposes: [2, 7, 8, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://rezonence.com/privacy-policy/'
+      },
+      '195': {
+        id: 195,
+        name: 'advanced store GmbH',
+        purposes: [1, 3, 4],
+        legIntPurposes: [2],
+        flexiblePurposes: [2],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.advanced-store.com/de/datenschutz/'
+      },
+      '199': {
+        id: 199,
+        name: 'ADUX',
+        purposes: [1, 2, 3, 4, 6, 7, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [2],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://www.adux.com/donnees-personelles/'
+      },
+      '200': {
+        id: 200,
+        name: 'Tapjoy, Inc.',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7],
+        flexiblePurposes: [2, 3, 4, 7],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://www.tapjoy.com/legal/#privacy-policy'
+      },
+      '203': {
+        id: 203,
+        name: 'Revcontent, LLC',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl:
+          'https://intercom.help/revcontent2/en/articles/2290675-revcontent-s-privacy-policy'
+      },
+      '205': {
+        id: 205,
+        name: 'Adssets AB',
+        purposes: [1, 2, 4, 7, 8, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://adssets.com/policy/'
+      },
+      '206': {
+        id: 206,
+        name: 'Hybrid Adtech GmbH',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://hybrid.ai/data_protection_policy'
+      },
+      '209': {
+        id: 209,
+        name: 'Delta Projects AB',
+        purposes: [1, 2, 3, 4],
+        legIntPurposes: [7, 10],
+        flexiblePurposes: [2, 7, 10],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://deltaprojects.com/data-collection-policy'
+      },
+      '210': {
+        id: 210,
+        name: 'Zemanta, Inc.',
+        purposes: [1],
+        legIntPurposes: [3, 7, 9, 10],
+        flexiblePurposes: [3, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1],
+        specialFeatures: [],
+        policyUrl: 'http://www.zemanta.com/legal/privacy'
+      },
+      '211': {
+        id: 211,
+        name: 'AdTheorent, Inc',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'http://adtheorent.com/privacy-policy'
+      },
+      '212': {
+        id: 212,
+        name: 'usemax advertisement (Emego GmbH)',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.usemax.de/?l=privacy'
+      },
+      '213': {
+        id: 213,
+        name: 'emetriq GmbH',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [2],
+        features: [1, 2],
+        specialFeatures: [],
+        policyUrl: 'https://www.emetriq.com/datenschutz/'
+      },
+      '215': {
+        id: 215,
+        name: 'ARMIS SAS',
+        purposes: [1, 2, 7],
+        legIntPurposes: [10],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://armis.tech/en/armis-personal-data-privacy-policy/'
+      },
+      '216': {
+        id: 216,
+        name: 'Mindlytix SAS',
+        purposes: [1, 2, 3, 5, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1],
+        features: [1, 2],
+        specialFeatures: [],
+        policyUrl: 'http://mindlytix.com/privacy/'
+      },
+      '217': {
+        id: 217,
+        name: '2KDirect, Inc. (dba iPromote)',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7, 9, 10],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.ipromote.com/privacy-policy/'
+      },
+      '218': {
+        id: 218,
+        name: 'Bigabid Media ltd',
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.bigabid.com/privacy-policy'
+      },
+      '223': {
+        id: 223,
+        name: 'Audience Trading Platform Ltd.',
+        purposes: [1],
+        legIntPurposes: [7, 8],
+        flexiblePurposes: [7, 8],
+        specialPurposes: [],
+        features: [2],
+        specialFeatures: [],
+        policyUrl: 'https://atp.io/privacy-policy'
+      },
+      '224': {
+        id: 224,
+        name: 'adrule mobile GmbH',
+        purposes: [1, 2, 3, 4, 8],
+        legIntPurposes: [7],
+        flexiblePurposes: [2, 3, 4, 7, 8],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://www.adrule.net/de/datenschutz/'
+      },
+      '226': {
+        id: 226,
+        name: 'Publicis Media GmbH',
+        purposes: [1, 9],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 10],
+        specialPurposes: [],
+        features: [1],
+        specialFeatures: [],
+        policyUrl: 'https://www.publicismedia.de/datenschutz/'
+      },
+      '227': {
+        id: 227,
+        name: 'ORTEC B.V.',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.ortecadscience.com/privacy-policy/'
+      },
+      '228': {
+        id: 228,
+        name: 'McCann Discipline LTD',
+        purposes: [1, 2, 5, 6, 7, 8],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.primis.tech/privacy-policy/'
+      },
+      '231': {
+        id: 231,
+        name: 'AcuityAds Inc.',
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 8, 10],
+        flexiblePurposes: [3, 4],
+        specialPurposes: [1, 2],
+        features: [2],
+        specialFeatures: [],
+        policyUrl:
+          'https://privacy.acuityads.com/corporate-privacy-policy.html',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '234': {
+        id: 234,
+        name: 'ZBO Media',
+        purposes: [1, 3, 4, 9],
+        legIntPurposes: [2, 7, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1],
+        specialFeatures: [],
+        policyUrl:
+          'https://zbo.media/mentions-legales/politique-de-confidentialite-service-publicitaire/'
+      },
+      '235': {
+        id: 235,
+        name: 'Bucksense Inc',
+        purposes: [2, 3, 4, 7, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 7, 9],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'http://www.bucksense.com/platform-privacy-policy/'
+      },
+      '240': {
+        id: 240,
+        name: '7Hops.com Inc. (ZergNet)',
+        purposes: [1],
+        legIntPurposes: [5, 6, 8, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://zergnet.com/privacy'
+      },
+      '241': {
+        id: 241,
+        name: 'OneTag Limited',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [7],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.onetag.com/privacy/'
+      },
+      '242': {
+        id: 242,
+        name: 'twiago GmbH',
+        purposes: [1, 2, 3, 4, 7, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 7],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://www.twiago.com/datenschutz/',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '243': {
+        id: 243,
+        name: 'Cloud Technologies S.A.',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl:
+          'https://www.cloudtechnologies.pl/en/internet-advertising-privacy-policy'
+      },
+      '248': {
+        id: 248,
+        name: 'Converge-Digital',
+        purposes: [1],
+        legIntPurposes: [2],
+        flexiblePurposes: [2],
+        specialPurposes: [],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://converge-digital.com/privacy-policy/',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '249': {
+        id: 249,
+        name: 'Spolecznosci Sp. z o.o. Sp. k.',
+        purposes: [1, 2, 3, 4, 5, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 5, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.spolecznosci.pl/polityka-prywatnosci'
+      },
+      '250': {
+        id: 250,
+        name: 'Qriously Ltd',
+        purposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.brandwatch.com/legal/qriously-privacy-notice/'
+      },
+      '251': {
+        id: 251,
+        name: 'Yieldlove GmbH',
+        purposes: [1],
+        legIntPurposes: [2, 7, 10],
+        flexiblePurposes: [2, 7, 10],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.yieldlove.com/cookie-policy'
+      },
+      '252': {
+        id: 252,
+        name: 'Jaduda GmbH',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.jadudamobile.com/datenschutzerklaerung/'
+      },
+      '253': {
+        id: 253,
+        name: 'Improve Digital BV',
+        purposes: [1, 3, 4, 9],
+        legIntPurposes: [2, 7, 10],
+        flexiblePurposes: [2, 7, 10],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.improvedigital.com/platform-privacy-policy',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '255': {
+        id: 255,
+        name: 'Onnetwork Sp. z o.o.',
+        purposes: [1, 5, 6],
+        legIntPurposes: [2, 7, 8],
+        flexiblePurposes: [],
+        specialPurposes: [2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.onnetwork.tv/pp_services.php'
+      },
+      '256': {
+        id: 256,
+        name: 'Bounce Exchange, Inc',
+        purposes: [1],
+        legIntPurposes: [7, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.bouncex.com/privacy/'
+      },
+      '262': {
+        id: 262,
+        name: 'Fyber ',
+        purposes: [1, 2, 3, 4, 5, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.fyber.com/legal/privacy-policy/'
+      },
+      '263': {
+        id: 263,
+        name: 'Nativo, Inc.',
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 9, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [2],
+        specialFeatures: [],
+        policyUrl: 'https://www.nativo.com/interest-based-ads'
+      },
+      '265': {
+        id: 265,
+        name: 'Instinctive, Inc.',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8],
+        legIntPurposes: [9, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'https://instinctive.io/privacy'
+      },
+      '272': {
+        id: 272,
+        name: 'A.Mob',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.we-are-adot.com/privacy-policy/'
+      },
+      '273': {
+        id: 273,
+        name: 'Bannerflow AB',
+        purposes: [1, 4],
+        legIntPurposes: [7],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.bannerflow.com/privacy '
+      },
+      '275': {
+        id: 275,
+        name: 'TabMo SAS',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl:
+          'http://static.tabmo.io.s3.amazonaws.com/privacy-policy/index.html'
+      },
+      '277': {
+        id: 277,
+        name: 'Codewise VL Sp. z o.o. Sp. k',
+        purposes: [1, 2, 3, 4, 7, 9],
+        legIntPurposes: [10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://voluumdsp.com/end-user-privacy-policy/'
+      },
+      '278': {
+        id: 278,
+        name: 'Integral Ad Science, Inc.',
+        purposes: [],
+        legIntPurposes: [7, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://integralads.com/privacy-policy/'
+      },
+      '279': {
+        id: 279,
+        name: 'Mirando GmbH &amp; Co KG',
+        purposes: [1],
+        legIntPurposes: [2, 7],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://wwwmirando.de/datenschutz/'
+      },
+      '280': {
+        id: 280,
+        name: 'Spot.IM LTD',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://www.spot.im/privacy/'
+      },
+      '281': {
+        id: 281,
+        name: 'Wizaly',
+        purposes: [1, 7, 8, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2],
+        specialFeatures: [],
+        policyUrl: 'https://www.wizaly.com/terms-of-use#privacy-policy'
+      },
+      '282': {
+        id: 282,
+        name: 'Welect GmbH',
+        purposes: [10],
+        legIntPurposes: [2, 7],
+        flexiblePurposes: [],
+        specialPurposes: [2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.welect.de/datenschutz'
+      },
+      '284': {
+        id: 284,
+        name: 'WEBORAMA',
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [2, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [1],
+        policyUrl: 'https://weborama.com/privacy_en/'
+      },
+      '285': {
+        id: 285,
+        name: 'Comcast International France SAS',
+        purposes: [1],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.freewheel.com/privacy-policy'
+      },
+      '289': {
+        id: 289,
+        name: 'mobalo GmbH',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1],
+        specialFeatures: [1],
+        policyUrl: 'https://www.mobalo.com/en/privacy/'
+      },
+      '290': {
+        id: 290,
+        name: 'Readpeak Oy',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://readpeak.com/privacy-policy/'
+      },
+      '293': {
+        id: 293,
+        name: 'SpringServe, LLC',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1],
+        features: [3],
+        specialFeatures: [2],
+        policyUrl: 'https://springserve.com/privacy-policy/'
+      },
+      '294': {
+        id: 294,
+        name: 'Jivox Corporation',
+        purposes: [1, 2, 3, 4, 5, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 5, 7],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.jivox.com/privacy',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '299': {
+        id: 299,
+        name: 'AdClear GmbH',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [2],
+        features: [1, 2],
+        specialFeatures: [],
+        policyUrl: 'https://www.adclear.de/datenschutzerklaerung/'
+      },
+      '301': {
+        id: 301,
+        name: 'zeotap GmbH',
+        purposes: [1, 3, 4, 5, 6, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [3, 4, 5, 6, 7, 9, 10],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://zeotap.com/privacy_policy'
+      },
+      '302': {
+        id: 302,
+        name: 'Mobile Professionals BV',
+        purposes: [1, 2, 3, 4, 5, 7, 8, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [3, 5, 7, 8],
+        specialPurposes: [],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'https://mobpro.com/privacy.html'
+      },
+      '303': {
+        id: 303,
+        name: 'Orion Semantics',
+        purposes: [1, 2, 3, 4, 7, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://static.orion-semantics.com/privacy.html'
+      },
+      '304': {
+        id: 304,
+        name: 'On Device Research Limited',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://s.on-device.com/privacyPolicy'
+      },
+      '310': {
+        id: 310,
+        name: 'Adevinta Spain S.L.U.',
+        purposes: [1, 2, 3, 4, 9],
+        legIntPurposes: [7, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.adevinta.com/about/privacy/'
+      },
+      '312': {
+        id: 312,
+        name: 'Exactag GmbH',
+        purposes: [1, 3, 7, 8],
+        legIntPurposes: [],
+        flexiblePurposes: [3, 7, 8],
+        specialPurposes: [1],
+        features: [2],
+        specialFeatures: [],
+        policyUrl: 'https://www.exactag.com/en/data-privacy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '314': {
+        id: 314,
+        name: 'Keymantics',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.keymantics.com/assets/privacy-policy.pdf'
+      },
+      '315': {
+        id: 315,
+        name: 'Celtra, Inc.',
+        purposes: [1, 2, 4, 7, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://www.celtra.com/privacy-policy/'
+      },
+      '316': {
+        id: 316,
+        name: 'Gamned',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://www.gamned.com/privacy-policy/'
+      },
+      '317': {
+        id: 317,
+        name: 'mainADV Srl',
+        purposes: [1, 2, 3, 4, 5, 6, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.mainad.com/privacy-policy/'
+      },
+      '318': {
+        id: 318,
+        name: 'Accorp Sp. z o.o.',
+        purposes: [1, 3, 4, 9],
+        legIntPurposes: [7, 10],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [2],
+        specialFeatures: [],
+        policyUrl: 'http://www.instytut-pollster.pl/privacy-policy/'
+      },
+      '319': {
+        id: 319,
+        name: 'Clipcentric, Inc.',
+        purposes: [1],
+        legIntPurposes: [2, 7, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://clipcentric.com/privacy.bhtml'
+      },
+      '325': {
+        id: 325,
+        name: 'Knorex',
+        purposes: [1, 2, 3, 4, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.knorex.com/privacy'
+      },
+      '328': {
+        id: 328,
+        name: 'Gemius SA',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://www.gemius.com/cookie-policy.html'
+      },
+      '329': {
+        id: 329,
+        name: 'Browsi Mobile Ltd',
+        purposes: [1, 7, 8],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://gobrowsi.com/browsi-privacy-policy/'
+      },
+      '333': {
+        id: 333,
+        name: 'InMobi Pte Ltd',
+        purposes: [1, 2, 3, 4, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [9],
+        specialPurposes: [1],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.inmobi.com/privacy-policy-for-eea'
+      },
+      '336': {
+        id: 336,
+        name: 'Telecoming S.A.',
+        purposes: [2, 4],
+        legIntPurposes: [7, 9],
+        flexiblePurposes: [2, 4],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.telecoming.com/privacy-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '343': {
+        id: 343,
+        name: 'DIGITEKA Technologies',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://www.ultimedia.com/POLICY.html'
+      },
+      '345': {
+        id: 345,
+        name: 'The Kantar Group Limited',
+        purposes: [1, 2, 3, 4, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 7, 8, 9, 10],
+        specialPurposes: [2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'http://www.kantar.com/cookies-policies'
+      },
+      '350': {
+        id: 350,
+        name: 'Free Stream Media Corp. dba Samba TV',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://samba.tv/legal/privacy-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '351': {
+        id: 351,
+        name: 'Samba TV UK Limited',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://samba.tv/legal/privacy-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '354': {
+        id: 354,
+        name: 'Apester Ltd',
+        purposes: [2, 4],
+        legIntPurposes: [6, 7, 8, 9, 10],
+        flexiblePurposes: [7],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://apester.com/privacy-policy/'
+      },
+      '358': {
+        id: 358,
+        name: 'MGID Inc.',
+        purposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.mgid.com/privacy-policy'
+      },
+      '359': {
+        id: 359,
+        name: 'AerServ LLC',
+        purposes: [1, 2, 3, 4, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [9],
+        specialPurposes: [1],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.inmobi.com/privacy-policy-for-eea'
+      },
+      '365': {
+        id: 365,
+        name: 'Forensiq LLC',
+        purposes: [],
+        legIntPurposes: [7],
+        flexiblePurposes: [],
+        specialPurposes: [1],
+        features: [1, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://impact.com/privacy-policy/'
+      },
+      '368': {
+        id: 368,
+        name: 'VECTAURY',
+        purposes: [1, 2, 3, 4, 7, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.vectaury.io/en/personal-data'
+      },
+      '371': {
+        id: 371,
+        name: 'Seeding Alliance GmbH',
+        purposes: [],
+        legIntPurposes: [2, 7, 8],
+        flexiblePurposes: [7],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://seeding-alliance.de/datenschutz'
+      },
+      '373': {
+        id: 373,
+        name: 'Nielsen Marketing Cloud',
+        purposes: [1, 3, 5],
+        legIntPurposes: [7, 8, 9, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl:
+          'http://www.nielsen.com/us/en/privacy-statement/exelate-privacy-policy.html'
+      },
+      '374': {
+        id: 374,
+        name: 'Bmind a Sales Maker Company, S.L.',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [],
+        policyUrl: 'http://www.bmind.es/legal-notice/'
+      },
+      '377': {
+        id: 377,
+        name: 'AddApptr GmbH',
+        purposes: [1],
+        legIntPurposes: [7, 10],
+        flexiblePurposes: [7, 10],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://www.addapptr.com/data-privacy'
+      },
+      '381': {
+        id: 381,
+        name: 'Solocal',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://frontend.adhslx.com/privacy.html?'
+      },
+      '382': {
+        id: 382,
+        name: 'The Reach Group GmbH',
+        purposes: [1, 3, 4, 5, 6, 9],
+        legIntPurposes: [2, 7, 8],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://trg.de/en/privacy-statement/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '385': {
+        id: 385,
+        name: 'Oracle Data Cloud',
+        purposes: [1, 3, 5, 9, 10],
+        legIntPurposes: [7],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2],
+        specialFeatures: [],
+        policyUrl:
+          'https://www.oracle.com/legal/privacy/marketing-cloud-data-cloud-privacy-policy.html'
+      },
+      '387': {
+        id: 387,
+        name: 'Triapodi Ltd.',
+        purposes: [2, 3, 4, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://appreciate.mobi/page.html#/end-user-privacy-policy'
+      },
+      '388': {
+        id: 388,
+        name: 'numberly',
+        purposes: [1, 3, 4, 5, 6, 9],
+        legIntPurposes: [2, 7, 8, 10],
+        flexiblePurposes: [2, 7, 8, 10],
+        specialPurposes: [1],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://numberly.com/en/privacy/'
+      },
+      '394': {
+        id: 394,
+        name: 'AudienceProject Aps',
+        purposes: [1, 3, 4, 5, 6],
+        legIntPurposes: [2, 7, 8, 9, 10],
+        flexiblePurposes: [2, 7, 8, 9],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [],
+        policyUrl: 'https://privacy.audienceproject.com'
+      },
+      '402': {
+        id: 402,
+        name: 'Effiliation',
+        purposes: [1, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl:
+          'https://inter.effiliation.com/politique-confidentialite.html'
+      },
+      '408': {
+        id: 408,
+        name: 'Fidelity Media',
+        purposes: [1, 2, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 7],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://fidelity-media.com/privacy-policy/'
+      },
+      '409': {
+        id: 409,
+        name: 'Arrivalist Co.',
+        purposes: [1, 9],
+        legIntPurposes: [7, 8],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://www.arrivalist.com/privacy'
+      },
+      '410': {
+        id: 410,
+        name: 'Adtelligent Inc.',
+        purposes: [1, 7, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'https://adtelligent.com/privacy-policy/'
+      },
+      '412': {
+        id: 412,
+        name: 'Cxense ASA',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.cxense.com/about-us/privacy-policy'
+      },
+      '413': {
+        id: 413,
+        name: 'Eulerian Technologies',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.eulerian.com/en/privacy/'
+      },
+      '415': {
+        id: 415,
+        name: 'Seenthis AB',
+        purposes: [],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://seenthis.co/privacy-notice-2018-04-18.pdf'
+      },
+      '416': {
+        id: 416,
+        name: 'Commanders Act',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.commandersact.com/en/privacy/'
+      },
+      '418': {
+        id: 418,
+        name: 'PROXISTORE',
+        purposes: [1, 2, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [2],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://www.proxistore.com/common/en/cgv'
+      },
+      '422': {
+        id: 422,
+        name: 'Brand Metrics Sweden AB',
+        purposes: [1, 6, 7, 8, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl:
+          'https://collector.brandmetrics.com/brandmetrics_privacypolicy.pdf'
+      },
+      '423': {
+        id: 423,
+        name: 'travel audience GmbH',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2],
+        specialFeatures: [1],
+        policyUrl: 'https://travelaudience.com/product-privacy-policy/'
+      },
+      '424': {
+        id: 424,
+        name: 'KUPONA GmbH',
+        purposes: [4, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [4],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.kupona.de/dsgvo/'
+      },
+      '428': {
+        id: 428,
+        name: 'Internet BillBoard a.s.',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7],
+        flexiblePurposes: [2, 3, 4],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.ibillboard.com/en/privacy-information/'
+      },
+      '429': {
+        id: 429,
+        name: 'Signals',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://signalsdata.com/platform-cookie-policy/'
+      },
+      '431': {
+        id: 431,
+        name: 'White Ops, Inc.',
+        purposes: [],
+        legIntPurposes: [7, 9, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 3],
+        specialFeatures: [2],
+        policyUrl: 'https://www.whiteops.com/privacy'
+      },
+      '436': {
+        id: 436,
+        name: 'INVIBES GROUP',
+        purposes: [1, 3, 4, 5, 6, 9],
+        legIntPurposes: [2, 7, 8, 10],
+        flexiblePurposes: [2, 10],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'http://www.invibes.com/terms'
+      },
+      '438': {
+        id: 438,
+        name: 'INVIDI technologies AB',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
+        specialPurposes: [],
+        features: [1, 2],
+        specialFeatures: [],
+        policyUrl:
+          'http://www.invidi.com/wp-content/uploads/2020/02/ad-tech-services-privacy-policy.pdf'
+      },
+      '439': {
+        id: 439,
+        name: 'Bit Q Holdings Limited',
+        purposes: [1, 7, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.rippll.com/privacy'
+      },
+      '440': {
+        id: 440,
+        name: 'DEFINE MEDIA GMBH',
+        purposes: [1, 4],
+        legIntPurposes: [2, 7, 9, 10],
+        flexiblePurposes: [2, 4, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.definemedia.de/datenschutz-conative/'
+      },
+      '444': {
+        id: 444,
+        name: 'Playbuzz Ltd (aka EX.CO)',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 5, 6],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://ex.co/privacy-policy/'
+      },
+      '447': {
+        id: 447,
+        name: 'Adludio Ltd',
+        purposes: [2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1],
+        specialFeatures: [1],
+        policyUrl: 'https://www.adludio.com/privacy-policy/'
+      },
+      '450': {
+        id: 450,
+        name: 'Neodata Group srl',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.neodatagroup.com/en/security-policy',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '455': {
+        id: 455,
+        name: 'GDMServices, Inc. d/b/a FiksuDSP',
+        purposes: [1, 2, 3, 4, 10],
+        legIntPurposes: [7, 8],
+        flexiblePurposes: [2, 3, 4, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://fiksu.com/privacy-policy/'
+      },
+      '466': {
+        id: 466,
+        name: 'TACTIC™ Real-Time Marketing AS',
+        purposes: [],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://tacticrealtime.com/privacy/'
+      },
+      '467': {
+        id: 467,
+        name: 'Haensel AMS GmbH',
+        purposes: [1],
+        legIntPurposes: [7],
+        flexiblePurposes: [7],
+        specialPurposes: [],
+        features: [2],
+        specialFeatures: [],
+        policyUrl: 'https://haensel-ams.com/data-privacy/'
+      },
+      '475': {
+        id: 475,
+        name: 'TAPTAP Digital SL',
+        purposes: [1, 2, 3, 4, 5, 6, 7],
+        legIntPurposes: [8, 10],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'http://www.taptapnetworks.com/privacy_policy/'
+      },
+      '479': {
+        id: 479,
+        name: 'INFINIA MOBILE S.L.',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'http://www.infiniamobile.com/privacy_policy'
+      },
+      '484': {
+        id: 484,
+        name: 'STRIATUM SAS',
+        purposes: [],
+        legIntPurposes: [7, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://adledge.com/data-privacy/'
+      },
+      '486': {
+        id: 486,
+        name: 'Madington',
+        purposes: [],
+        legIntPurposes: [7, 8, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://delivered-by-madington.com/dat-privacy-policy/'
+      },
+      '488': {
+        id: 488,
+        name: 'Opinary GmbH',
+        purposes: [1],
+        legIntPurposes: [2, 7, 8, 10],
+        flexiblePurposes: [2, 7, 8, 10],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://opinary.com/privacy-policy/'
+      },
+      '490': {
+        id: 490,
+        name: 'PLAYGROUND XYZ EMEA LTD',
+        purposes: [1, 2, 3, 4, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 7],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://playground.xyz/privacy'
+      },
+      '491': {
+        id: 491,
+        name: 'Triboo Data Analytics',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl:
+          'https://www.shinystat.com/it/informativa_privacy_generale.html'
+      },
+      '495': {
+        id: 495,
+        name: 'Arcspire Limited',
+        purposes: [2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'https://public.arcspire.io/privacy.pdf',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '498': {
+        id: 498,
+        name: 'Dr. Banner',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8],
+        legIntPurposes: [9, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://drbanner.com/privacypolicy_en/'
+      },
+      '501': {
+        id: 501,
+        name: 'Alliance Gravity Data Media',
+        purposes: [1, 2, 3, 4, 7, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2],
+        specialFeatures: [],
+        policyUrl:
+          'https://www.alliancegravity.com/politiquedeprotectiondesdonneespersonnelles'
+      },
+      '502': {
+        id: 502,
+        name: 'NEXD',
+        purposes: [1, 7, 10],
+        legIntPurposes: [9],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://nexd.com/privacy-policy',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '505': {
+        id: 505,
+        name: 'Shopalyst Inc',
+        purposes: [1, 7, 8],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://www.shortlyst.com/eu/privacy_terms.html'
+      },
+      '507': {
+        id: 507,
+        name: 'AdsWizz Inc.',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://www.adswizz.com/our-privacy-policy/'
+      },
+      '508': {
+        id: 508,
+        name: 'Lucid Holdings, LLC',
+        purposes: [1, 7, 8, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [7, 8, 9],
+        specialPurposes: [1],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'luc.id/privacy-policy'
+      },
+      '511': {
+        id: 511,
+        name: 'Admixer EU GmbH',
+        purposes: [1, 2, 3, 4, 5, 7, 9],
+        legIntPurposes: [10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [1],
+        policyUrl: 'https://admixer.com/privacy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '512': {
+        id: 512,
+        name: 'PubNative GmbH',
+        purposes: [1, 2, 3, 4, 7, 8, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [3],
+        specialFeatures: [2],
+        policyUrl: 'https://pubnative.net/privacy-notice/'
+      },
+      '516': {
+        id: 516,
+        name: 'Pexi B.V.',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://pexi.nl/privacy-policy/'
+      },
+      '517': {
+        id: 517,
+        name: 'SunMedia ',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://www.sunmedia.tv/en/cookies'
+      },
+      '521': {
+        id: 521,
+        name: 'netzeffekt GmbH',
+        purposes: [1, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://www.netzeffekt.de/en/imprint'
+      },
+      '524': {
+        id: 524,
+        name: 'The Ozone Project Limited',
+        purposes: [1, 2, 3, 4, 5, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://ozoneproject.com/privacy-policy'
+      },
+      '527': {
+        id: 527,
+        name: 'Jampp LTD',
+        purposes: [1, 2, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://jampp.com/privacy.html'
+      },
+      '528': {
+        id: 528,
+        name: 'Kayzen',
+        purposes: [1, 2, 3, 4, 9, 10],
+        legIntPurposes: [7],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1],
+        specialFeatures: [],
+        policyUrl: 'https://kayzen.io/data-privacy-policy'
+      },
+      '530': {
+        id: 530,
+        name: 'Near Pte Ltd',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 9, 10],
+        specialPurposes: [],
+        features: [1, 2],
+        specialFeatures: [1],
+        policyUrl: 'https://near.co/privacy',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '531': {
+        id: 531,
+        name: 'Smartclip Hispania SL',
+        purposes: [1, 2, 3, 4, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [2, 3],
+        specialFeatures: [1],
+        policyUrl: 'http://rgpd-smartclip.com/'
+      },
+      '535': {
+        id: 535,
+        name: 'INNITY',
+        purposes: [1, 2, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [],
+        policyUrl: 'https://www.innity.com/privacy-policy.php'
+      },
+      '536': {
+        id: 536,
+        name: 'GlobalWebIndex',
+        purposes: [1, 7, 8, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'http://legal.trendstream.net/non-panellist_privacy_policy'
+      },
+      '539': {
+        id: 539,
+        name: 'AdDefend GmbH',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7],
+        flexiblePurposes: [2, 3, 4, 7],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://www.addefend.com/en/privacy-policy/'
+      },
+      '543': {
+        id: 543,
+        name: 'PaperG, Inc. dba Thunder Industries',
+        purposes: [1, 3, 4, 5, 6],
+        legIntPurposes: [2, 7, 8],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.makethunder.com/privacy'
+      },
+      '544': {
+        id: 544,
+        name: 'Kochava Inc.',
+        purposes: [],
+        legIntPurposes: [7],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://www.kochava.com/support-privacy/'
+      },
+      '545': {
+        id: 545,
+        name: 'Reignn Platform Ltd',
+        purposes: [1, 2, 3, 4, 7, 8, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [2],
+        policyUrl: 'http://reignn.com/user-privacy-policy'
+      },
+      '546': {
+        id: 546,
+        name: 'Smart Traffik',
+        purposes: [1, 8],
+        legIntPurposes: [7],
+        flexiblePurposes: [7, 8],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://smart-traffik.io/politique-de-confidentialite'
+      },
+      '549': {
+        id: 549,
+        name: 'Bandsintown Amplified LLC',
+        purposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://corp.bandsintown.com/privacy'
+      },
+      '550': {
+        id: 550,
+        name: 'Happydemics',
+        purposes: [7],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.iubenda.com/privacy-policy/69056167/full-legal'
+      },
+      '553': {
+        id: 553,
+        name: 'Adhese',
+        purposes: [1, 2, 3, 4, 7, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [1],
+        policyUrl: 'https://adhese.com/privacy-and-cookie-policy'
+      },
+      '554': {
+        id: 554,
+        name: 'RMSi Radio Marketing Service interactive GmbH',
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 9],
+        flexiblePurposes: [2],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://www.rms.de/datenschutz/'
+      },
+      '556': {
+        id: 556,
+        name: 'adhood.com',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [1],
+        policyUrl:
+          'http://v3.adhood.com/en/site/politikavekurallar/gizlilik.php?lang=en'
+      },
+      '559': {
+        id: 559,
+        name: 'Otto (GmbH &amp; Co KG)',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7, 9, 10],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.otto.de/shoppages/service/datenschutz'
+      },
+      '561': {
+        id: 561,
+        name: 'AuDigent',
+        purposes: [1, 2, 3, 4, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [2, 3],
+        specialFeatures: [],
+        policyUrl: 'http://audigent.com/platform-privacy-policy'
+      },
+      '565': {
+        id: 565,
+        name: 'Adobe Audience Manager',
+        purposes: [1, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.adobe.com/privacy/policy.html'
+      },
+      '568': {
+        id: 568,
+        name: 'Jointag S.r.l.',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://www.jointag.com/privacy/kariboo/publisher/third/'
+      },
+      '571': {
+        id: 571,
+        name: 'ViewPay',
+        purposes: [1, 2, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'http://viewpay.tv/mentions-legales/'
+      },
+      '573': {
+        id: 573,
+        name: 'Dailymotion SA',
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 5, 6, 7, 8, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [2],
+        specialFeatures: [],
+        policyUrl: 'https://www.dailymotion.com/legal/privacy',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '574': {
+        id: 574,
+        name: 'Realeyes OU',
+        purposes: [1, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1],
+        specialFeatures: [],
+        policyUrl: 'https://realview.realeyesit.com/privacy'
+      },
+      '577': {
+        id: 577,
+        name: 'Neustar on behalf of The Procter & Gamble Company',
+        purposes: [1, 2, 3, 4, 6, 9],
+        legIntPurposes: [5, 7, 8],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.pg.com/privacy/english/privacy_statement.shtml'
+      },
+      '580': {
+        id: 580,
+        name: 'Goldbach Group AG',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://goldbach.com/ch/de/datenschutz'
+      },
+      '587': {
+        id: 587,
+        name: 'Localsensor B.V.',
+        purposes: [1, 2, 3, 4, 7, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 7, 10],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.localsensor.com/privacy.html'
+      },
+      '591': {
+        id: 591,
+        name: 'Consumable, Inc.',
+        purposes: [1, 2, 4, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://consumable.com/privacy-policy.html'
+      },
+      '593': {
+        id: 593,
+        name: 'Programatica de publicidad S.L.',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://datmean.com/politica-privacidad/'
+      },
+      '596': {
+        id: 596,
+        name: 'InsurAds Technologies SA.',
+        purposes: [1, 2, 3, 4, 5, 6, 9, 10],
+        legIntPurposes: [7, 8],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://www.insurads.com/privacy.html'
+      },
+      '598': {
+        id: 598,
+        name: 'audio content &amp; control GmbH',
+        purposes: [1],
+        legIntPurposes: [2, 7, 9],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://www.audio-cc.com/audiocc_privacy_policy.pdf'
+      },
+      '599': {
+        id: 599,
+        name: 'Maximus Live LLC',
+        purposes: [],
+        legIntPurposes: [7, 8],
+        flexiblePurposes: [],
+        specialPurposes: [1],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://maximusx.com/privacy-policy/'
+      },
+      '601': {
+        id: 601,
+        name: 'WebAds B.V',
+        purposes: [1, 2],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://privacy.webads.eu/'
+      },
+      '602': {
+        id: 602,
+        name: 'Online Solution Int Limited',
+        purposes: [2, 7, 8, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 7, 8, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [],
+        policyUrl: 'https://adsafety.net/privacy.html',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '606': {
+        id: 606,
+        name: 'Impactify ',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://impactify.io/privacy-policy/'
+      },
+      '607': {
+        id: 607,
+        name: 'ucfunnel Co., Ltd.',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.ucfunnel.com/privacy-policy'
+      },
+      '609': {
+        id: 609,
+        name: 'Predicio',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'http://www.predic.io/privacy',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '610': {
+        id: 610,
+        name: 'Azerion Holding B.V.',
+        purposes: [1, 3, 4, 9],
+        legIntPurposes: [2, 5, 6, 7, 8, 10],
+        flexiblePurposes: [2, 5, 6],
+        specialPurposes: [1, 2],
+        features: [2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://azerion.com/business/privacy.html',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '612': {
+        id: 612,
+        name: 'Adnami Aps',
+        purposes: [1],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.adnami.io/privacy',
+        deletedDate: '2020-03-17T00:00:00Z'
+      },
+      '613': {
+        id: 613,
+        name: 'Adserve.zone / Artworx AS',
+        purposes: [1],
+        legIntPurposes: [2, 7],
+        flexiblePurposes: [2],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://adserve.zone/adserveprivacypolicy.html'
+      },
+      '614': {
+        id: 614,
+        name: 'Market Resource Partners LLC',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [2],
+        policyUrl: 'https://www.mrpfd.com/privacy-policy/'
+      },
+      '615': {
+        id: 615,
+        name: 'Adsolutions BV',
+        purposes: [],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.adsolutions.com/privacy-policy/'
+      },
+      '617': {
+        id: 617,
+        name: 'Onfocus (Adagio)',
+        purposes: [1, 2],
+        legIntPurposes: [7],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://adagio.io/privacy'
+      },
+      '618': {
+        id: 618,
+        name: 'BEINTOO SPA',
+        purposes: [1, 2, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1],
+        specialFeatures: [1],
+        policyUrl: 'http://www.beintoo.com/privacy-cookie-policy/'
+      },
+      '620': {
+        id: 620,
+        name: 'Blue',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [2, 3],
+        specialFeatures: [1],
+        policyUrl: 'http://www.getblue.io/privacy/'
+      },
+      '625': {
+        id: 625,
+        name: 'BILENDI SA',
+        purposes: [1, 6, 7, 8, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1],
+        specialFeatures: [],
+        policyUrl: 'https://www.maximiles.com/privacy-policy'
+      },
+      '626': {
+        id: 626,
+        name: 'Hivestack Inc.',
+        purposes: [1, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://hivestack.com/privacy-policy'
+      },
+      '628': {
+        id: 628,
+        name: ': Tappx',
+        purposes: [1, 2, 4, 7, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [2],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://www.tappx.com/en/privacy-policy/'
+      },
+      '630': {
+        id: 630,
+        name: 'Contact Impact GmbH',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7, 10],
+        flexiblePurposes: [2, 3, 4, 7, 10],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://contactimpact.de/privacy'
+      },
+      '631': {
+        id: 631,
+        name: 'Relay42 Netherlands B.V.',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://relay42.com/privacy'
+      },
+      '638': {
+        id: 638,
+        name: 'Passendo Aps',
+        purposes: [1, 2, 4, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://passendo.com/users-privacy-policy'
+      },
+      '639': {
+        id: 639,
+        name: 'Smile Wanted Group',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [2],
+        policyUrl: 'https://www.smilewanted.com/privacy.php'
+      },
+      '645': {
+        id: 645,
+        name: 'Noster Finance S.L.',
+        purposes: [1, 2, 3, 4, 5, 6, 9, 10],
+        legIntPurposes: [7, 8],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://www.finect.com/terminos-legales/politica-de-cookies'
+      },
+      '646': {
+        id: 646,
+        name: 'Notify',
+        purposes: [],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1],
+        specialFeatures: [],
+        policyUrl: 'https://notify-group.com/en/mentions-legales/'
+      },
+      '647': {
+        id: 647,
+        name: 'Axel Springer Teaser Ad GmbH',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7, 10],
+        flexiblePurposes: [2, 3, 4, 7, 10],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://www.adup-tech.com/privacy'
+      },
+      '648': {
+        id: 648,
+        name: 'TrueData Solutions, Inc.',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://www.truedata.co/privacy-policy/'
+      },
+      '649': {
+        id: 649,
+        name: 'adality GmbH',
+        purposes: [],
+        legIntPurposes: [2],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1],
+        specialFeatures: [],
+        policyUrl: 'https://adality.de/en/privacy/'
+      },
+      '650': {
+        id: 650,
+        name: 'Telefonica Investigación y Desarrollo S.A.U',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'http://www.cognitivemarketing.tid.es/'
+      },
+      '652': {
+        id: 652,
+        name: 'Skaze',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'http://www.skaze.fr/rgpd/'
+      },
+      '653': {
+        id: 653,
+        name: 'Smartme Analytics',
+        purposes: [7, 8, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 3],
+        specialFeatures: [],
+        policyUrl: 'http://smartmeapp.com/info/smartme/aviso_legal.php',
+        deletedDate: '2020-07-03T00:00:00Z'
+      },
+      '655': {
+        id: 655,
+        name: 'Sportradar AG',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://www.sportradar.com/about-us/privacy/'
+      },
+      '656': {
+        id: 656,
+        name: 'Think Clever Media',
+        purposes: [1, 2, 3, 4, 5, 6, 9],
+        legIntPurposes: [7, 8, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.contentignite.com/privacy-policy/'
+      },
+      '657': {
+        id: 657,
+        name: 'GP One GmbH',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4],
+        flexiblePurposes: [2, 3, 4],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://www.gsi-one.org/de/privacy-policy.html'
+      },
+      '659': {
+        id: 659,
+        name: 'Research and Analysis of Media in Sweden AB',
+        purposes: [1],
+        legIntPurposes: [7, 8, 9],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [2],
+        specialFeatures: [],
+        policyUrl: 'https://www2.rampanel.com/privacy-policy/'
+      },
+      '662': {
+        id: 662,
+        name: 'SoundCast',
+        purposes: [1, 2, 3, 4, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://soundcast.fm/en/data-privacy'
+      },
+      '663': {
+        id: 663,
+        name: 'Mobsuccess',
+        purposes: [1, 2, 3, 4, 7, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 7],
+        specialPurposes: [1, 2],
+        features: [1],
+        specialFeatures: [],
+        policyUrl: 'https://www.mobsuccess.com/en/privacy'
+      },
+      '664': {
+        id: 664,
+        name: 'adMarketplace, Inc.',
+        purposes: [1, 2, 3, 4],
+        legIntPurposes: [7, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.admarketplace.com/privacy-policy/'
+      },
+      '665': {
+        id: 665,
+        name: 'Digital East GmbH',
+        purposes: [2, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.digitaleast.mobi/en/legal/privacy-policy/'
+      },
+      '667': {
+        id: 667,
+        name: 'Liftoff Mobile, Inc.',
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 5, 6, 7, 8, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 10],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'https://liftoff.io/privacy-policy/'
+      },
+      '668': {
+        id: 668,
+        name: 'WhatRocks Inc. ',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [2],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://www.whatrocks.co/en/privacy-policy '
+      },
+      '674': {
+        id: 674,
+        name: 'Duration Media, LLC.',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.durationmedia.net/privacy-policy'
+      },
+      '675': {
+        id: 675,
+        name: 'Instreamatic inc.',
+        purposes: [2, 3, 4, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://instreamatic.com/privacy-policy/'
+      },
+      '676': {
+        id: 676,
+        name: 'BusinessClick',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [1],
+        policyUrl:
+          'https://www.businessclick.com/documents/RegulaminProgramuBusinessClick-2019.pdf'
+      },
+      '678': {
+        id: 678,
+        name: 'Axonix LTD',
+        purposes: [2],
+        legIntPurposes: [7, 10],
+        flexiblePurposes: [2],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'https://axonix.com/privacy-cookie-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '681': {
+        id: 681,
+        name: 'MyTraffic',
+        purposes: [1, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [9],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://www.mytraffic.io/en/privacy'
+      },
+      '682': {
+        id: 682,
+        name: 'Radio Net Media Limited',
+        purposes: [1, 2, 3, 4],
+        legIntPurposes: [7],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://www.adtonos.com/service-privacy-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '683': {
+        id: 683,
+        name: 'Cookie Market LTD',
+        purposes: [1, 3, 4, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [2, 3],
+        specialFeatures: [1],
+        policyUrl: 'http://cookie.market/privacyPolicy.php'
+      },
+      '684': {
+        id: 684,
+        name: 'Blue Billywig BV',
+        purposes: [],
+        legIntPurposes: [7],
+        flexiblePurposes: [7],
+        specialPurposes: [2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.bluebillywig.com/privacy-statement/'
+      },
+      '686': {
+        id: 686,
+        name: 'The MediaGrid Inc.',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2],
+        specialFeatures: [],
+        policyUrl: 'https://www.themediagrid.com/privacy-policy/'
+      },
+      '687': {
+        id: 687,
+        name: 'MISSENA',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8],
+        legIntPurposes: [],
+        flexiblePurposes: [2],
+        specialPurposes: [2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://missena.com/confidentialite/'
+      },
+      '688': {
+        id: 688,
+        name: 'Effinity',
+        purposes: [],
+        legIntPurposes: [2],
+        flexiblePurposes: [2, 7],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.effiliation.com/politique-de-confidentialite/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '690': {
+        id: 690,
+        name: 'Go.pl sp. z o.o.',
+        purposes: [1, 2, 3, 4],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://go.pl/polityka-prywatnosci/'
+      },
+      '691': {
+        id: 691,
+        name: 'Lifesight Pte. Ltd.',
+        purposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.lifesight.io/privacy-policy/'
+      },
+      '694': {
+        id: 694,
+        name: 'Snapupp Technologies SL',
+        purposes: [2, 3, 4, 5, 6, 9],
+        legIntPurposes: [7, 8, 10],
+        flexiblePurposes: [10],
+        specialPurposes: [],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://www.enterprise.noddus.com/privacy-policy',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '699': {
+        id: 699,
+        name: 'HyperTV Inc.',
+        purposes: [1, 2, 4, 9],
+        legIntPurposes: [7, 10],
+        flexiblePurposes: [],
+        specialPurposes: [2],
+        features: [1],
+        specialFeatures: [],
+        policyUrl: 'https://www.hypertvx.com/privacy/'
+      },
+      '702': {
+        id: 702,
+        name: 'Kwanko',
+        purposes: [1, 2, 7, 8],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 7, 8],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://www.kwanko.com/fr/rgpd/'
+      },
+      '703': {
+        id: 703,
+        name: 'MindTake Research GmbH',
+        purposes: [1, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1],
+        features: [2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.mindtake.com/en/reppublika-privacy-policy'
+      },
+      '707': {
+        id: 707,
+        name: 'Dentsu Aegis Network Italia SpA',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl:
+          'https://www.dentsuaegisnetwork.com/it/it/policies/info-cookie'
+      },
+      '708': {
+        id: 708,
+        name: 'Dugout Limited ',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://dugout.com/privacy-policy'
+      },
+      '709': {
+        id: 709,
+        name: 'NC Audience Exchange, LLC (NewsIQ)',
+        purposes: [1, 3, 4, 5],
+        legIntPurposes: [2, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 5, 7, 8, 9, 10],
+        specialPurposes: [2],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://www.ncaudienceexchange.com/privacy/'
+      },
+      '711': {
+        id: 711,
+        name: 'SITU8ED SA',
+        purposes: [1, 3, 4, 5, 6, 7, 8, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.situ8ed.com/privacy-policy/'
+      },
+      '712': {
+        id: 712,
+        name: 'Inspired Mobile Limited',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://byinspired.com/privacypolicy.pdf'
+      },
+      '713': {
+        id: 713,
+        name: 'Dataseat Ltd',
+        purposes: [2, 3, 4, 5, 6, 7, 8, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 7, 8],
+        specialPurposes: [],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://dataseat.com/privacy-policy'
+      },
+      '714': {
+        id: 714,
+        name: 'Survata Inc.',
+        purposes: [1],
+        legIntPurposes: [7, 9],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.survata.com/respondent-privacy-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '716': {
+        id: 716,
+        name: 'OnAudience Ltd',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl:
+          'https://www.onaudience.com/internet-advertising-privacy-policy'
+      },
+      '719': {
+        id: 719,
+        name: 'Online Advertising Network Sp. z o.o.',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.oan.pl/en/privacy-policy'
+      },
+      '720': {
+        id: 720,
+        name: 'AAX LLC',
+        purposes: [1, 3, 4],
+        legIntPurposes: [2, 7, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://aax.media/privacy/',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '721': {
+        id: 721,
+        name: 'Beaconspark Ltd',
+        purposes: [1, 2, 3, 4, 5, 7],
+        legIntPurposes: [6, 8],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8],
+        specialPurposes: [1, 2],
+        features: [1],
+        specialFeatures: [],
+        policyUrl: 'https://www.engageya.com/privacy'
+      },
+      '722': {
+        id: 722,
+        name: 'agof - daily campaign facts',
+        purposes: [1, 8, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [7],
+        specialPurposes: [1],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.agof.de/datenschutz/'
+      },
+      '723': {
+        id: 723,
+        name: 'Adzymic Pte Ltd',
+        purposes: [1, 2, 3, 4, 7, 8],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [2],
+        specialFeatures: [],
+        policyUrl: 'http://www.adzymic.co/privacy',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '725': {
+        id: 725,
+        name: 'Pubfinity LLC',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://pubfinity.com/privacy-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '727': {
+        id: 727,
+        name: 'Pinpoll GmbH (Private Limited)',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1],
+        specialFeatures: [],
+        policyUrl: 'https://www.pinpoll.com/#data_protection_declaration'
+      },
+      '728': {
+        id: 728,
+        name: 'Appier PTE Ltd',
+        purposes: [1, 3, 4, 5, 6, 9],
+        legIntPurposes: [2, 7, 8, 10],
+        flexiblePurposes: [2, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://www.appier.com/privacy-policy/'
+      },
+      '729': {
+        id: 729,
+        name: 'Cavai AS & UK ',
+        purposes: [],
+        legIntPurposes: [7, 8],
+        flexiblePurposes: [7, 8],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://cav.ai/privacy-policy/'
+      },
+      '730': {
+        id: 730,
+        name: 'INFOnline GmbH',
+        purposes: [1],
+        legIntPurposes: [8],
+        flexiblePurposes: [8],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.infonline.de/en/privacy-policy/'
+      },
+      '731': {
+        id: 731,
+        name: 'GeistM Technologies LTD',
+        purposes: [],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.geistm.com/privacy'
+      },
+      '733': {
+        id: 733,
+        name: 'Anzu Virtual reality LTD',
+        purposes: [1, 2, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1, 2],
+        specialFeatures: [1],
+        policyUrl: 'https://anzu.io/privacy/'
+      },
+      '734': {
+        id: 734,
+        name: 'Cint AB',
+        purposes: [1, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1],
+        specialFeatures: [],
+        policyUrl: 'https://www.cint.com/participant-privacy-notice'
+      },
+      '735': {
+        id: 735,
+        name: 'Deutsche Post AG',
+        purposes: [1, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1],
+        specialFeatures: [],
+        policyUrl:
+          'https://www.deutschepost.de/de/c/consentric/datenschutz.html'
+      },
+      '737': {
+        id: 737,
+        name: 'Monet Engine Inc',
+        purposes: [1, 2, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://appmonet.com/privacy-policy/'
+      },
+      '738': {
+        id: 738,
+        name: 'adbility media GmbH',
+        purposes: [2, 3, 4, 9],
+        legIntPurposes: [7],
+        flexiblePurposes: [2, 3, 4, 9],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://www.adbility-media.com/datenschutzerklaerung/'
+      },
+      '739': {
+        id: 739,
+        name: 'Blingby LLC',
+        purposes: [1, 8, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://blingby.com/privacy'
+      },
+      '740': {
+        id: 740,
+        name: '6Sense Insights, Inc.',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 7, 8, 10],
+        flexiblePurposes: [2, 3, 4, 5, 7, 8, 10],
+        specialPurposes: [],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl: 'https://6sense.com/privacy-policy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '741': {
+        id: 741,
+        name: 'Brand Advance Limited',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://www.wearebrandadvance.com/website-privacy-policy'
+      },
+      '742': {
+        id: 742,
+        name: 'Audiencerate LTD',
+        purposes: [1, 2, 3, 5, 6],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.audiencerate.com/privacy/'
+      },
+      '743': {
+        id: 743,
+        name: 'MOVIads Sp. z o.o. Sp. k.',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [2, 3],
+        specialFeatures: [1],
+        policyUrl: 'https://moviads.pl/polityka-prywatnosci/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '744': {
+        id: 744,
+        name: 'Vidazoo Ltd',
+        purposes: [3, 4],
+        legIntPurposes: [2, 7, 8, 10],
+        flexiblePurposes: [3, 4],
+        specialPurposes: [1, 2],
+        features: [2],
+        specialFeatures: [2],
+        policyUrl: 'https://vidazoo.gitbook.io/vidazoo-legal/privacy-policy',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '745': {
+        id: 745,
+        name: 'Justtag Sp. z o.o.',
+        purposes: [1, 3, 4, 9],
+        legIntPurposes: [7],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1],
+        policyUrl:
+          'https://www.justtag.com/pdf/PRIVACY_POLICY_Koalametrics_english.pdf'
+      },
+      '746': {
+        id: 746,
+        name: 'Adxperience SAS',
+        purposes: [4],
+        legIntPurposes: [2, 7],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://adxperience.com/privacy-policy/'
+      },
+      '747': {
+        id: 747,
+        name: 'Kairion GmbH',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [],
+        features: [2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://kairion.de/datenschutzbestimmungen/'
+      },
+      '748': {
+        id: 748,
+        name: 'AUDIOMOB LTD',
+        purposes: [1, 2, 3, 4, 7, 8, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 7, 8, 9],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [1],
+        policyUrl: 'https://www.audiomob.io/privacy'
+      },
+      '749': {
+        id: 749,
+        name: 'Good-Loop Ltd',
+        purposes: [1, 3, 4, 5, 6],
+        legIntPurposes: [2, 7, 8, 9, 10],
+        flexiblePurposes: [7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://doc.good-loop.com/policy/privacy-policy.html'
+      },
+      '750': {
+        id: 750,
+        name: 'THE NEWCO S.R.L.',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl:
+          'https://www.thenewco.it/privacy_policy_servizi_prodotti.html'
+      },
+      '751': {
+        id: 751,
+        name: 'Kiosked Ltd',
+        purposes: [],
+        legIntPurposes: [2, 7],
+        flexiblePurposes: [2, 7],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://kiosked.com/privacy-policy/'
+      },
+      '753': {
+        id: 753,
+        name: 'ScaleMonk Inc.',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [2, 3, 4, 7, 9, 10],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://www.scalemonk.com/privacy-policy/index.html'
+      },
+      '754': {
+        id: 754,
+        name: 'DistroScale, Inc.',
+        purposes: [1, 2],
+        legIntPurposes: [],
+        flexiblePurposes: [2],
+        specialPurposes: [2],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'http://www.distroscale.com/privacy-policy/'
+      },
+      '757': {
+        id: 757,
+        name: 'UAB Meazy',
+        purposes: [1, 2, 3, 4, 5, 7, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://meazy.co/privacy-policy'
+      },
+      '758': {
+        id: 758,
+        name: 'GfK Netherlands B.V.',
+        purposes: [1, 7, 8, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [7, 8, 9],
+        specialPurposes: [],
+        features: [1],
+        specialFeatures: [],
+        policyUrl: 'https://gfkpanel.nl/privacy'
+      },
+      '759': {
+        id: 759,
+        name: 'RevJet',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1],
+        specialFeatures: [],
+        policyUrl: 'https://www.revjet.com/privacy',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '760': {
+        id: 760,
+        name: 'VEXPRO TECHNOLOGIES LTD',
+        purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [2],
+        policyUrl: 'https://onedash.com/privacy-policy.html'
+      },
+      '761': {
+        id: 761,
+        name: 'Digiseg ApS',
+        purposes: [1, 3, 5, 7, 8, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [1],
+        specialFeatures: [],
+        policyUrl: 'https://digiseg.io/privacy-center/'
+      },
+      '762': {
+        id: 762,
+        name: 'Protected Media LTD',
+        purposes: [1],
+        legIntPurposes: [3, 5, 7, 8, 9, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://www.protected.media/privacy-policy/'
+      },
+      '764': {
+        id: 764,
+        name: 'Lucidity',
+        purposes: [1, 2, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://golucidity.com/privacy-policy/'
+      },
+      '765': {
+        id: 765,
+        name: 'Grabit Interactive Media Inc dba KERV Interctive',
+        purposes: [2, 3, 4, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [2],
+        specialFeatures: [],
+        policyUrl: 'https://kervit.com/privacy-policy/'
+      },
+      '766': {
+        id: 766,
+        name: 'ADCELL | Firstlead GmbH',
+        purposes: [1, 2],
+        legIntPurposes: [],
+        flexiblePurposes: [2],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.adcell.de/agb#sector_6'
+      },
+      '768': {
+        id: 768,
+        name: 'Global Media & Entertainment Limited',
+        purposes: [1, 2, 3, 4, 7, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'http://global.com/privacy-policy/'
+      },
+      '769': {
+        id: 769,
+        name: 'MEDIAMETRIE',
+        purposes: [1, 8],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.mediametrie.fr/fr/gestion-des-cookies'
+      },
+      '770': {
+        id: 770,
+        name: 'MARKETPERF CORP',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6],
+        specialPurposes: [1, 2],
+        features: [1, 2, 3],
+        specialFeatures: [],
+        policyUrl:
+          'https://www.marketperf.com/assets/images/app/marketperf/pdf/privacy-policy.pdf'
+      },
+      '771': {
+        id: 771,
+        name: 'bam! interactive marketing GmbH ',
+        purposes: [1, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://bam-interactive.de/privacy-policy/'
+      },
+      '772': {
+        id: 772,
+        name: 'Oracle Data Cloud - Moat',
+        purposes: [],
+        legIntPurposes: [7, 8, 10],
+        flexiblePurposes: [],
+        specialPurposes: [1],
+        features: [],
+        specialFeatures: [],
+        policyUrl:
+          'https://www.oracle.com/legal/privacy/services-privacy-policy.html'
+      },
+      '774': {
+        id: 774,
+        name: 'Wagawin GmbH',
+        purposes: [1],
+        legIntPurposes: [2, 7],
+        flexiblePurposes: [2],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.wagawin.com/privacy-en/#productprivacy'
+      },
+      '775': {
+        id: 775,
+        name: 'SelectMedia International LTD',
+        purposes: [1, 2],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [3],
+        specialFeatures: [],
+        policyUrl: 'https://www.selectmedia.asia/terms-and-privacy/'
+      },
+      '776': {
+        id: 776,
+        name: 'Mars Media Group',
+        purposes: [2],
+        legIntPurposes: [],
+        flexiblePurposes: [2],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://pay-per-leads.com/terms'
+      },
+      '777': {
+        id: 777,
+        name: 'One Planet Only',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 7],
+        flexiblePurposes: [2, 3, 4, 7],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://oneplanetonly.com/files/PRIVACY%20POLICY.pdf',
+        overflow: {
+          httpGetLimit: 32
+        }
+      },
+      '778': {
+        id: 778,
+        name: 'Discover-Tech ltd',
+        purposes: [2, 3, 4, 5, 6, 7, 8, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [1],
+        policyUrl: 'https://discover-tech.io/dsp-privacy-policy/'
+      },
+      '779': {
+        id: 779,
+        name: 'Adtarget Medya A.S.',
+        purposes: [1, 7],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [3],
+        specialFeatures: [1],
+        policyUrl: 'https://adtarget.com.tr/adtarget-privacy-policy-2020.pdf'
+      },
+      '780': {
+        id: 780,
+        name: 'Aniview LTD',
+        purposes: [1, 2, 7, 8],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.aniview.com/privacy-policy/'
+      },
+      '781': {
+        id: 781,
+        name: 'FeedAd GmbH',
+        purposes: [1, 3, 4, 5, 6, 8, 9],
+        legIntPurposes: [2, 7, 10],
+        flexiblePurposes: [2, 7, 10],
+        specialPurposes: [1, 2],
+        features: [2, 3],
+        specialFeatures: [1, 2],
+        policyUrl: 'https://feedad.com/privacy/',
+        overflow: {
+          httpGetLimit: 128
+        }
+      },
+      '782': {
+        id: 782,
+        name: 'AirGrid LTD',
+        purposes: [1, 3, 5, 7, 8, 9, 10],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'airgid.io/privacy-policy'
+      },
+      '783': {
+        id: 783,
+        name: 'Audienzz AG',
+        purposes: [1],
+        legIntPurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        flexiblePurposes: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+        specialPurposes: [1, 2],
+        features: [1, 2],
+        specialFeatures: [1],
+        policyUrl:
+          'https://audienzz.ch/wp-content/uploads/2020/03/AGB_audienzz_2020.pdf'
+      },
+      '784': {
+        id: 784,
+        name: 'Nubo LTD',
+        purposes: [],
+        legIntPurposes: [2],
+        flexiblePurposes: [],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.recod3.com/privacypolicy.php'
+      },
+      '785': {
+        id: 785,
+        name: 'agof - daily digital facts',
+        purposes: [1, 9],
+        legIntPurposes: [],
+        flexiblePurposes: [],
+        specialPurposes: [1],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'http://www.agof.de/datenschutz/'
+      },
+      '786': {
+        id: 786,
+        name: 'TargetVideo GmbH',
+        purposes: [1, 2, 3, 4],
+        legIntPurposes: [7, 8, 10],
+        flexiblePurposes: [2, 3, 4, 7, 8, 10],
+        specialPurposes: [1, 2],
+        features: [],
+        specialFeatures: [],
+        policyUrl: 'https://www.target-video.com/datenschutz/'
       }
-    },
-    '50': {
-      id: 50,
-      name: 'Adform',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        7,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://site.adform.com/privacy-center/platform-privacy/product-and-services-privacy-policy/',
-      overflow: {
-        httpGetLimit: 32
-      }
-    },
-    '51': {
-      id: 51,
-      name: 'xAd, Inc. dba GroundTruth',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.groundtruth.com/privacy-policy/'
-    },
-    '52': {
-      id: 52,
-      name: 'The Rubicon Project, Inc. ',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        7,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://www.rubiconproject.com/rubicon-project-yield-optimization-privacy-policy/',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '53': {
-      id: 53,
-      name: 'Sirdata',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.sirdata.com/privacy/'
-    },
-    '57': {
-      id: 57,
-      name: 'ADARA MEDIA UNLIMITED',
-      purposes: [
-        1,
-        2,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        7,
-        9,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://adara.com/privacy-promise/'
-    },
-    '58': {
-      id: 58,
-      name: '33Across',
-      purposes: [
-        1,
-        2,
-        4,
-        7,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'http://www.33across.com/privacy-policy'
-    },
-    '59': {
-      id: 59,
-      name: 'Sift Media, Inc',
-      purposes: [
-        2
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2
-      ],
-      specialPurposes: [],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.sift.co/privacy'
-    },
-    '60': {
-      id: 60,
-      name: 'Rakuten Marketing LLC',
-      purposes: [
-        1,
-        3
-      ],
-      legIntPurposes: [
-        2,
-        4,
-        7,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://rakutenadvertising.com/legal-notices/services-privacy-policy/'
-    },
-    '61': {
-      id: 61,
-      name: 'GumGum, Inc.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://gumgum.com/privacy-policy'
-    },
-    '62': {
-      id: 62,
-      name: 'Justpremium BV',
-      purposes: [
-        1,
-        4,
-        5,
-        10
-      ],
-      legIntPurposes: [
-        2,
-        7
-      ],
-      flexiblePurposes: [
-        2,
-        4,
-        7,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://justpremium.com/privacy-policy/'
-    },
-    '63': {
-      id: 63,
-      name: 'Avocet Systems Limited',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6
-      ],
-      legIntPurposes: [
-        7,
-        8,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://avocet.io/privacy-portal'
-    },
-    '65': {
-      id: 65,
-      name: 'Location Sciences AI Ltd',
-      purposes: [
-        1,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        7,
-        8
-      ],
-      specialPurposes: [
-        1
-      ],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.locationsciences.ai/privacy-policy/'
-    },
-    '66': {
-      id: 66,
-      name: 'adsquare GmbH',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        9,
-        10
-      ],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.adsquare.com/privacy'
-    },
-    '68': {
-      id: 68,
-      name: 'Sizmek by Amazon',
-      purposes: [
-        1,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.sizmek.com/privacy-policy/'
-    },
-    '69': {
-      id: 69,
-      name: 'OpenX',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.openx.com/legal/privacy-policy/'
-    },
-    '70': {
-      id: 70,
-      name: 'Yieldlab AG',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://www.yieldlab.de/meta-navigation/datenschutz/',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '72': {
-      id: 72,
-      name: 'Nano Interactive GmbH',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://www.nanointeractive.com/privacy'
-    },
-    '73': {
-      id: 73,
-      name: 'Simplifi Holdings Inc.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4
-      ],
-      specialPurposes: [],
-      features: [
-        2
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://simpli.fi/site-privacy-policy/'
-    },
-    '76': {
-      id: 76,
-      name: 'PubMatic, Inc.',
-      purposes: [
-        1,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://pubmatic.com/privacy-policy/'
-    },
-    '77': {
-      id: 77,
-      name: 'comScore, Inc.',
-      purposes: [
-        1,
-        7,
-        8,
-        10
-      ],
-      legIntPurposes: [
-        9
-      ],
-      flexiblePurposes: [
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.scorecardresearch.com/privacy.aspx?newlanguage=1'
-    },
-    '78': {
-      id: 78,
-      name: 'Flashtalking, Inc.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://www.flashtalking.com/privacypolicy/'
-    },
-    '79': {
-      id: 79,
-      name: 'MediaMath, Inc.',
-      purposes: [
-        1,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        10
-      ],
-      flexiblePurposes: [
-        3,
-        4
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://www.mediamath.com/privacy-policy/'
-    },
-    '80': {
-      id: 80,
-      name: 'Sharethrough, Inc',
-      purposes: [
-        1,
-        2,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        4,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://platform-cdn.sharethrough.com/privacy-policy'
-    },
-    '82': {
-      id: 82,
-      name: 'Smaato, Inc.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9
-      ],
-      legIntPurposes: [
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.smaato.com/privacy/'
-    },
-    '83': {
-      id: 83,
-      name: 'Visarity Technologies GmbH',
-      purposes: [
-        2,
-        6,
-        7,
-        8
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://primo.design/docs/PrivacyPolicyPrimo.html'
-    },
-    '84': {
-      id: 84,
-      name: 'Semasio GmbH',
-      purposes: [
-        1,
-        3,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        3,
-        9,
-        10
-      ],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://www.semasio.com/privacy-policy/'
-    },
-    '85': {
-      id: 85,
-      name: 'Crimtan Holdings Limited',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://crimtan.com/privacy/'
-    },
-    '86': {
-      id: 86,
-      name: 'Scene Stealer Limited',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        7,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://scenestealer.tv/privacy-policy/'
-    },
-    '88': {
-      id: 88,
-      name: 'TreSensa, Inc.',
-      purposes: [
-        1,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.tresensa.com/eu-privacy'
-    },
-    '89': {
-      id: 89,
-      name: 'Tapad, Inc.',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.tapad.com/eu-privacy-policy'
-    },
-    '90': {
-      id: 90,
-      name: 'Teroa S.A.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.e-planning.net/en/privacy.html'
-    },
-    '91': {
-      id: 91,
-      name: 'Criteo SA',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7
-      ],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.criteo.com/privacy/'
-    },
-    '92': {
-      id: 92,
-      name: '1plusX AG',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.1plusx.com/privacy-policy/'
-    },
-    '93': {
-      id: 93,
-      name: 'Adloox SA',
-      purposes: [],
-      legIntPurposes: [
-        7
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://adloox.com/disclaimer',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '94': {
-      id: 94,
-      name: 'Blis Media Limited',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://www.blis.com/privacy/'
-    },
-    '95': {
-      id: 95,
-      name: 'Lotame Solutions, inc',
-      purposes: [
-        1,
-        3,
-        5
-      ],
-      legIntPurposes: [
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.lotame.com/about-lotame/privacy/lotame-corporate-websites-privacy-policy/'
-    },
-    '97': {
-      id: 97,
-      name: 'LiveRamp, Inc.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.liveramp.com/service-privacy-policy/'
-    },
-    '98': {
-      id: 98,
-      name: 'GroupM UK Limited',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6
-      ],
-      legIntPurposes: [
-        7,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.groupm.com/privacy-notice'
-    },
-    '100': {
-      id: 100,
-      name: 'Fifty Technology Limited',
-      purposes: [
-        1,
-        2,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        7,
-        9,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://fifty.io/privacy-policy.php'
-    },
-    '101': {
-      id: 101,
-      name: 'MiQ',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://wearemiq.com/privacy-policy/'
-    },
-    '104': {
-      id: 104,
-      name: 'Sonobi, Inc',
-      purposes: [
-        1,
-        2,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        7,
-        8
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        2
-      ],
-      features: [
-        1
-      ],
-      specialFeatures: [],
-      policyUrl: 'http://sonobi.com/privacy-policy/'
-    },
-    '108': {
-      id: 108,
-      name: 'Rich Audience',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://richaudience.com/privacy/'
-    },
-    '109': {
-      id: 109,
-      name: 'LoopMe Limited',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8
-      ],
-      legIntPurposes: [
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        9
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://loopme.com/privacy-policy/'
-    },
-    '110': {
-      id: 110,
-      name: 'Dynata LLC',
-      purposes: [
-        1,
-        7,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.opinionoutpost.co.uk/en-gb/policies/privacy'
-    },
-    '111': {
-      id: 111,
-      name: 'Showheroes SE',
-      purposes: [
-        1,
-        3,
-        4,
-        9,
-        10
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        8
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://showheroes.com/privacy/'
-    },
-    '114': {
-      id: 114,
-      name: 'Sublime',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9
-      ],
-      legIntPurposes: [
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://ayads.co/privacy.php'
-    },
-    '115': {
-      id: 115,
-      name: 'smartclip Europe GmbH',
-      purposes: [
-        1,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://privacy-portal.smartclip.net/',
-      overflow: {
-        httpGetLimit: 32
-      }
-    },
-    '119': {
-      id: 119,
-      name: 'Fusio by S4M',
-      purposes: [
-        1,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1
-      ],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://www.s4m.io/privacy-policy/'
-    },
-    '120': {
-      id: 120,
-      name: 'Eyeota Pte Ltd',
-      purposes: [
-        1,
-        3,
-        5,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        3,
-        5,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.eyeota.com/privacy-center'
-    },
-    '126': {
-      id: 126,
-      name: 'DoubleVerify Inc.​',
-      purposes: [
-        2,
-        7,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.doubleverify.com/privacy/'
-    },
-    '127': {
-      id: 127,
-      name: 'PIXIMEDIA SAS',
-      purposes: [
-        1,
-        3,
-        4,
-        5,
-        6,
-        9,
-        10
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        8
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://piximedia.com/privacy/',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '128': {
-      id: 128,
-      name: 'BIDSWITCH GmbH',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://www.bidswitch.com/privacy-policy/'
-    },
-    '129': {
-      id: 129,
-      name: 'IPONWEB GmbH',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.iponweb.com/privacy-policy/'
-    },
-    '130': {
-      id: 130,
-      name: 'NextRoll, Inc.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.nextroll.com/privacy'
-    },
-    '131': {
-      id: 131,
-      name: 'ID5 Technology SAS',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.id5.io/privacy'
-    },
-    '132': {
-      id: 132,
-      name: 'Teads ',
-      purposes: [
-        1,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        9,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.teads.com/privacy-policy/'
-    },
-    '133': {
-      id: 133,
-      name: 'digitalAudience',
-      purposes: [
-        1,
-        3,
-        5,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://digitalaudience.io/legal/privacy-cookies/'
-    },
-    '134': {
-      id: 134,
-      name: 'SMARTSTREAM.TV GmbH',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.smartstream.tv/en/productprivacy',
-      overflow: {
-        httpGetLimit: 32
-      }
-    },
-    '136': {
-      id: 136,
-      name: 'Ströer SSP GmbH (SSP)',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.stroeer.de/fileadmin/de/Konvergenz_und_Konzepte/Daten_und_Technologien/Stroeer_SSP/Downloads/Datenschutz_Stroeer_SSP.pdf'
-    },
-    '137': {
-      id: 137,
-      name: 'Ströer SSP GmbH (DSP)',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        9
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.stroeer.de/fileadmin/de/Konvergenz_und_Konzepte/Daten_und_Technologien/Stroeer_SSP/Downloads/Datenschutz_Stroeer_SSP.pdf'
-    },
-    '138': {
-      id: 138,
-      name: 'ConnectAd Realtime GmbH',
-      purposes: [
-        1,
-        3,
-        4,
-        5
-      ],
-      legIntPurposes: [
-        2,
-        7
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'http://connectadrealtime.com/privacy/'
-    },
-    '139': {
-      id: 139,
-      name: 'Permodo GmbH',
-      purposes: [
-        1,
-        2,
-        7,
-        8,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        7,
-        8,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://permodo.com/de/privacy.html',
-      overflow: {
-        httpGetLimit: 32
-      }
-    },
-    '142': {
-      id: 142,
-      name: 'Media.net Advertising FZ-LLC',
-      purposes: [
-        1,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        5,
-        6,
-        8
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.media.net/en/privacy-policy'
-    },
-    '143': {
-      id: 143,
-      name: 'Connatix Native Exchange Inc.',
-      purposes: [
-        1,
-        2,
-        4,
-        6,
-        7,
-        8,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://connatix.com/privacy-policy/'
-    },
-    '144': {
-      id: 144,
-      name: 'district m inc.',
-      purposes: [
-        1,
-        2,
-        4,
-        7,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://districtm.net/en/page/platforms-data-and-privacy-policy/',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '147': {
-      id: 147,
-      name: 'Adacado Technologies Inc. (DBA Adacado)',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.adacado.com/privacy-policy-april-25-2018/'
-    },
-    '149': {
-      id: 149,
-      name: 'ADman Interactive SLU',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2
-      ],
-      specialPurposes: [],
-      features: [
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://admanmedia.com/politica.html?setLng=es'
-    },
-    '150': {
-      id: 150,
-      name: 'Inskin Media LTD',
-      purposes: [
-        1,
-        3,
-        4,
-        9,
-        10
-      ],
-      legIntPurposes: [
-        2,
-        7
-      ],
-      flexiblePurposes: [
-        2,
-        7
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'http://www.inskinmedia.com/privacy-policy.html'
-    },
-    '152': {
-      id: 152,
-      name: 'Meetrics GmbH',
-      purposes: [
-        1,
-        9
-      ],
-      legIntPurposes: [
-        7
-      ],
-      flexiblePurposes: [
-        7
-      ],
-      specialPurposes: [
-        1
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.meetrics.com/en/data-privacy/'
-    },
-    '153': {
-      id: 153,
-      name: 'MADVERTISE MEDIA',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        5,
-        6,
-        10
-      ],
-      specialPurposes: [
-        2
-      ],
-      features: [],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://madvertise.com/en/gdpr/',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '154': {
-      id: 154,
-      name: 'YOC AG',
-      purposes: [
-        1,
-        3,
-        4,
-        10
-      ],
-      legIntPurposes: [
-        2,
-        7
-      ],
-      flexiblePurposes: [
-        2,
-        7
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://yoc.com/privacy/'
-    },
-    '155': {
-      id: 155,
-      name: 'AntVoice',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.antvoice.com/en/privacypolicy/'
-    },
-    '157': {
-      id: 157,
-      name: 'Seedtag Advertising S.L',
-      purposes: [
-        1,
-        2,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        7,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.seedtag.com/en/privacy-policy/'
-    },
-    '160': {
-      id: 160,
-      name: 'Netsprint SA',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://netsprint.eu/privacy.html',
-      overflow: {
-        httpGetLimit: 32
-      }
-    },
-    '161': {
-      id: 161,
-      name: 'Smadex SL',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://smadex.com/end-user-privacy-policy/'
-    },
-    '162': {
-      id: 162,
-      name: 'Unruly Group Ltd',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://unruly.co/privacy/'
-    },
-    '163': {
-      id: 163,
-      name: 'Bombora Inc.',
-      purposes: [
-        1,
-        3,
-        8
-      ],
-      legIntPurposes: [
-        7,
-        10
-      ],
-      flexiblePurposes: [
-        7,
-        10
-      ],
-      specialPurposes: [],
-      features: [
-        1
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://bombora.com/privacy'
-    },
-    '164': {
-      id: 164,
-      name: 'Outbrain UK Ltd',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.outbrain.com/legal/privacy#privacy-policy'
-    },
-    '165': {
-      id: 165,
-      name: 'SpotX, Inc.',
-      purposes: [
-        1,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.spotx.tv/privacy-policy/',
-      overflow: {
-        httpGetLimit: 32
-      }
-    },
-    '167': {
-      id: 167,
-      name: 'Audiens S.r.l.',
-      purposes: [
-        1,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'http://www.audiens.com/privacy'
-    },
-    '168': {
-      id: 168,
-      name: 'EASYmedia GmbH',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://login.rtbmarket.com/gdpr'
-    },
-    '173': {
-      id: 173,
-      name: 'Yieldmo, Inc.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.yieldmo.com/privacy/'
-    },
-    '174': {
-      id: 174,
-      name: 'A Million Ads Ltd',
-      purposes: [],
-      legIntPurposes: [
-        2,
-        4
-      ],
-      flexiblePurposes: [
-        2,
-        4
-      ],
-      specialPurposes: [],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.amillionads.com/privacy-policy'
-    },
-    '177': {
-      id: 177,
-      name: 'plista GmbH',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        7,
-        8,
-        10
-      ],
-      flexiblePurposes: [
-        7,
-        8,
-        10
-      ],
-      specialPurposes: [
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.plista.com/about/privacy/'
-    },
-    '178': {
-      id: 178,
-      name: 'Hybrid Theory',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://hybridtheory.com/privacy-policy/'
-    },
-    '179': {
-      id: 179,
-      name: 'Collective Europe Ltd.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        9
-      ],
-      legIntPurposes: [
-        7
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.collectiveuk.com/privacy.html',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '184': {
-      id: 184,
-      name: 'mediarithmics SAS',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        7
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.mediarithmics.com/en-us/content/privacy-policy'
-    },
-    '185': {
-      id: 185,
-      name: 'Bidtellect, Inc',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        8
-      ],
-      legIntPurposes: [
-        9,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.bidtellect.com/privacy-policy/',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '190': {
-      id: 190,
-      name: 'video intelligence AG',
-      purposes: [],
-      legIntPurposes: [
-        2,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.vi.ai/privacy-policy/'
-    },
-    '192': {
-      id: 192,
-      name: 'remerge GmbH',
-      purposes: [
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://remerge.io/privacy-policy.html'
-    },
-    '193': {
-      id: 193,
-      name: 'Mediasmart Mobile S.L.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://mediasmart.io/privacy/'
-    },
-    '194': {
-      id: 194,
-      name: 'Rezonence Limited',
-      purposes: [
-        1,
-        3,
-        4,
-        9
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        8,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://rezonence.com/privacy-policy/'
-    },
-    '195': {
-      id: 195,
-      name: 'advanced store GmbH',
-      purposes: [
-        1,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2
-      ],
-      flexiblePurposes: [
-        2
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://www.advanced-store.com/de/datenschutz/'
-    },
-    '199': {
-      id: 199,
-      name: 'ADUX',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        6,
-        7,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        2
-      ],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.adux.com/donnees-personelles/'
-    },
-    '200': {
-      id: 200,
-      name: 'Tapjoy, Inc.',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        7
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.tapjoy.com/legal/#privacy-policy'
-    },
-    '203': {
-      id: 203,
-      name: 'Revcontent, LLC',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6
-      ],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://intercom.help/revcontent2/en/articles/2290675-revcontent-s-privacy-policy'
-    },
-    '205': {
-      id: 205,
-      name: 'Adssets AB',
-      purposes: [
-        1,
-        2,
-        4,
-        7,
-        8,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://adssets.com/policy/'
-    },
-    '206': {
-      id: 206,
-      name: 'Hybrid Adtech GmbH',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://hybrid.ai/data_protection_policy'
-    },
-    '209': {
-      id: 209,
-      name: 'Delta Projects AB',
-      purposes: [
-        1,
-        2,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        7,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        7,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://deltaprojects.com/data-collection-policy'
-    },
-    '210': {
-      id: 210,
-      name: 'Zemanta, Inc.',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        3,
-        7,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        3,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1
-      ],
-      specialFeatures: [],
-      policyUrl: 'http://www.zemanta.com/legal/privacy'
-    },
-    '211': {
-      id: 211,
-      name: 'AdTheorent, Inc',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'http://adtheorent.com/privacy-policy'
-    },
-    '212': {
-      id: 212,
-      name: 'usemax advertisement (Emego GmbH)',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://www.usemax.de/?l=privacy'
-    },
-    '213': {
-      id: 213,
-      name: 'emetriq GmbH',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        2
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.emetriq.com/datenschutz/'
-    },
-    '215': {
-      id: 215,
-      name: 'ARMIS SAS',
-      purposes: [
-        1,
-        2,
-        7
-      ],
-      legIntPurposes: [
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://armis.tech/en/armis-personal-data-privacy-policy/'
-    },
-    '216': {
-      id: 216,
-      name: 'Mindlytix SAS',
-      purposes: [
-        1,
-        2,
-        3,
-        5,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'http://mindlytix.com/privacy/'
-    },
-    '217': {
-      id: 217,
-      name: '2KDirect, Inc. (dba iPromote)',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.ipromote.com/privacy-policy/'
-    },
-    '218': {
-      id: 218,
-      name: 'Bigabid Media ltd',
-      purposes: [
-        1,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.bigabid.com/privacy-policy'
-    },
-    '223': {
-      id: 223,
-      name: 'Audience Trading Platform Ltd.',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        7,
-        8
-      ],
-      flexiblePurposes: [
-        7,
-        8
-      ],
-      specialPurposes: [],
-      features: [
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://atp.io/privacy-policy'
-    },
-    '224': {
-      id: 224,
-      name: 'adrule mobile GmbH',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        8
-      ],
-      legIntPurposes: [
-        7
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        8
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.adrule.net/de/datenschutz/'
-    },
-    '226': {
-      id: 226,
-      name: 'Publicis Media GmbH',
-      purposes: [
-        1,
-        9
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        10
-      ],
-      specialPurposes: [],
-      features: [
-        1
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.publicismedia.de/datenschutz/'
-    },
-    '227': {
-      id: 227,
-      name: 'ORTEC B.V.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.ortecadscience.com/privacy-policy/'
-    },
-    '228': {
-      id: 228,
-      name: 'McCann Discipline LTD',
-      purposes: [
-        1,
-        2,
-        5,
-        6,
-        7,
-        8
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.primis.tech/privacy-policy/'
-    },
-    '231': {
-      id: 231,
-      name: 'AcuityAds Inc.',
-      purposes: [
-        1,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        8,
-        10
-      ],
-      flexiblePurposes: [
-        3,
-        4
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://privacy.acuityads.com/corporate-privacy-policy.html',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '234': {
-      id: 234,
-      name: 'ZBO Media',
-      purposes: [
-        1,
-        3,
-        4,
-        9
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://zbo.media/mentions-legales/politique-de-confidentialite-service-publicitaire/'
-    },
-    '235': {
-      id: 235,
-      name: 'Bucksense Inc',
-      purposes: [
-        2,
-        3,
-        4,
-        7,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        9
-      ],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://www.bucksense.com/platform-privacy-policy/'
-    },
-    '240': {
-      id: 240,
-      name: '7Hops.com Inc. (ZergNet)',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        5,
-        6,
-        8,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://zergnet.com/privacy'
-    },
-    '241': {
-      id: 241,
-      name: 'OneTag Limited',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        7
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.onetag.com/privacy/'
-    },
-    '242': {
-      id: 242,
-      name: 'twiago GmbH',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.twiago.com/datenschutz/',
-      overflow: {
-        httpGetLimit: 32
-      }
-    },
-    '243': {
-      id: 243,
-      name: 'Cloud Technologies S.A.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.cloudtechnologies.pl/en/internet-advertising-privacy-policy'
-    },
-    '248': {
-      id: 248,
-      name: 'Converge-Digital',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2
-      ],
-      flexiblePurposes: [
-        2
-      ],
-      specialPurposes: [],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://converge-digital.com/privacy-policy/',
-      overflow: {
-        httpGetLimit: 32
-      }
-    },
-    '249': {
-      id: 249,
-      name: 'Spolecznosci Sp. z o.o. Sp. k.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.spolecznosci.pl/polityka-prywatnosci'
-    },
-    '250': {
-      id: 250,
-      name: 'Qriously Ltd',
-      purposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.brandwatch.com/legal/qriously-privacy-notice/'
-    },
-    '251': {
-      id: 251,
-      name: 'Yieldlove GmbH',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        7,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://www.yieldlove.com/cookie-policy'
-    },
-    '252': {
-      id: 252,
-      name: 'Jaduda GmbH',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.jadudamobile.com/datenschutzerklaerung/'
-    },
-    '253': {
-      id: 253,
-      name: 'Improve Digital BV',
-      purposes: [
-        1,
-        3,
-        4,
-        9
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        7,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.improvedigital.com/platform-privacy-policy',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '255': {
-      id: 255,
-      name: 'Onnetwork Sp. z o.o.',
-      purposes: [
-        1,
-        5,
-        6
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        8
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.onnetwork.tv/pp_services.php'
-    },
-    '256': {
-      id: 256,
-      name: 'Bounce Exchange, Inc',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        7,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.bouncex.com/privacy/'
-    },
-    '262': {
-      id: 262,
-      name: 'Fyber ',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.fyber.com/legal/privacy-policy/'
-    },
-    '263': {
-      id: 263,
-      name: 'Nativo, Inc.',
-      purposes: [
-        1,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        9,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.nativo.com/interest-based-ads'
-    },
-    '265': {
-      id: 265,
-      name: 'Instinctive, Inc.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8
-      ],
-      legIntPurposes: [
-        9,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://instinctive.io/privacy'
-    },
-    '272': {
-      id: 272,
-      name: 'A.Mob',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.we-are-adot.com/privacy-policy/'
-    },
-    '273': {
-      id: 273,
-      name: 'Bannerflow AB',
-      purposes: [
-        1,
-        4
-      ],
-      legIntPurposes: [
-        7
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.bannerflow.com/privacy '
-    },
-    '275': {
-      id: 275,
-      name: 'TabMo SAS',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://static.tabmo.io.s3.amazonaws.com/privacy-policy/index.html'
-    },
-    '277': {
-      id: 277,
-      name: 'Codewise VL Sp. z o.o. Sp. k',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9
-      ],
-      legIntPurposes: [
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://voluumdsp.com/end-user-privacy-policy/'
-    },
-    '278': {
-      id: 278,
-      name: 'Integral Ad Science, Inc.',
-      purposes: [],
-      legIntPurposes: [
-        7,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://integralads.com/privacy-policy/'
-    },
-    '279': {
-      id: 279,
-      name: 'Mirando GmbH &amp; Co KG',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        7
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://wwwmirando.de/datenschutz/'
-    },
-    '280': {
-      id: 280,
-      name: 'Spot.IM LTD',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://www.spot.im/privacy/'
-    },
-    '281': {
-      id: 281,
-      name: 'Wizaly',
-      purposes: [
-        1,
-        7,
-        8,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.wizaly.com/terms-of-use#privacy-policy'
-    },
-    '282': {
-      id: 282,
-      name: 'Welect GmbH',
-      purposes: [
-        10
-      ],
-      legIntPurposes: [
-        2,
-        7
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.welect.de/datenschutz'
-    },
-    '284': {
-      id: 284,
-      name: 'WEBORAMA',
-      purposes: [
-        1,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://weborama.com/privacy_en/'
-    },
-    '285': {
-      id: 285,
-      name: 'Comcast International France SAS',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.freewheel.com/privacy-policy'
-    },
-    '289': {
-      id: 289,
-      name: 'mobalo GmbH',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.mobalo.com/en/privacy/'
-    },
-    '290': {
-      id: 290,
-      name: 'Readpeak Oy',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://readpeak.com/privacy-policy/'
-    },
-    '293': {
-      id: 293,
-      name: 'SpringServe, LLC',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        2
-      ],
-      policyUrl: 'https://springserve.com/privacy-policy/'
-    },
-    '294': {
-      id: 294,
-      name: 'Jivox Corporation',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        7
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.jivox.com/privacy',
-      overflow: {
-        httpGetLimit: 32
-      }
-    },
-    '299': {
-      id: 299,
-      name: 'AdClear GmbH',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        2
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.adclear.de/datenschutzerklaerung/'
-    },
-    '301': {
-      id: 301,
-      name: 'zeotap GmbH',
-      purposes: [
-        1,
-        3,
-        4,
-        5,
-        6,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        3,
-        4,
-        5,
-        6,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://zeotap.com/privacy_policy'
-    },
-    '302': {
-      id: 302,
-      name: 'Mobile Professionals BV',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        7,
-        8,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        3,
-        5,
-        7,
-        8
-      ],
-      specialPurposes: [],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://mobpro.com/privacy.html'
-    },
-    '303': {
-      id: 303,
-      name: 'Orion Semantics',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://static.orion-semantics.com/privacy.html'
-    },
-    '304': {
-      id: 304,
-      name: 'On Device Research Limited',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://s.on-device.com/privacyPolicy'
-    },
-    '310': {
-      id: 310,
-      name: 'Adevinta Spain S.L.U.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        9
-      ],
-      legIntPurposes: [
-        7,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.adevinta.com/about/privacy/'
-    },
-    '312': {
-      id: 312,
-      name: 'Exactag GmbH',
-      purposes: [
-        1,
-        3,
-        7,
-        8
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        3,
-        7,
-        8
-      ],
-      specialPurposes: [
-        1
-      ],
-      features: [
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.exactag.com/en/data-privacy/',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '314': {
-      id: 314,
-      name: 'Keymantics',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.keymantics.com/assets/privacy-policy.pdf'
-    },
-    '315': {
-      id: 315,
-      name: 'Celtra, Inc.',
-      purposes: [
-        1,
-        2,
-        4,
-        7,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.celtra.com/privacy-policy/'
-    },
-    '316': {
-      id: 316,
-      name: 'Gamned',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.gamned.com/privacy-policy/'
-    },
-    '317': {
-      id: 317,
-      name: 'mainADV Srl',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://www.mainad.com/privacy-policy/'
-    },
-    '318': {
-      id: 318,
-      name: 'Accorp Sp. z o.o.',
-      purposes: [
-        1,
-        3,
-        4,
-        9
-      ],
-      legIntPurposes: [
-        7,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'http://www.instytut-pollster.pl/privacy-policy/'
-    },
-    '319': {
-      id: 319,
-      name: 'Clipcentric, Inc.',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://clipcentric.com/privacy.bhtml'
-    },
-    '325': {
-      id: 325,
-      name: 'Knorex',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.knorex.com/privacy'
-    },
-    '328': {
-      id: 328,
-      name: 'Gemius SA',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.gemius.com/cookie-policy.html'
-    },
-    '329': {
-      id: 329,
-      name: 'Browsi Mobile Ltd',
-      purposes: [
-        1,
-        7,
-        8
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://gobrowsi.com/browsi-privacy-policy/'
-    },
-    '333': {
-      id: 333,
-      name: 'InMobi Pte Ltd',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        9
-      ],
-      specialPurposes: [
-        1
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.inmobi.com/privacy-policy-for-eea'
-    },
-    '336': {
-      id: 336,
-      name: 'Telecoming S.A.',
-      purposes: [
-        2,
-        4
-      ],
-      legIntPurposes: [
-        7,
-        9
-      ],
-      flexiblePurposes: [
-        2,
-        4
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://www.telecoming.com/privacy-policy/',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '343': {
-      id: 343,
-      name: 'DIGITEKA Technologies',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://www.ultimedia.com/POLICY.html'
-    },
-    '345': {
-      id: 345,
-      name: 'The Kantar Group Limited',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'http://www.kantar.com/cookies-policies'
-    },
-    '350': {
-      id: 350,
-      name: 'Free Stream Media Corp. dba Samba TV',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://samba.tv/legal/privacy-policy/',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '351': {
-      id: 351,
-      name: 'Samba TV UK Limited',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://samba.tv/legal/privacy-policy/',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '354': {
-      id: 354,
-      name: 'Apester Ltd',
-      purposes: [
-        2,
-        4
-      ],
-      legIntPurposes: [
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        7
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://apester.com/privacy-policy/'
-    },
-    '358': {
-      id: 358,
-      name: 'MGID Inc.',
-      purposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.mgid.com/privacy-policy'
-    },
-    '359': {
-      id: 359,
-      name: 'AerServ LLC',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        9
-      ],
-      specialPurposes: [
-        1
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.inmobi.com/privacy-policy-for-eea'
-    },
-    '365': {
-      id: 365,
-      name: 'Forensiq LLC',
-      purposes: [],
-      legIntPurposes: [
-        7
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1
-      ],
-      features: [
-        1,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://impact.com/privacy-policy/'
-    },
-    '368': {
-      id: 368,
-      name: 'VECTAURY',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.vectaury.io/en/personal-data'
-    },
-    '371': {
-      id: 371,
-      name: 'Seeding Alliance GmbH',
-      purposes: [],
-      legIntPurposes: [
-        2,
-        7,
-        8
-      ],
-      flexiblePurposes: [
-        7
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://seeding-alliance.de/datenschutz'
-    },
-    '373': {
-      id: 373,
-      name: 'Nielsen Marketing Cloud',
-      purposes: [
-        1,
-        3,
-        5
-      ],
-      legIntPurposes: [
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://www.nielsen.com/us/en/privacy-statement/exelate-privacy-policy.html'
-    },
-    '374': {
-      id: 374,
-      name: 'Bmind a Sales Maker Company, S.L.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'http://www.bmind.es/legal-notice/'
-    },
-    '377': {
-      id: 377,
-      name: 'AddApptr GmbH',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        7,
-        10
-      ],
-      flexiblePurposes: [
-        7,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.addapptr.com/data-privacy'
-    },
-    '381': {
-      id: 381,
-      name: 'Solocal',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://frontend.adhslx.com/privacy.html?'
-    },
-    '382': {
-      id: 382,
-      name: 'The Reach Group GmbH',
-      purposes: [
-        1,
-        3,
-        4,
-        5,
-        6,
-        9
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        8
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://trg.de/en/privacy-statement/',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '385': {
-      id: 385,
-      name: 'Oracle Data Cloud',
-      purposes: [
-        1,
-        3,
-        5,
-        9,
-        10
-      ],
-      legIntPurposes: [
-        7
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.oracle.com/legal/privacy/marketing-cloud-data-cloud-privacy-policy.html'
-    },
-    '387': {
-      id: 387,
-      name: 'Triapodi Ltd.',
-      purposes: [
-        2,
-        3,
-        4,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://appreciate.mobi/page.html#/end-user-privacy-policy'
-    },
-    '388': {
-      id: 388,
-      name: 'numberly',
-      purposes: [
-        1,
-        3,
-        4,
-        5,
-        6,
-        9
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        8,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        7,
-        8,
-        10
-      ],
-      specialPurposes: [
-        1
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://numberly.com/en/privacy/'
-    },
-    '394': {
-      id: 394,
-      name: 'AudienceProject Aps',
-      purposes: [
-        1,
-        3,
-        4,
-        5,
-        6
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        7,
-        8,
-        9
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://privacy.audienceproject.com'
-    },
-    '402': {
-      id: 402,
-      name: 'Effiliation',
-      purposes: [
-        1,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://inter.effiliation.com/politique-confidentialite.html'
-    },
-    '408': {
-      id: 408,
-      name: 'Fidelity Media',
-      purposes: [
-        1,
-        2,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        7
-      ],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://fidelity-media.com/privacy-policy/'
-    },
-    '409': {
-      id: 409,
-      name: 'Arrivalist Co.',
-      purposes: [
-        1,
-        9
-      ],
-      legIntPurposes: [
-        7,
-        8
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://www.arrivalist.com/privacy'
-    },
-    '410': {
-      id: 410,
-      name: 'Adtelligent Inc.',
-      purposes: [
-        1,
-        7,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://adtelligent.com/privacy-policy/'
-    },
-    '412': {
-      id: 412,
-      name: 'Cxense ASA',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.cxense.com/about-us/privacy-policy'
-    },
-    '413': {
-      id: 413,
-      name: 'Eulerian Technologies',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.eulerian.com/en/privacy/'
-    },
-    '415': {
-      id: 415,
-      name: 'Seenthis AB',
-      purposes: [],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://seenthis.co/privacy-notice-2018-04-18.pdf'
-    },
-    '416': {
-      id: 416,
-      name: 'Commanders Act',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.commandersact.com/en/privacy/'
-    },
-    '418': {
-      id: 418,
-      name: 'PROXISTORE',
-      purposes: [
-        1,
-        2,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        2
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://www.proxistore.com/common/en/cgv'
-    },
-    '422': {
-      id: 422,
-      name: 'Brand Metrics Sweden AB',
-      purposes: [
-        1,
-        6,
-        7,
-        8,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://collector.brandmetrics.com/brandmetrics_privacypolicy.pdf'
-    },
-    '423': {
-      id: 423,
-      name: 'travel audience GmbH',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://travelaudience.com/product-privacy-policy/'
-    },
-    '424': {
-      id: 424,
-      name: 'KUPONA GmbH',
-      purposes: [
-        4,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        4
-      ],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.kupona.de/dsgvo/'
-    },
-    '428': {
-      id: 428,
-      name: 'Internet BillBoard a.s.',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        7
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://www.ibillboard.com/en/privacy-information/'
-    },
-    '429': {
-      id: 429,
-      name: 'Signals',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://signalsdata.com/platform-cookie-policy/'
-    },
-    '431': {
-      id: 431,
-      name: 'White Ops, Inc.',
-      purposes: [],
-      legIntPurposes: [
-        7,
-        9,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        3
-      ],
-      specialFeatures: [
-        2
-      ],
-      policyUrl: 'https://www.whiteops.com/privacy'
-    },
-    '436': {
-      id: 436,
-      name: 'INVIBES GROUP',
-      purposes: [
-        1,
-        3,
-        4,
-        5,
-        6,
-        9
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        8,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        10
-      ],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'http://www.invibes.com/terms'
-    },
-    '438': {
-      id: 438,
-      name: 'INVIDI technologies AB',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'http://www.invidi.com/wp-content/uploads/2020/02/ad-tech-services-privacy-policy.pdf'
-    },
-    '439': {
-      id: 439,
-      name: 'Bit Q Holdings Limited',
-      purposes: [
-        1,
-        7,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.rippll.com/privacy'
-    },
-    '440': {
-      id: 440,
-      name: 'DEFINE MEDIA GMBH',
-      purposes: [
-        1,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        4,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://www.definemedia.de/datenschutz-conative/'
-    },
-    '444': {
-      id: 444,
-      name: 'Playbuzz Ltd (aka EX.CO)',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        5,
-        6
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://ex.co/privacy-policy/'
-    },
-    '447': {
-      id: 447,
-      name: 'Adludio Ltd',
-      purposes: [
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.adludio.com/privacy-policy/'
-    },
-    '450': {
-      id: 450,
-      name: 'Neodata Group srl',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.neodatagroup.com/en/security-policy',
-      overflow: {
-        httpGetLimit: 32
-      }
-    },
-    '455': {
-      id: 455,
-      name: 'GDMServices, Inc. d/b/a FiksuDSP',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        10
-      ],
-      legIntPurposes: [
-        7,
-        8
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://fiksu.com/privacy-policy/'
-    },
-    '466': {
-      id: 466,
-      name: 'TACTIC™ Real-Time Marketing AS',
-      purposes: [],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://tacticrealtime.com/privacy/'
-    },
-    '467': {
-      id: 467,
-      name: 'Haensel AMS GmbH',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        7
-      ],
-      flexiblePurposes: [
-        7
-      ],
-      specialPurposes: [],
-      features: [
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://haensel-ams.com/data-privacy/'
-    },
-    '475': {
-      id: 475,
-      name: 'TAPTAP Digital SL',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7
-      ],
-      legIntPurposes: [
-        8,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://www.taptapnetworks.com/privacy_policy/'
-    },
-    '479': {
-      id: 479,
-      name: 'INFINIA MOBILE S.L.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'http://www.infiniamobile.com/privacy_policy'
-    },
-    '484': {
-      id: 484,
-      name: 'STRIATUM SAS',
-      purposes: [],
-      legIntPurposes: [
-        7,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://adledge.com/data-privacy/'
-    },
-    '486': {
-      id: 486,
-      name: 'Madington',
-      purposes: [],
-      legIntPurposes: [
-        7,
-        8,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://delivered-by-madington.com/dat-privacy-policy/'
-    },
-    '488': {
-      id: 488,
-      name: 'Opinary GmbH',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        8,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        7,
-        8,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://opinary.com/privacy-policy/'
-    },
-    '490': {
-      id: 490,
-      name: 'PLAYGROUND XYZ EMEA LTD',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7
-      ],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://playground.xyz/privacy'
-    },
-    '491': {
-      id: 491,
-      name: 'Triboo Data Analytics',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.shinystat.com/it/informativa_privacy_generale.html'
-    },
-    '495': {
-      id: 495,
-      name: 'Arcspire Limited',
-      purposes: [
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://public.arcspire.io/privacy.pdf',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '498': {
-      id: 498,
-      name: 'Dr. Banner',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8
-      ],
-      legIntPurposes: [
-        9,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://drbanner.com/privacypolicy_en/'
-    },
-    '501': {
-      id: 501,
-      name: 'Alliance Gravity Data Media',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.alliancegravity.com/politiquedeprotectiondesdonneespersonnelles'
-    },
-    '502': {
-      id: 502,
-      name: 'NEXD',
-      purposes: [
-        1,
-        7,
-        10
-      ],
-      legIntPurposes: [
-        9
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://nexd.com/privacy-policy',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '505': {
-      id: 505,
-      name: 'Shopalyst Inc',
-      purposes: [
-        1,
-        7,
-        8
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.shortlyst.com/eu/privacy_terms.html'
-    },
-    '507': {
-      id: 507,
-      name: 'AdsWizz Inc.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://www.adswizz.com/our-privacy-policy/'
-    },
-    '508': {
-      id: 508,
-      name: 'Lucid Holdings, LLC',
-      purposes: [
-        1,
-        7,
-        8,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        7,
-        8,
-        9
-      ],
-      specialPurposes: [
-        1
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'luc.id/privacy-policy'
-    },
-    '511': {
-      id: 511,
-      name: 'Admixer EU GmbH',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        7,
-        9
-      ],
-      legIntPurposes: [
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://admixer.com/privacy/',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '512': {
-      id: 512,
-      name: 'PubNative GmbH',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        8,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        2
-      ],
-      policyUrl: 'https://pubnative.net/privacy-notice/'
-    },
-    '516': {
-      id: 516,
-      name: 'Pexi B.V.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://pexi.nl/privacy-policy/'
-    },
-    '517': {
-      id: 517,
-      name: 'SunMedia ',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.sunmedia.tv/en/cookies'
-    },
-    '521': {
-      id: 521,
-      name: 'netzeffekt GmbH',
-      purposes: [
-        1,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.netzeffekt.de/en/imprint'
-    },
-    '524': {
-      id: 524,
-      name: 'The Ozone Project Limited',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://ozoneproject.com/privacy-policy'
-    },
-    '527': {
-      id: 527,
-      name: 'Jampp LTD',
-      purposes: [
-        1,
-        2,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://jampp.com/privacy.html'
-    },
-    '528': {
-      id: 528,
-      name: 'Kayzen',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        9,
-        10
-      ],
-      legIntPurposes: [
-        7
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://kayzen.io/data-privacy-policy'
-    },
-    '530': {
-      id: 530,
-      name: 'Near Pte Ltd',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://near.co/privacy',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '531': {
-      id: 531,
-      name: 'Smartclip Hispania SL',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://rgpd-smartclip.com/'
-    },
-    '535': {
-      id: 535,
-      name: 'INNITY',
-      purposes: [
-        1,
-        2,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.innity.com/privacy-policy.php'
-    },
-    '536': {
-      id: 536,
-      name: 'GlobalWebIndex',
-      purposes: [
-        1,
-        7,
-        8,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'http://legal.trendstream.net/non-panellist_privacy_policy'
-    },
-    '539': {
-      id: 539,
-      name: 'AdDefend GmbH',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        7
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.addefend.com/en/privacy-policy/'
-    },
-    '543': {
-      id: 543,
-      name: 'PaperG, Inc. dba Thunder Industries',
-      purposes: [
-        1,
-        3,
-        4,
-        5,
-        6
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        8
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.makethunder.com/privacy'
-    },
-    '544': {
-      id: 544,
-      name: 'Kochava Inc.',
-      purposes: [],
-      legIntPurposes: [
-        7
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://www.kochava.com/support-privacy/'
-    },
-    '545': {
-      id: 545,
-      name: 'Reignn Platform Ltd',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        8,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [
-        2
-      ],
-      policyUrl: 'http://reignn.com/user-privacy-policy'
-    },
-    '546': {
-      id: 546,
-      name: 'Smart Traffik',
-      purposes: [
-        1,
-        8
-      ],
-      legIntPurposes: [
-        7
-      ],
-      flexiblePurposes: [
-        7,
-        8
-      ],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://smart-traffik.io/politique-de-confidentialite'
-    },
-    '549': {
-      id: 549,
-      name: 'Bandsintown Amplified LLC',
-      purposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://corp.bandsintown.com/privacy'
-    },
-    '550': {
-      id: 550,
-      name: 'Happydemics',
-      purposes: [
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.iubenda.com/privacy-policy/69056167/full-legal'
-    },
-    '553': {
-      id: 553,
-      name: 'Adhese',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://adhese.com/privacy-and-cookie-policy'
-    },
-    '554': {
-      id: 554,
-      name: 'RMSi Radio Marketing Service interactive GmbH',
-      purposes: [
-        1,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        9
-      ],
-      flexiblePurposes: [
-        2
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://www.rms.de/datenschutz/'
-    },
-    '556': {
-      id: 556,
-      name: 'adhood.com',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://v3.adhood.com/en/site/politikavekurallar/gizlilik.php?lang=en'
-    },
-    '559': {
-      id: 559,
-      name: 'Otto (GmbH &amp; Co KG)',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.otto.de/shoppages/service/datenschutz'
-    },
-    '561': {
-      id: 561,
-      name: 'AuDigent',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'http://audigent.com/platform-privacy-policy'
-    },
-    '565': {
-      id: 565,
-      name: 'Adobe Audience Manager',
-      purposes: [
-        1,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.adobe.com/privacy/policy.html'
-    },
-    '568': {
-      id: 568,
-      name: 'Jointag S.r.l.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://www.jointag.com/privacy/kariboo/publisher/third/'
-    },
-    '571': {
-      id: 571,
-      name: 'ViewPay',
-      purposes: [
-        1,
-        2,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'http://viewpay.tv/mentions-legales/'
-    },
-    '573': {
-      id: 573,
-      name: 'Dailymotion SA',
-      purposes: [
-        1,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        5,
-        6,
-        7,
-        8,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.dailymotion.com/legal/privacy',
-      overflow: {
-        httpGetLimit: 32
-      }
-    },
-    '574': {
-      id: 574,
-      name: 'Realeyes OU',
-      purposes: [
-        1,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://realview.realeyesit.com/privacy'
-    },
-    '577': {
-      id: 577,
-      name: 'Neustar on behalf of The Procter & Gamble Company',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        6,
-        9
-      ],
-      legIntPurposes: [
-        5,
-        7,
-        8
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9
-      ],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.pg.com/privacy/english/privacy_statement.shtml'
-    },
-    '580': {
-      id: 580,
-      name: 'Goldbach Group AG',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://goldbach.com/ch/de/datenschutz'
-    },
-    '587': {
-      id: 587,
-      name: 'Localsensor B.V.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.localsensor.com/privacy.html'
-    },
-    '591': {
-      id: 591,
-      name: 'Consumable, Inc.',
-      purposes: [
-        1,
-        2,
-        4,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://consumable.com/privacy-policy.html'
-    },
-    '593': {
-      id: 593,
-      name: 'Programatica de publicidad S.L.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://datmean.com/politica-privacidad/'
-    },
-    '596': {
-      id: 596,
-      name: 'InsurAds Technologies SA.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        9,
-        10
-      ],
-      legIntPurposes: [
-        7,
-        8
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.insurads.com/privacy.html'
-    },
-    '598': {
-      id: 598,
-      name: 'audio content &amp; control GmbH',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        9
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.audio-cc.com/audiocc_privacy_policy.pdf'
-    },
-    '599': {
-      id: 599,
-      name: 'Maximus Live LLC',
-      purposes: [],
-      legIntPurposes: [
-        7,
-        8
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1
-      ],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://maximusx.com/privacy-policy/'
-    },
-    '601': {
-      id: 601,
-      name: 'WebAds B.V',
-      purposes: [
-        1,
-        2
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://privacy.webads.eu/'
-    },
-    '602': {
-      id: 602,
-      name: 'Online Solution Int Limited',
-      purposes: [
-        2,
-        7,
-        8,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        7,
-        8,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://adsafety.net/privacy.html',
-      overflow: {
-        httpGetLimit: 32
-      }
-    },
-    '606': {
-      id: 606,
-      name: 'Impactify ',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://impactify.io/privacy-policy/'
-    },
-    '607': {
-      id: 607,
-      name: 'ucfunnel Co., Ltd.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.ucfunnel.com/privacy-policy'
-    },
-    '609': {
-      id: 609,
-      name: 'Predicio',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'http://www.predic.io/privacy',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '610': {
-      id: 610,
-      name: 'Azerion Holding B.V.',
-      purposes: [
-        1,
-        3,
-        4,
-        9
-      ],
-      legIntPurposes: [
-        2,
-        5,
-        6,
-        7,
-        8,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        5,
-        6
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://azerion.com/business/privacy.html',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '612': {
-      id: 612,
-      name: 'Adnami Aps',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.adnami.io/privacy',
-      deletedDate: '2020-03-17T00:00:00Z'
-    },
-    '613': {
-      id: 613,
-      name: 'Adserve.zone / Artworx AS',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        7
-      ],
-      flexiblePurposes: [
-        2
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://adserve.zone/adserveprivacypolicy.html'
-    },
-    '614': {
-      id: 614,
-      name: 'Market Resource Partners LLC',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        2
-      ],
-      policyUrl: 'https://www.mrpfd.com/privacy-policy/'
-    },
-    '615': {
-      id: 615,
-      name: 'Adsolutions BV',
-      purposes: [],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.adsolutions.com/privacy-policy/'
-    },
-    '617': {
-      id: 617,
-      name: 'Onfocus (Adagio)',
-      purposes: [
-        1,
-        2
-      ],
-      legIntPurposes: [
-        7
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://adagio.io/privacy'
-    },
-    '618': {
-      id: 618,
-      name: 'BEINTOO SPA',
-      purposes: [
-        1,
-        2,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://www.beintoo.com/privacy-cookie-policy/'
-    },
-    '620': {
-      id: 620,
-      name: 'Blue',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://www.getblue.io/privacy/'
-    },
-    '625': {
-      id: 625,
-      name: 'BILENDI SA',
-      purposes: [
-        1,
-        6,
-        7,
-        8,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.maximiles.com/privacy-policy'
-    },
-    '626': {
-      id: 626,
-      name: 'Hivestack Inc.',
-      purposes: [
-        1,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://hivestack.com/privacy-policy'
-    },
-    '628': {
-      id: 628,
-      name: ': Tappx',
-      purposes: [
-        1,
-        2,
-        4,
-        7,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        2
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://www.tappx.com/en/privacy-policy/'
-    },
-    '630': {
-      id: 630,
-      name: 'Contact Impact GmbH',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        7,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://contactimpact.de/privacy'
-    },
-    '631': {
-      id: 631,
-      name: 'Relay42 Netherlands B.V.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://relay42.com/privacy'
-    },
-    '638': {
-      id: 638,
-      name: 'Passendo Aps',
-      purposes: [
-        1,
-        2,
-        4,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://passendo.com/users-privacy-policy'
-    },
-    '639': {
-      id: 639,
-      name: 'Smile Wanted Group',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [
-        2
-      ],
-      policyUrl: 'https://www.smilewanted.com/privacy.php'
-    },
-    '645': {
-      id: 645,
-      name: 'Noster Finance S.L.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        9,
-        10
-      ],
-      legIntPurposes: [
-        7,
-        8
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://www.finect.com/terminos-legales/politica-de-cookies'
-    },
-    '646': {
-      id: 646,
-      name: 'Notify',
-      purposes: [],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://notify-group.com/en/mentions-legales/'
-    },
-    '647': {
-      id: 647,
-      name: 'Axel Springer Teaser Ad GmbH',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        7,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.adup-tech.com/privacy'
-    },
-    '648': {
-      id: 648,
-      name: 'TrueData Solutions, Inc.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://www.truedata.co/privacy-policy/'
-    },
-    '649': {
-      id: 649,
-      name: 'adality GmbH',
-      purposes: [],
-      legIntPurposes: [
-        2
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://adality.de/en/privacy/'
-    },
-    '650': {
-      id: 650,
-      name: 'Telefonica Investigación y Desarrollo S.A.U',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://www.cognitivemarketing.tid.es/'
-    },
-    '652': {
-      id: 652,
-      name: 'Skaze',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://www.skaze.fr/rgpd/'
-    },
-    '653': {
-      id: 653,
-      name: 'Smartme Analytics',
-      purposes: [
-        7,
-        8,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'http://smartmeapp.com/info/smartme/aviso_legal.php',
-      deletedDate: '2020-07-03T00:00:00Z'
-    },
-    '655': {
-      id: 655,
-      name: 'Sportradar AG',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://www.sportradar.com/about-us/privacy/'
-    },
-    '656': {
-      id: 656,
-      name: 'Think Clever Media',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        9
-      ],
-      legIntPurposes: [
-        7,
-        8,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.contentignite.com/privacy-policy/'
-    },
-    '657': {
-      id: 657,
-      name: 'GP One GmbH',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://www.gsi-one.org/de/privacy-policy.html'
-    },
-    '659': {
-      id: 659,
-      name: 'Research and Analysis of Media in Sweden AB',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        7,
-        8,
-        9
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www2.rampanel.com/privacy-policy/'
-    },
-    '662': {
-      id: 662,
-      name: 'SoundCast',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://soundcast.fm/en/data-privacy'
-    },
-    '663': {
-      id: 663,
-      name: 'Mobsuccess',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        7
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.mobsuccess.com/en/privacy'
-    },
-    '664': {
-      id: 664,
-      name: 'adMarketplace, Inc.',
-      purposes: [
-        1,
-        2,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        7,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.admarketplace.com/privacy-policy/'
-    },
-    '665': {
-      id: 665,
-      name: 'Digital East GmbH',
-      purposes: [
-        2,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.digitaleast.mobi/en/legal/privacy-policy/'
-    },
-    '667': {
-      id: 667,
-      name: 'Liftoff Mobile, Inc.',
-      purposes: [
-        1,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        5,
-        6,
-        7,
-        8,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://liftoff.io/privacy-policy/'
-    },
-    '668': {
-      id: 668,
-      name: 'WhatRocks Inc. ',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        2
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://www.whatrocks.co/en/privacy-policy '
-    },
-    '674': {
-      id: 674,
-      name: 'Duration Media, LLC.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.durationmedia.net/privacy-policy'
-    },
-    '675': {
-      id: 675,
-      name: 'Instreamatic inc.',
-      purposes: [
-        2,
-        3,
-        4,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://instreamatic.com/privacy-policy/'
-    },
-    '676': {
-      id: 676,
-      name: 'BusinessClick',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.businessclick.com/documents/RegulaminProgramuBusinessClick-2019.pdf'
-    },
-    '678': {
-      id: 678,
-      name: 'Axonix LTD',
-      purposes: [
-        2
-      ],
-      legIntPurposes: [
-        7,
-        10
-      ],
-      flexiblePurposes: [
-        2
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://axonix.com/privacy-cookie-policy/',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '681': {
-      id: 681,
-      name: 'MyTraffic',
-      purposes: [
-        1,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        9
-      ],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.mytraffic.io/en/privacy'
-    },
-    '682': {
-      id: 682,
-      name: 'Radio Net Media Limited',
-      purposes: [
-        1,
-        2,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        7
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://www.adtonos.com/service-privacy-policy/',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '683': {
-      id: 683,
-      name: 'Cookie Market LTD',
-      purposes: [
-        1,
-        3,
-        4,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'http://cookie.market/privacyPolicy.php'
-    },
-    '684': {
-      id: 684,
-      name: 'Blue Billywig BV',
-      purposes: [],
-      legIntPurposes: [
-        7
-      ],
-      flexiblePurposes: [
-        7
-      ],
-      specialPurposes: [
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.bluebillywig.com/privacy-statement/'
-    },
-    '686': {
-      id: 686,
-      name: 'The MediaGrid Inc.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.themediagrid.com/privacy-policy/'
-    },
-    '687': {
-      id: 687,
-      name: 'MISSENA',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2
-      ],
-      specialPurposes: [
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://missena.com/confidentialite/'
-    },
-    '688': {
-      id: 688,
-      name: 'Effinity',
-      purposes: [],
-      legIntPurposes: [
-        2
-      ],
-      flexiblePurposes: [
-        2,
-        7
-      ],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.effiliation.com/politique-de-confidentialite/',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '690': {
-      id: 690,
-      name: 'Go.pl sp. z o.o.',
-      purposes: [
-        1,
-        2,
-        3,
-        4
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://go.pl/polityka-prywatnosci/'
-    },
-    '691': {
-      id: 691,
-      name: 'Lifesight Pte. Ltd.',
-      purposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.lifesight.io/privacy-policy/'
-    },
-    '694': {
-      id: 694,
-      name: 'Snapupp Technologies SL',
-      purposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        9
-      ],
-      legIntPurposes: [
-        7,
-        8,
-        10
-      ],
-      flexiblePurposes: [
-        10
-      ],
-      specialPurposes: [],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.enterprise.noddus.com/privacy-policy',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '699': {
-      id: 699,
-      name: 'HyperTV Inc.',
-      purposes: [
-        1,
-        2,
-        4,
-        9
-      ],
-      legIntPurposes: [
-        7,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        2
-      ],
-      features: [
-        1
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.hypertvx.com/privacy/'
-    },
-    '702': {
-      id: 702,
-      name: 'Kwanko',
-      purposes: [
-        1,
-        2,
-        7,
-        8
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        7,
-        8
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.kwanko.com/fr/rgpd/'
-    },
-    '703': {
-      id: 703,
-      name: 'MindTake Research GmbH',
-      purposes: [
-        1,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1
-      ],
-      features: [
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.mindtake.com/en/reppublika-privacy-policy'
-    },
-    '707': {
-      id: 707,
-      name: 'Dentsu Aegis Network Italia SpA',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://www.dentsuaegisnetwork.com/it/it/policies/info-cookie'
-    },
-    '708': {
-      id: 708,
-      name: 'Dugout Limited ',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://dugout.com/privacy-policy'
-    },
-    '709': {
-      id: 709,
-      name: 'NC Audience Exchange, LLC (NewsIQ)',
-      purposes: [
-        1,
-        3,
-        4,
-        5
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.ncaudienceexchange.com/privacy/'
-    },
-    '711': {
-      id: 711,
-      name: 'SITU8ED SA',
-      purposes: [
-        1,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.situ8ed.com/privacy-policy/'
-    },
-    '712': {
-      id: 712,
-      name: 'Inspired Mobile Limited',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://byinspired.com/privacypolicy.pdf'
-    },
-    '713': {
-      id: 713,
-      name: 'Dataseat Ltd',
-      purposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        7,
-        8
-      ],
-      specialPurposes: [],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://dataseat.com/privacy-policy'
-    },
-    '714': {
-      id: 714,
-      name: 'Survata Inc.',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        7,
-        9
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.survata.com/respondent-privacy-policy/',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '716': {
-      id: 716,
-      name: 'OnAudience Ltd',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.onaudience.com/internet-advertising-privacy-policy'
-    },
-    '719': {
-      id: 719,
-      name: 'Online Advertising Network Sp. z o.o.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.oan.pl/en/privacy-policy'
-    },
-    '720': {
-      id: 720,
-      name: 'AAX LLC',
-      purposes: [
-        1,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://aax.media/privacy/',
-      overflow: {
-        httpGetLimit: 32
-      }
-    },
-    '721': {
-      id: 721,
-      name: 'Beaconspark Ltd',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        7
-      ],
-      legIntPurposes: [
-        6,
-        8
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.engageya.com/privacy'
-    },
-    '722': {
-      id: 722,
-      name: 'agof - daily campaign facts',
-      purposes: [
-        1,
-        8,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        7
-      ],
-      specialPurposes: [
-        1
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://www.agof.de/datenschutz/'
-    },
-    '723': {
-      id: 723,
-      name: 'Adzymic Pte Ltd',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        8
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'http://www.adzymic.co/privacy',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '725': {
-      id: 725,
-      name: 'Pubfinity LLC',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://pubfinity.com/privacy-policy/',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '727': {
-      id: 727,
-      name: 'Pinpoll GmbH (Private Limited)',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.pinpoll.com/#data_protection_declaration'
-    },
-    '728': {
-      id: 728,
-      name: 'Appier PTE Ltd',
-      purposes: [
-        1,
-        3,
-        4,
-        5,
-        6,
-        9
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        8,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.appier.com/privacy-policy/'
-    },
-    '729': {
-      id: 729,
-      name: 'Cavai AS & UK ',
-      purposes: [],
-      legIntPurposes: [
-        7,
-        8
-      ],
-      flexiblePurposes: [
-        7,
-        8
-      ],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://cav.ai/privacy-policy/'
-    },
-    '730': {
-      id: 730,
-      name: 'INFOnline GmbH',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        8
-      ],
-      flexiblePurposes: [
-        8
-      ],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.infonline.de/en/privacy-policy/'
-    },
-    '731': {
-      id: 731,
-      name: 'GeistM Technologies LTD',
-      purposes: [],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.geistm.com/privacy'
-    },
-    '733': {
-      id: 733,
-      name: 'Anzu Virtual reality LTD',
-      purposes: [
-        1,
-        2,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://anzu.io/privacy/'
-    },
-    '734': {
-      id: 734,
-      name: 'Cint AB',
-      purposes: [
-        1,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.cint.com/participant-privacy-notice'
-    },
-    '735': {
-      id: 735,
-      name: 'Deutsche Post AG',
-      purposes: [
-        1,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.deutschepost.de/de/c/consentric/datenschutz.html'
-    },
-    '737': {
-      id: 737,
-      name: 'Monet Engine Inc',
-      purposes: [
-        1,
-        2,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://appmonet.com/privacy-policy/'
-    },
-    '738': {
-      id: 738,
-      name: 'adbility media GmbH',
-      purposes: [
-        2,
-        3,
-        4,
-        9
-      ],
-      legIntPurposes: [
-        7
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        9
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://www.adbility-media.com/datenschutzerklaerung/'
-    },
-    '739': {
-      id: 739,
-      name: 'Blingby LLC',
-      purposes: [
-        1,
-        8,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://blingby.com/privacy'
-    },
-    '740': {
-      id: 740,
-      name: '6Sense Insights, Inc.',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        5,
-        7,
-        8,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        7,
-        8,
-        10
-      ],
-      specialPurposes: [],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://6sense.com/privacy-policy/',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '741': {
-      id: 741,
-      name: 'Brand Advance Limited',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://www.wearebrandadvance.com/website-privacy-policy'
-    },
-    '742': {
-      id: 742,
-      name: 'Audiencerate LTD',
-      purposes: [
-        1,
-        2,
-        3,
-        5,
-        6
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.audiencerate.com/privacy/'
-    },
-    '743': {
-      id: 743,
-      name: 'MOVIads Sp. z o.o. Sp. k.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://moviads.pl/polityka-prywatnosci/',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '744': {
-      id: 744,
-      name: 'Vidazoo Ltd',
-      purposes: [
-        3,
-        4
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        8,
-        10
-      ],
-      flexiblePurposes: [
-        3,
-        4
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        2
-      ],
-      specialFeatures: [
-        2
-      ],
-      policyUrl: 'https://vidazoo.gitbook.io/vidazoo-legal/privacy-policy',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '745': {
-      id: 745,
-      name: 'Justtag Sp. z o.o.',
-      purposes: [
-        1,
-        3,
-        4,
-        9
-      ],
-      legIntPurposes: [
-        7
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.justtag.com/pdf/PRIVACY_POLICY_Koalametrics_english.pdf'
-    },
-    '746': {
-      id: 746,
-      name: 'Adxperience SAS',
-      purposes: [
-        4
-      ],
-      legIntPurposes: [
-        2,
-        7
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://adxperience.com/privacy-policy/'
-    },
-    '747': {
-      id: 747,
-      name: 'Kairion GmbH',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [],
-      features: [
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://kairion.de/datenschutzbestimmungen/'
-    },
-    '748': {
-      id: 748,
-      name: 'AUDIOMOB LTD',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        8,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        8,
-        9
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://www.audiomob.io/privacy'
-    },
-    '749': {
-      id: 749,
-      name: 'Good-Loop Ltd',
-      purposes: [
-        1,
-        3,
-        4,
-        5,
-        6
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://doc.good-loop.com/policy/privacy-policy.html'
-    },
-    '750': {
-      id: 750,
-      name: 'THE NEWCO S.R.L.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://www.thenewco.it/privacy_policy_servizi_prodotti.html'
-    },
-    '751': {
-      id: 751,
-      name: 'Kiosked Ltd',
-      purposes: [],
-      legIntPurposes: [
-        2,
-        7
-      ],
-      flexiblePurposes: [
-        2,
-        7
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://kiosked.com/privacy-policy/'
-    },
-    '753': {
-      id: 753,
-      name: 'ScaleMonk Inc.',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.scalemonk.com/privacy-policy/index.html'
-    },
-    '754': {
-      id: 754,
-      name: 'DistroScale, Inc.',
-      purposes: [
-        1,
-        2
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2
-      ],
-      specialPurposes: [
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'http://www.distroscale.com/privacy-policy/'
-    },
-    '757': {
-      id: 757,
-      name: 'UAB Meazy',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        7,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://meazy.co/privacy-policy'
-    },
-    '758': {
-      id: 758,
-      name: 'GfK Netherlands B.V.',
-      purposes: [
-        1,
-        7,
-        8,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        7,
-        8,
-        9
-      ],
-      specialPurposes: [],
-      features: [
-        1
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://gfkpanel.nl/privacy'
-    },
-    '759': {
-      id: 759,
-      name: 'RevJet',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.revjet.com/privacy',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '760': {
-      id: 760,
-      name: 'VEXPRO TECHNOLOGIES LTD',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        2
-      ],
-      policyUrl: 'https://onedash.com/privacy-policy.html'
-    },
-    '761': {
-      id: 761,
-      name: 'Digiseg ApS',
-      purposes: [
-        1,
-        3,
-        5,
-        7,
-        8,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        1
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://digiseg.io/privacy-center/'
-    },
-    '762': {
-      id: 762,
-      name: 'Protected Media LTD',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        3,
-        5,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.protected.media/privacy-policy/'
-    },
-    '764': {
-      id: 764,
-      name: 'Lucidity',
-      purposes: [
-        1,
-        2,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://golucidity.com/privacy-policy/'
-    },
-    '765': {
-      id: 765,
-      name: 'Grabit Interactive Media Inc dba KERV Interctive',
-      purposes: [
-        2,
-        3,
-        4,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        2
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://kervit.com/privacy-policy/'
-    },
-    '766': {
-      id: 766,
-      name: 'ADCELL | Firstlead GmbH',
-      purposes: [
-        1,
-        2
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2
-      ],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.adcell.de/agb#sector_6'
-    },
-    '768': {
-      id: 768,
-      name: 'Global Media & Entertainment Limited',
-      purposes: [
-        1,
-        2,
-        3,
-        4,
-        7,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'http://global.com/privacy-policy/'
-    },
-    '769': {
-      id: 769,
-      name: 'MEDIAMETRIE',
-      purposes: [
-        1,
-        8
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.mediametrie.fr/fr/gestion-des-cookies'
-    },
-    '770': {
-      id: 770,
-      name: 'MARKETPERF CORP',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2,
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.marketperf.com/assets/images/app/marketperf/pdf/privacy-policy.pdf'
-    },
-    '771': {
-      id: 771,
-      name: 'bam! interactive marketing GmbH ',
-      purposes: [
-        1,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://bam-interactive.de/privacy-policy/'
-    },
-    '772': {
-      id: 772,
-      name: 'Oracle Data Cloud - Moat',
-      purposes: [],
-      legIntPurposes: [
-        7,
-        8,
-        10
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.oracle.com/legal/privacy/services-privacy-policy.html'
-    },
-    '774': {
-      id: 774,
-      name: 'Wagawin GmbH',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        7
-      ],
-      flexiblePurposes: [
-        2
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.wagawin.com/privacy-en/#productprivacy'
-    },
-    '775': {
-      id: 775,
-      name: 'SelectMedia International LTD',
-      purposes: [
-        1,
-        2
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        3
-      ],
-      specialFeatures: [],
-      policyUrl: 'https://www.selectmedia.asia/terms-and-privacy/'
-    },
-    '776': {
-      id: 776,
-      name: 'Mars Media Group',
-      purposes: [
-        2
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [
-        2
-      ],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://pay-per-leads.com/terms'
-    },
-    '777': {
-      id: 777,
-      name: 'One Planet Only',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        7
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://oneplanetonly.com/files/PRIVACY%20POLICY.pdf',
-      overflow: {
-        httpGetLimit: 32
-      }
-    },
-    '778': {
-      id: 778,
-      name: 'Discover-Tech ltd',
-      purposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://discover-tech.io/dsp-privacy-policy/'
-    },
-    '779': {
-      id: 779,
-      name: 'Adtarget Medya A.S.',
-      purposes: [
-        1,
-        7
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [
-        3
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://adtarget.com.tr/adtarget-privacy-policy-2020.pdf'
-    },
-    '780': {
-      id: 780,
-      name: 'Aniview LTD',
-      purposes: [
-        1,
-        2,
-        7,
-        8
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.aniview.com/privacy-policy/'
-    },
-    '781': {
-      id: 781,
-      name: 'FeedAd GmbH',
-      purposes: [
-        1,
-        3,
-        4,
-        5,
-        6,
-        8,
-        9
-      ],
-      legIntPurposes: [
-        2,
-        7,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        7,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        2,
-        3
-      ],
-      specialFeatures: [
-        1,
-        2
-      ],
-      policyUrl: 'https://feedad.com/privacy/',
-      overflow: {
-        httpGetLimit: 128
-      }
-    },
-    '782': {
-      id: 782,
-      name: 'AirGrid LTD',
-      purposes: [
-        1,
-        3,
-        5,
-        7,
-        8,
-        9,
-        10
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'airgid.io/privacy-policy'
-    },
-    '783': {
-      id: 783,
-      name: 'Audienzz AG',
-      purposes: [
-        1
-      ],
-      legIntPurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [
-        1,
-        2
-      ],
-      specialFeatures: [
-        1
-      ],
-      policyUrl: 'https://audienzz.ch/wp-content/uploads/2020/03/AGB_audienzz_2020.pdf'
-    },
-    '784': {
-      id: 784,
-      name: 'Nubo LTD',
-      purposes: [],
-      legIntPurposes: [
-        2
-      ],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.recod3.com/privacypolicy.php'
-    },
-    '785': {
-      id: 785,
-      name: 'agof - daily digital facts',
-      purposes: [
-        1,
-        9
-      ],
-      legIntPurposes: [],
-      flexiblePurposes: [],
-      specialPurposes: [
-        1
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'http://www.agof.de/datenschutz/'
-    },
-    '786': {
-      id: 786,
-      name: 'TargetVideo GmbH',
-      purposes: [
-        1,
-        2,
-        3,
-        4
-      ],
-      legIntPurposes: [
-        7,
-        8,
-        10
-      ],
-      flexiblePurposes: [
-        2,
-        3,
-        4,
-        7,
-        8,
-        10
-      ],
-      specialPurposes: [
-        1,
-        2
-      ],
-      features: [],
-      specialFeatures: [],
-      policyUrl: 'https://www.target-video.com/datenschutz/'
     }
   }
-}}
+}
 
-export {VendorListValueEnglish, VendorListValueSpanish, VendorList46, VendorList45}
+export {
+  VendorListValueEnglish,
+  VendorListValueSpanish,
+  VendorList46,
+  VendorList45
+}

--- a/src/test/testable/infrastructure/repository/iab/TestableGVLFactory.js
+++ b/src/test/testable/infrastructure/repository/iab/TestableGVLFactory.js
@@ -56,4 +56,13 @@ export class TestableGVLFactory extends GVLFactory {
   reset() {
     nock.cleanAll()
   }
+
+  mockReply({path, data}) {
+    nock('http://mock.borostcf.com/borostcf/v2/vendorlist')
+      .get(path)
+      .reply(200, data, {
+        'access-control-allow-origin': '*',
+        'access-control-allow-credentials': 'true'
+      })
+  }
 }


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->
- Scenario:
  - User have saved all the vendor consents for version 45
  - Vendor id  3 does not exist
  - User Load consent and new version list is available 
  - Vendor consent for vendor id 3 is false (becasue did not exist in version 45)
  - We think that user has fine grained consents (some true, some false) and we set consent to invalid (should be valid )
## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->
https://jira.scmspain.com/browse/PSP-3385
## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->
 - Consent should be set valid when load consent is called
 - When we detect that version list has changed we compare with the old existing version list 
## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->
![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/9216269/87945754-7a61da00-caa1-11ea-89ee-41c4bcffa8bd.gif)


## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/1dMNqVx9Kb12EBjFrc/giphy.gif)