### PR TITLE
Fixing save vendorlist version from de LATEST

### DIFF
--- a/src/main/application/services/vendorconsent/SaveUserConsentUseCase.js
+++ b/src/main/application/services/vendorconsent/SaveUserConsentUseCase.js
@@ -20,15 +20,13 @@ class SaveUserConsentUseCase {
   }
 
   async execute({purpose, vendor, specialFeatures}) {
-    const previousEncodedConsent = this._consentRepository.loadUserConsent()
     const incomingConsent = this._consentFactory.createConsent({
       vendor,
       purpose,
       specialFeatures
     })
     const consent = await this._consentEncoderService.encode({
-      consent: incomingConsent,
-      previousEncodedConsent
+      consent: incomingConsent
     })
     this._consentRepository.saveUserConsent({consent})
   }

--- a/src/test/application/BorosTcfTest.js
+++ b/src/test/application/BorosTcfTest.js
@@ -109,41 +109,37 @@ describe('BorosTcf', () => {
         })
         .persist()
       const cookieStorageMockTest = new TestableCookieStorageMock()
-      const cookie45WithoutVendors =
+      const cookie45WithoutVendorsConsentsAndValid =
         'CO2r3W7O2r3W7CBAEAENAtCoAP_AAH_AAAiQAAAAAAAA.YAAAAAAAAAAA'
-      cookieStorageMockTest.storage.set('euconsent-v2', cookie45WithoutVendors)
+      cookieStorageMockTest.storage.set(
+        'euconsent-v2',
+        cookie45WithoutVendorsConsentsAndValid
+      )
       const borosTcf = TestableTcfApiInitializer.create()
         .mock(CookieStorage, cookieStorageMockTest)
         .mock(GVLFactory, mockGVLFactory)
         .init()
 
-      return borosTcf.loadUserConsent().then(consent => {
-        expect(consent.valid).to.be.true
-        return borosTcf
-          .saveUserConsent({purpose: givenPurpose, vendor: givenVendor})
-          .then(() => {
-            const savedConsent = cookieStorageMockTest.storage.get(
-              'euconsent-v2'
-            )
-            console.log(
-              'savedConsent ' +
-                JSON.stringify(
-                  cookieStorageMockTest.storage.get('euconsent-v2')
-                )
-            )
-            expect(savedConsent).to.be.a('string')
+      return borosTcf
+        .saveUserConsent({purpose: givenPurpose, vendor: givenVendor})
+        .then(() => {
+          const savedConsent = cookieStorageMockTest.storage.get('euconsent-v2')
+          console.log(
+            'savedConsent ' +
+              JSON.stringify(cookieStorageMockTest.storage.get('euconsent-v2'))
+          )
+          expect(savedConsent).to.be.a('string')
 
-            const userConsent = TCString.decode(savedConsent)
-            expect(userConsent.cmpId).to.equal(BOROS_TCF_ID)
-            expect(userConsent.cmpVersion).to.equal(BOROS_TCF_VERSION)
-            expect(userConsent.publisherCountryCode).to.equal(PUBLISHER_CC)
-            expect(userConsent.vendorListVersion).to.equal(46)
-            expect(userConsent.vendorConsents.has(2)).to.be.true
-            expect(userConsent.vendorLegitimateInterests.has(2)).to.be.true
-            expect(userConsent.vendorConsents.has(1)).to.be.false
-            expect(userConsent.vendorLegitimateInterests.has(1)).to.be.false
-          })
-      })
+          const userConsent = TCString.decode(savedConsent)
+          expect(userConsent.cmpId).to.equal(BOROS_TCF_ID)
+          expect(userConsent.cmpVersion).to.equal(BOROS_TCF_VERSION)
+          expect(userConsent.publisherCountryCode).to.equal(PUBLISHER_CC)
+          expect(userConsent.vendorListVersion).to.equal(46)
+          expect(userConsent.vendorConsents.has(2)).to.be.true
+          expect(userConsent.vendorLegitimateInterests.has(2)).to.be.true
+          expect(userConsent.vendorConsents.has(1)).to.be.false
+          expect(userConsent.vendorLegitimateInterests.has(1)).to.be.false
+        })
     })
     it('should generate and save new user consent with latest vendorlist version', () => {
       const cookieStorageMock = new TestableCookieStorageMock()
@@ -171,7 +167,6 @@ describe('BorosTcf', () => {
         .mock(GVLFactory, mockGVLFactory)
         .init()
 
-      console.log('Running test')
       return borosTcfVersion
         .saveUserConsent({purpose: givenPurpose, vendor: givenVendor})
         .then(() => {
@@ -211,7 +206,7 @@ describe('BorosTcf', () => {
         }
       }
       const cookieStorageMock = new TestableCookieStorageMock()
-      borosTcf = TestableTcfApiInitializer.create()
+      const borosTcf = TestableTcfApiInitializer.create()
         .mock(CookieStorage, cookieStorageMock)
         .init()
       return borosTcf
@@ -457,9 +452,7 @@ describe('BorosTcf', () => {
         .mock(GVLFactory, mockGVLFactory)
         .mock(VendorListRepository, vendorListRepository)
         .init()
-      console.log('Before first load Consent')
-      const firstConsent = await borosTcf.loadUserConsent()
-      expect(firstConsent.valid).to.be.true
+
       await borosTcf.saveUserConsent({
         purpose: givenPurpose,
         vendor: givenVendor

--- a/src/test/testable/infrastructure/repository/iab/TestableGVLFactory.js
+++ b/src/test/testable/infrastructure/repository/iab/TestableGVLFactory.js
@@ -56,7 +56,6 @@ export class TestableGVLFactory extends GVLFactory {
 
   reset() {
     nock.cleanAll()
-    nock.abortPendingRequests()
   }
 
   mockReply({path, data}) {

--- a/src/test/testable/infrastructure/repository/iab/TestableGVLFactory.js
+++ b/src/test/testable/infrastructure/repository/iab/TestableGVLFactory.js
@@ -12,6 +12,7 @@ export class TestableGVLFactory extends GVLFactory {
     super({
       baseUrl: BASE_URL
     })
+    super.resetCaches()
 
     nock('http://mock.borostcf.com/borostcf/v2/vendorlist')
       .get('/LATEST?language=es')
@@ -55,10 +56,11 @@ export class TestableGVLFactory extends GVLFactory {
 
   reset() {
     nock.cleanAll()
+    nock.abortPendingRequests()
   }
 
   mockReply({path, data}) {
-    nock('http://mock.borostcf.com/borostcf/v2/vendorlist')
+    return nock('http://mock.borostcf.com/borostcf/v2/vendorlist')
       .get(path)
       .reply(200, data, {
         'access-control-allow-origin': '*',


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->
- Bug Scenario:
1. User have fine grained consent
2. Version List has changed
3. UI pop up, user change consents
4. Vendor List Version is not stored(bug) but vendor list consents and vendor list LI are stored
## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->
https://jira.scmspain.com/browse/PSP-3412
## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->
- Vendor Version List should be updated with the last vendor version list, not the previous vendor list version
## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->
Set this cookie for old vendor list 46 (actual 47)  with fine grained consent for vendors


CO24yk1O24yk1CBAFAENAuCsAP_AAH_AAAiQGIlX_T5fb2vj-3Z99_tkeYwf95y3p-wzhheMs-8NyYeH7BoGv2MwvBX4JiQKGRgksjLBAQdtHGhcSQgBgIhViTLMYk2MjzNKJLJAilsbe0NYGD9unsHT3ZCY70-vu__7P3ff_gYiVf9Pl9va-P7dn33-2R5jB_3nLen7DOGF4yz7w3Jh4fsGga_YzC8FfgmJAoZGCSyMsEBB20caFxJCAGAiFWJMsxiTYyPM0okskCKWxt7Q1gYP26ewdPdkJjvT6-7__s_d9_-AAAAA.YAAAAAAAAAAA

And load the consent, modified and decode the stored cookie and review if version is not 46

## Further considerations
<!--- If applies, add information of breaking changes, agreed deploy timings, ...  -->
- May be the version of the vendor list should be supplied by the UI, and boros save the version vendor list with the supplied vendor version list
## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/PzY10Xavk18ze/giphy.gif)