### PR TITLE
update vendorlist url

### DIFF
--- a/src/main/core/constants.js
+++ b/src/main/core/constants.js
@@ -39,7 +39,8 @@ export const VENDOR_LIST_LATEST_VERSION = 'LATEST'
 /**
  * Base endpoint to get access to remote Vendor List resources
  */
-export const VENDOR_LIST_ENDPOINT = 'https://a.dcdn.es/borostcf/v2/vendorlist'
+export const VENDOR_LIST_ENDPOINT =
+  'https://ms-adit--operations-gateway.spain.advgo.net/borostcf/v2/vendorlist'
 
 /**
  * Country code of the country that determines the legislation of

--- a/src/main/infrastructure/repository/iab/GVLFactory.js
+++ b/src/main/infrastructure/repository/iab/GVLFactory.js
@@ -1,13 +1,14 @@
 import {GVL} from '@iabtcf/core'
 import {
   VENDOR_LIST_DEFAULT_LANGUAGE,
+  VENDOR_LIST_ENDPOINT,
   VENDOR_LIST_LATEST_VERSION
 } from '../../../core/constants'
 import {Language} from '../../../domain/vendorlist/Language'
 
 export class GVLFactory {
   constructor({
-    baseUrl = 'https://a.dcdn.es/borostcf/v2/vendorlist',
+    baseUrl = VENDOR_LIST_ENDPOINT,
     language = VENDOR_LIST_DEFAULT_LANGUAGE
   } = {}) {
     GVL.baseUrl = baseUrl


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

The A CDN will be deprecated for being used as semi-static resources cache because we've just registered the advertising operations gateway to the corporate's cloudfront for zuuls cache, so the public endpoint `/borostcf/v2/vendorlist` can be used directly as its results will be served from the corporate's cloudfront directly.
 
## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3450

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

no changes

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/RhB0eCe5aUXrPMR0Kx/giphy.gif)