### PR TITLE
move language to be an initialization parameter

### DIFF
--- a/src/main/application/BorosTcf.js
+++ b/src/main/application/BorosTcf.js
@@ -36,12 +36,10 @@ class BorosTcf {
   /**
    * @param {Object} param
    * @param {Number} param.version
-   * @param {String} param.language
    */
-  getVendorList({version, language} = {}) {
+  getVendorList({version} = {}) {
     return this._getVendorListUseCase.execute({
-      vendorListVersion: version,
-      translationLanguage: language
+      vendorListVersion: version
     })
   }
 

--- a/src/main/application/services/vendorlist/GetVendorListUseCase.js
+++ b/src/main/application/services/vendorlist/GetVendorListUseCase.js
@@ -1,18 +1,16 @@
 import {VendorListRepository} from '../../../domain/vendorlist/VendorListRepository'
 import {inject} from '../../../core/ioc/ioc'
 import {Version} from '../../../domain/vendorlist/Version'
-import {Language} from '../../../domain/vendorlist/Language'
 
 class GetVendorListUseCase {
   constructor({vendorListRepository = inject(VendorListRepository)} = {}) {
     this._vendorListRepository = vendorListRepository
   }
 
-  execute({vendorListVersion, translationLanguage}) {
+  execute({vendorListVersion}) {
     const version = new Version(vendorListVersion)
-    const language = new Language(translationLanguage)
     return this._vendorListRepository
-      .getVendorList({version, language})
+      .getVendorList({version})
       .then(vendorList => vendorList.value)
   }
 }

--- a/src/main/domain/vendorlist/VendorList.js
+++ b/src/main/domain/vendorlist/VendorList.js
@@ -1,17 +1,12 @@
 class VendorList {
-  constructor({version, policyVersion, language, value}) {
+  constructor({version, policyVersion, value}) {
     this._version = version
     this._policyVersion = policyVersion
-    this._language = language
     this._value = value
   }
 
   get version() {
     return this._version
-  }
-
-  get language() {
-    return this._language
   }
 
   get policyVersion() {

--- a/src/main/domain/vendorlist/VendorListRepository.js
+++ b/src/main/domain/vendorlist/VendorListRepository.js
@@ -2,7 +2,7 @@
  * @interface
  */
 class VendorListRepository {
-  getVendorList({version, language}) {}
+  getVendorList({version}) {}
 }
 
 export {VendorListRepository}

--- a/src/main/infrastructure/bootstrap/TcfApiInitializer.js
+++ b/src/main/infrastructure/bootstrap/TcfApiInitializer.js
@@ -34,7 +34,7 @@ import {TcfApiV2} from '../../application/TcfApiV2'
 import {ObservableFactory} from '../../domain/service/ObservableFactory'
 
 class TcfApiInitializer {
-  static init() {
+  static init({language} = {}) {
     iocModule({
       module: IOC_MODULE,
       initializer: ({singleton}) => {
@@ -57,7 +57,7 @@ class TcfApiInitializer {
         )
 
         singleton(VendorListRepository, () => new IABVendorListRepository())
-        singleton(GVLFactory, () => new GVLFactory())
+        singleton(GVLFactory, () => new GVLFactory({language}))
 
         singleton(ConsentRepository, () => new CookieConsentRepository())
         singleton(

--- a/src/main/infrastructure/repository/iab/GVLFactory.js
+++ b/src/main/infrastructure/repository/iab/GVLFactory.js
@@ -3,37 +3,40 @@ import {
   VENDOR_LIST_DEFAULT_LANGUAGE,
   VENDOR_LIST_LATEST_VERSION
 } from '../../../core/constants'
+import {Language} from '../../../domain/vendorlist/Language'
 
 export class GVLFactory {
-  constructor({baseUrl = 'https://a.dcdn.es/borostcf/v2/vendorlist'} = {}) {
+  constructor({
+    baseUrl = 'https://a.dcdn.es/borostcf/v2/vendorlist',
+    language = VENDOR_LIST_DEFAULT_LANGUAGE
+  } = {}) {
     GVL.baseUrl = baseUrl
+    this._language = new Language(language).value
     this._cached = new Map()
   }
 
-  create({
-    version = VENDOR_LIST_LATEST_VERSION,
-    language = VENDOR_LIST_DEFAULT_LANGUAGE
-  } = {}) {
-    const key = this._key({version, language})
+  create({version = VENDOR_LIST_LATEST_VERSION} = {}) {
+    const key = this._key({version})
     if (!this._cached.has(key)) {
-      this._setStaticGVLParameters({language})
+      this._setStaticGVLParameters()
       this._cached.set(key, new GVL(version))
     }
     return this._cached.get(key)
   }
 
-  _key({version, language}) {
-    return `${version}:${language}`
+  _key({version}) {
+    return `${version}:${this._language}`
   }
 
   resetCaches() {
     GVL.emptyCache()
     GVL.emptyLanguageCache()
+    this._cached = new Map()
   }
 
-  _setStaticGVLParameters({language}) {
+  _setStaticGVLParameters() {
     GVL.languageFilename = `${VENDOR_LIST_LATEST_VERSION}?language=[LANG]`
-    GVL.latestFilename = `${VENDOR_LIST_LATEST_VERSION}?language=${language}`
-    GVL.versionedFilename = `[VERSION]?language=${language}`
+    GVL.latestFilename = `${VENDOR_LIST_LATEST_VERSION}?language=${this._language}`
+    GVL.versionedFilename = `[VERSION]?language=${this._language}`
   }
 }

--- a/src/main/infrastructure/repository/iab/IABVendorListRepository.js
+++ b/src/main/infrastructure/repository/iab/IABVendorListRepository.js
@@ -2,8 +2,6 @@ import {VendorListRepository} from '../../../domain/vendorlist/VendorListReposit
 import {VendorList} from '../../../domain/vendorlist/VendorList'
 import {inject} from '../../../core/ioc/ioc'
 import {GVLFactory} from './GVLFactory'
-import {Language} from '../../../domain/vendorlist/Language'
-import {VENDOR_LIST_DEFAULT_LANGUAGE} from '../../../core/constants'
 
 export class IABVendorListRepository extends VendorListRepository {
   constructor({gvlFactory = inject(GVLFactory)} = {}) {
@@ -11,13 +9,9 @@ export class IABVendorListRepository extends VendorListRepository {
     this._gvlFactory = gvlFactory
   }
 
-  async getVendorList({
-    version,
-    language = new Language(VENDOR_LIST_DEFAULT_LANGUAGE)
-  } = {}) {
+  async getVendorList({version} = {}) {
     const gvl = this._gvlFactory.create({
-      version: version?.value,
-      language: language?.value
+      version: version?.value
     })
     await gvl.readyPromise
     const vendorListJson = gvl.getJson()

--- a/src/test/application/BorosTcfTest.js
+++ b/src/test/application/BorosTcfTest.js
@@ -27,14 +27,13 @@ import {StatusRepository} from '../../main/domain/status/StatusRepository'
 
 describe('BorosTcf', () => {
   describe('getVendorList use case', () => {
-    let borosTcf
-    beforeEach(() => {
-      borosTcf = TestableTcfApiInitializer.create()
-        .mock(GVLFactory, new TestableGVLFactory())
-        .init()
-    })
+    const initBoros = ({language} = {}) =>
+      TestableTcfApiInitializer.create()
+        .mock(GVLFactory, new TestableGVLFactory({language}))
+        .init({language})
 
     it('should return the spanish latest vendor list if nothing (language, version) is specified', async () => {
+      const borosTcf = initBoros()
       const vendorList = await borosTcf.getVendorList()
       expect(vendorList.vendorListVersion).to.deep.equal(
         VendorListValueSpanish.data.vendorListVersion
@@ -52,6 +51,7 @@ describe('BorosTcf', () => {
 
     it('should return the translation of a specific version if parameters are specified', async () => {
       const givenVersion = VendorListValueEnglish.data.vendorListVersion
+      const borosTcf = initBoros({language: 'en'})
       const vendorList = await borosTcf.getVendorList({
         version: givenVersion,
         language: 'en'

--- a/src/test/domain/vendorlist/VendorListTest.js
+++ b/src/test/domain/vendorlist/VendorListTest.js
@@ -4,11 +4,9 @@ describe('VendorList Should', () => {
   it('Create Empty Vendor List', () => {
     const policyVersion = 'aPolicyVersion'
     const version = 'aVersion'
-    const language = 'es'
     const value = {}
-    const vendorList = new VendorList({policyVersion, language, version, value})
+    const vendorList = new VendorList({policyVersion, version, value})
     expect(vendorList.policyVersion).equal(policyVersion)
-    expect(vendorList.language).equal(language)
     expect(vendorList.version).equal(version)
     expect(vendorList.value).equal(value)
   })

--- a/src/test/testable/infrastructure/bootstrap/TestableTcfApiInitializer.js
+++ b/src/test/testable/infrastructure/bootstrap/TestableTcfApiInitializer.js
@@ -16,7 +16,7 @@ class TestableTcfApiInitializer {
     return this
   }
 
-  init() {
+  init({language} = {}) {
     iocReset(IOC_MODULE)
     iocModule({
       module: IOC_MODULE,
@@ -27,7 +27,7 @@ class TestableTcfApiInitializer {
       },
       chain: true
     })
-    return TcfApiInitializer.init()
+    return TcfApiInitializer.init({language})
   }
 }
 

--- a/src/test/testable/infrastructure/repository/iab/TestableGVLFactory.js
+++ b/src/test/testable/infrastructure/repository/iab/TestableGVLFactory.js
@@ -8,9 +8,10 @@ import {
 const BASE_URL = 'http://mock.borostcf.com/borostcf/v2/vendorlist'
 export const UNAVAILABLE_VERSION = 9999999
 export class TestableGVLFactory extends GVLFactory {
-  constructor() {
+  constructor({language} = {}) {
     super({
-      baseUrl: BASE_URL
+      baseUrl: BASE_URL,
+      language
     })
     super.resetCaches()
 


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

As discussed in previous PRs, IAB's GVL does not fit well with how we need to load the GVL translated versions without having to do more than 1 HTTP requests for loading the GVL directly with the version and language we want.

![image](https://user-images.githubusercontent.com/20399660/88276188-eaa96f00-ccde-11ea-8b99-ae8bf6cf1976.png)

This behavior can be reproduced in current deployed version of the TCFv2 and also locally with this snippet:

```
import BorosTcf from '../main'

const boros = BorosTcf.init()

const doit = async () => {
  setTimeout(() => {
    console.log('now loading vendor list with IT language')
    boros.getVendorList({language: 'it'}).then(console.log)
  }, 1000)
}
doit()
```

Actually, when Boros is loaded, a first GVL is loaded with the default language, and as GVL has a static mutable attribute to store the language and there's only the option to change it by calling a method on a loaded GVL, we cannot load a translated GVL with a single HTTP request.

Actually, it loads the default GVL (ES) and will never load any other translation for the same version.


## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3418

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

* We can initialize Boros for a specific language (by the moment, there's no need to change the language once it's loaded)
* Loading the GVL will use the given language from the initialization param in order to load the translation, or will use the default language if nothing is provided.

## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->

Checked locally changing the `local.index.js` to validate the HTTP requests and what responds as the vendor list:

`npm run start`

```
import BorosTcf from '../main'

const boros = BorosTcf.init({language: 'it'})

const doit = async () => {
  setTimeout(() => {
    console.log('now loading vendor list with IT language')
    boros.getVendorList({language: 'it'}).then(console.log)
  }, 1000)
}
doit()
```

![image](https://user-images.githubusercontent.com/20399660/88276712-cf8b2f00-ccdf-11ea-8cba-51f71e655363.png)


## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/12hPQk7oAsk5UY/giphy.gif)