### PR TITLE
keep cookie between subdomains

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,3 @@
+import TcfApiInitializer from './main'
+
+export default TcfApiInitializer

--- a/src/main/core/constants.js
+++ b/src/main/core/constants.js
@@ -2,14 +2,19 @@
 /**
  * Package Name
  */
-export const PACKAGE_NAME = __PACKAGE_NAME__
+export const PACKAGE_NAME =
+  (typeof __PACKAGE_NAME__ !== 'undefined' && __PACKAGE_NAME__) ||
+  'boros-tcf-dev'
 
 /**
  * Boros TCF Version is the current version.
  * It'll be the minor version as once developed, the IAB's TCF defined API should not change,
  * so major versions are useless to define this information value required by the PingReturn object.
  */
-export const BOROS_TCF_VERSION = __PACKAGE_MINOR_VERSION__
+export const BOROS_TCF_VERSION =
+  (typeof __PACKAGE_MINOR_VERSION__ !== 'undefined' &&
+    __PACKAGE_MINOR_VERSION__) ||
+  1
 
 /**
  * Boros TCF IAB's registered ID

--- a/src/main/infrastructure/repository/cookie/BrowserCookieStorage.js
+++ b/src/main/infrastructure/repository/cookie/BrowserCookieStorage.js
@@ -1,9 +1,8 @@
 import {CookieStorage} from './CookieStorage'
 
-class BrowserCookieStorage extends CookieStorage {
-  constructor({domain = VENDOR_CONSENT_COOKIE_DEFAULT_DOMAIN, window} = {}) {
+export class BrowserCookieStorage extends CookieStorage {
+  constructor({window} = {}) {
     super()
-    this._domain = domain
     this._window = window
   }
 
@@ -22,21 +21,29 @@ class BrowserCookieStorage extends CookieStorage {
   }
 
   save({data}) {
+    const domain = this._parseDomain()
     const cookieValue = [
       `${VENDOR_CONSENT_COOKIE_NAME}=${data}`,
-      this._domain && `domain=${this._domain}`,
-      `path=${VENDOR_CONSENT_COOKIE_DEFAULT_PATH};max-age=${VENDOR_CONSENT_COOKIE_MAX_AGE};SameSite=${VENDOR_CONSENT_COOKIE_SAME_SITE_LOCAL_VALUE}`
-    ]
-      .filter(Boolean)
-      .join(';')
+      `domain=${domain}`,
+      `path=${VENDOR_CONSENT_COOKIE_DEFAULT_PATH}`,
+      `max-age=${VENDOR_CONSENT_COOKIE_MAX_AGE}`,
+      `SameSite=${VENDOR_CONSENT_COOKIE_SAME_SITE_LOCAL_VALUE}`
+    ].join(';')
     this._window.document.cookie = cookieValue
+  }
+
+  _parseDomain() {
+    const host = this._window.location.hostname || ''
+    const parts = host.split(DOT)
+    if (parts.length > 2) {
+      parts.shift()
+    }
+    return `${DOT}${parts.join('.')}`
   }
 }
 
-export {BrowserCookieStorage}
-
-const VENDOR_CONSENT_COOKIE_DEFAULT_DOMAIN = ''
 const VENDOR_CONSENT_COOKIE_NAME = 'euconsent-v2'
 const VENDOR_CONSENT_COOKIE_MAX_AGE = 33696000
 const VENDOR_CONSENT_COOKIE_DEFAULT_PATH = '/'
 const VENDOR_CONSENT_COOKIE_SAME_SITE_LOCAL_VALUE = 'Lax'
+const DOT = '.'

--- a/src/test/infrastructure/repository/cookie/BrowserCookieStorageTest.js
+++ b/src/test/infrastructure/repository/cookie/BrowserCookieStorageTest.js
@@ -8,7 +8,6 @@ describe('BrowserCookieStorage Should', () => {
       url: 'http://example.com/'
     }).window
     const browserCookieStorage = new BrowserCookieStorage({
-      domain: 'example.com',
       window
     })
 
@@ -29,16 +28,41 @@ describe('BrowserCookieStorage Should', () => {
     expect(cookie).equal('foo')
   })
   it('Write And read a cookie with different domain should be undefined', () => {
-    const window = new JSDOM('<!DOCTYPE html><body></body>', {
-      url: 'http://example.com/'
-    }).window
-    const browserCookieStorage = new BrowserCookieStorage({
-      domain: 'example2.com',
-      window
+    const givenCookie = 'foo'
+    const dom1 = new JSDOM('<!DOCTYPE html><body></body>', {
+      url: 'http://example1.com/'
     })
-
-    browserCookieStorage.save({data: 'foo'})
-    const cookie = browserCookieStorage.load()
-    expect(cookie).equal(undefined)
+    const browserCookieStorage1 = new BrowserCookieStorage({
+      window: dom1.window
+    })
+    const dom2 = new JSDOM('<!DOCTYPE html><body></body>', {
+      url: 'http://example2.com/'
+    })
+    const browserCookieStorage2 = new BrowserCookieStorage({
+      window: dom2.window
+    })
+    browserCookieStorage1.save({data: givenCookie})
+    const cookie1 = browserCookieStorage1.load()
+    const cookie2 = browserCookieStorage2.load()
+    expect(cookie1).to.equal(givenCookie)
+    expect(cookie2).to.be.undefined
+  })
+  it('Should keep the cookie between subdomains', () => {
+    const givenCookie = 'foo'
+    const dom = new JSDOM('<!DOCTYPE html><body></body>', {
+      url: 'http://example1.com/'
+    })
+    const browserCookieStorage1 = new BrowserCookieStorage({
+      window: dom.window
+    })
+    dom.reconfigure({url: 'http://asubdomainof.example1.com/'})
+    const browserCookieStorage2 = new BrowserCookieStorage({
+      window: dom.window
+    })
+    browserCookieStorage1.save({data: givenCookie})
+    const cookie1 = browserCookieStorage1.load()
+    const cookie2 = browserCookieStorage2.load()
+    expect(cookie1).to.equal(givenCookie)
+    expect(cookie2).to.equal(cookie1)
   })
 })


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

Actually we're storing the default host to the saved cookie, causing navigation between subdomains of the same site to request a new consent.

![image](https://user-images.githubusercontent.com/20399660/90239220-7b2f2700-de27-11ea-83de-e6615758ea1d.png)

As we can see in this screenshot, euconsent-v2 should be saved as '.milanuncios.com' instead of '.www.milanuncios.com' as other cookies do to avoid losing the cookie in subdomains.

## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3470

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

The cookie is saved for the main host excluding the subdomain part to keep the cookie in subdomain user's navigation:

![image](https://user-images.githubusercontent.com/20399660/90239406-c34e4980-de27-11ea-84bf-1fec7a430d87.png)

## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->

- used the adevinta components tcf/ui linking this project

## Further considerations
<!--- If applies, add information of breaking changes, agreed deploy timings, ...  -->

- a new index.js is created in "src" folder in order to be able to link the boros-tcf as a package of the tcf/ui in adevinta components, it has no other effect as will not be included in the 'dist' folder when the project is built.

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/1ngQorBCDcUFy/giphy.gif)