### PR TITLE
Feature/cookie expiration renew

### DIFF
--- a/src/test/domain/consent/LoadConsentServiceTest.js
+++ b/src/test/domain/consent/LoadConsentServiceTest.js
@@ -37,7 +37,8 @@ describe('LoadConsentService Should', () => {
     const encodedConsent =
       'CO1hOaZO1hOaZCBABAENArCAAMAAAEAAAAAAABMAAmAA.IGCNV_T5eb2vj-3Zdt_tkaYwf55y3o-wzhhaIse8NwIeH7BoGP2MwvBX4JiQCGBAkkiKBAQdtHGhcCQABgIhRiTKMYk2MjzNKJLJAilsbO0NYCD9mnsHT3ZCY70--u__7P3fAAAA'
     const consentRepositoryThatReturnsAValidConsent = {
-      loadUserConsent: () => encodedConsent
+      loadUserConsent: () => encodedConsent,
+      saveUserConsent: () => null
     }
 
     const decodedConsent = new IABConsentDecoderService().decode({


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

There was a bug in validating the old consent before renewing it: if the saved consent had the same GVL version than the latest GVL version, the consent was not renewed. It was only renewing it if it had automatic updates from a new GVL.

This PR fixes that by:
- first checking if it's a valid consent (which updates the current saved consent as before)
- saving the valid consent when we already know that it's valid but just before returning it

## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3414

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

When a valid consent is saved, next consent read (aware if it has automatic updates or not) is renewed saving, updating its expiration date and its encoded data.

![image](https://user-images.githubusercontent.com/20399660/88365466-67dbef00-cd86-11ea-971d-d4bee79e8908.png)


## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->

`npm run start`

Sample consent: `CO3CNbEO3CNbECBAGAENAvCoAP_AAH_AAAiQGLNX_T5fb2vj-_Z99_tkeYwf95y3p-wzhheMs-8NyYeH7B4Gv2MwvBX4JiQKGRgksjLBAQdtHGhcTQgBgIhViTLMYk2MjzNKJrJAilsbe2NYGD9vnsHT3ZCY70-vu__7P3ff_3AxZq_6fL7e18f37Pvv9sjzGD_vOW9P2GcMLxln3huTDw_YPA1-xmF4K_BMSBQyMElkZYICDto40LiaEAMBEKsSZZjEmxkeZpRNZIEUtjb2xrAwft89g6e7ITHen193__Z-77_-4AAA.YAAAAAAAAAAA`

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/xUNd9GxUaMOMYbdZlK/giphy.gif)