### PR TITLE
Fix/share cookie between domains

### DIFF
--- a/src/main/infrastructure/repository/cookie/BrowserCookieStorage.js
+++ b/src/main/infrastructure/repository/cookie/BrowserCookieStorage.js
@@ -54,10 +54,11 @@ export class BrowserCookieStorage extends CookieStorage {
 
   _parseDomain() {
     const host = this._window.location.hostname || ''
-    const parts = host.split(DOT)
-    if (parts.length > 2) {
-      parts.shift()
-    }
+    const parts = host
+      .split(DOT)
+      .reverse()
+      .filter((_, index) => index <= 1)
+      .reverse()
     return `${DOT}${parts.join('.')}`
   }
 }

--- a/src/main/infrastructure/repository/cookie/BrowserCookieStorage.js
+++ b/src/main/infrastructure/repository/cookie/BrowserCookieStorage.js
@@ -1,42 +1,69 @@
 import {CookieStorage} from './CookieStorage'
 
-class BrowserCookieStorage extends CookieStorage {
-  constructor({domain = VENDOR_CONSENT_COOKIE_DEFAULT_DOMAIN, window} = {}) {
+export class BrowserCookieStorage extends CookieStorage {
+  constructor({window}) {
     super()
-    this._domain = domain
     this._window = window
   }
 
   load() {
-    const cookieParts = `; ${this._window.document.cookie}`.split(
-      `; ${VENDOR_CONSENT_COOKIE_NAME}=`
-    )
-    return (
-      (cookieParts.length === 2 &&
-        cookieParts
-          .pop()
-          .split(';')
-          .shift()) ||
-      undefined
-    )
+    this._replaceSubdomainCookie()
+    const cookies = this._getConsentCookies()
+    return cookies.length ? cookies[0].split('=')[1] : undefined
   }
 
   save({data}) {
+    const domain = this._parseDomain()
     const cookieValue = [
       `${VENDOR_CONSENT_COOKIE_NAME}=${data}`,
-      this._domain && `domain=${this._domain}`,
-      `path=${VENDOR_CONSENT_COOKIE_DEFAULT_PATH};max-age=${VENDOR_CONSENT_COOKIE_MAX_AGE};SameSite=${VENDOR_CONSENT_COOKIE_SAME_SITE_LOCAL_VALUE}`
-    ]
-      .filter(Boolean)
-      .join(';')
+      `domain=${domain}`,
+      `path=${VENDOR_CONSENT_COOKIE_DEFAULT_PATH}`,
+      `max-age=${VENDOR_CONSENT_COOKIE_MAX_AGE}`,
+      `SameSite=${VENDOR_CONSENT_COOKIE_SAME_SITE_LOCAL_VALUE}`
+    ].join(';')
     this._window.document.cookie = cookieValue
+  }
+
+  _replaceSubdomainCookie() {
+    const consentCookies = this._getConsentCookies()
+    if (!consentCookies.length) {
+      return
+    }
+    const data = consentCookies[0].split('=')[1]
+    const host = this._window.location.hostname || ''
+    const cookieParts = [
+      `${VENDOR_CONSENT_COOKIE_NAME}=`,
+      `path=${VENDOR_CONSENT_COOKIE_DEFAULT_PATH}`,
+      `domain=${host}`,
+      `expires= Thu, 01 Jan 1970 00:00:00 GMT`
+    ]
+    document.cookie = cookieParts.join(';') // delete cookie with subdomain
+    const consentCookiesAfterDeletion = this._getConsentCookies()
+    if (!consentCookiesAfterDeletion.length) {
+      this.save({data})
+    }
+  }
+
+  _getConsentCookies() {
+    const cookies = `; ${this._window.document.cookie}`.split(';')
+    const consentCookies = cookies
+      .filter(cookie => cookie.includes(`${VENDOR_CONSENT_COOKIE_NAME}=`))
+      .map(cookie => cookie.trim())
+    return consentCookies
+  }
+
+  _parseDomain() {
+    const host = this._window.location.hostname || ''
+    const parts = host.split(DOT)
+    if (parts.length > 2) {
+      parts.shift()
+    }
+    return `${DOT}${parts.join('.')}`
   }
 }
 
-export {BrowserCookieStorage}
-
-const VENDOR_CONSENT_COOKIE_DEFAULT_DOMAIN = ''
 const VENDOR_CONSENT_COOKIE_NAME = 'euconsent-v2'
 const VENDOR_CONSENT_COOKIE_MAX_AGE = 33696000
 const VENDOR_CONSENT_COOKIE_DEFAULT_PATH = '/'
 const VENDOR_CONSENT_COOKIE_SAME_SITE_LOCAL_VALUE = 'Lax'
+const DOT = '.'

--- a/src/main/infrastructure/repository/cookie/BrowserCookieStorage.js
+++ b/src/main/infrastructure/repository/cookie/BrowserCookieStorage.js
@@ -37,7 +37,7 @@ export class BrowserCookieStorage extends CookieStorage {
       `domain=${host}`,
       `expires= Thu, 01 Jan 1970 00:00:00 GMT`
     ]
-    document.cookie = cookieParts.join(';') // delete cookie with subdomain
+    this._window.document.cookie = cookieParts.join(';') // delete cookie with subdomain
     const consentCookiesAfterDeletion = this._getConsentCookies()
     if (!consentCookiesAfterDeletion.length) {
       this.save({data})

--- a/src/test/infrastructure/repository/cookie/BrowserCookieStorageTest.js
+++ b/src/test/infrastructure/repository/cookie/BrowserCookieStorageTest.js
@@ -1,6 +1,6 @@
 import {BrowserCookieStorage} from '../../../../main/infrastructure/repository/cookie/BrowserCookieStorage'
 import {expect} from 'chai'
-import {JSDOM} from 'jsdom'
+import jsdom, {JSDOM} from 'jsdom'
 
 describe('BrowserCookieStorage Should', () => {
   it('Write And read a cookie', () => {
@@ -8,7 +8,6 @@ describe('BrowserCookieStorage Should', () => {
       url: 'http://example.com/'
     }).window
     const browserCookieStorage = new BrowserCookieStorage({
-      domain: 'example.com',
       window
     })
 
@@ -29,16 +28,43 @@ describe('BrowserCookieStorage Should', () => {
     expect(cookie).equal('foo')
   })
   it('Write And read a cookie with different domain should be undefined', () => {
-    const window = new JSDOM('<!DOCTYPE html><body></body>', {
-      url: 'http://example.com/'
-    }).window
-    const browserCookieStorage = new BrowserCookieStorage({
-      domain: 'example2.com',
-      window
+    const givenCookie = 'foo'
+    const dom1 = new JSDOM('<!DOCTYPE html><body></body>', {
+      url: 'http://example1.com/'
     })
-
-    browserCookieStorage.save({data: 'foo'})
-    const cookie = browserCookieStorage.load()
-    expect(cookie).equal(undefined)
+    const browserCookieStorage1 = new BrowserCookieStorage({
+      window: dom1.window
+    })
+    const dom2 = new JSDOM('<!DOCTYPE html><body></body>', {
+      url: 'http://example2.com/'
+    })
+    const browserCookieStorage2 = new BrowserCookieStorage({
+      window: dom2.window
+    })
+    browserCookieStorage1.save({data: givenCookie})
+    const cookie1 = browserCookieStorage1.load()
+    const cookie2 = browserCookieStorage2.load()
+    expect(cookie1).to.equal(givenCookie)
+    expect(cookie2).to.be.undefined
+  })
+  it('Should keep the cookie between subdomains', () => {
+    const givenHost = 'example.com'
+    const givenCookie = 'foo'
+    const cookieJar = new jsdom.CookieJar()
+    const dom = new JSDOM('<!DOCTYPE html><body></body>', {
+      url: `http://www.${givenHost}/`,
+      cookieJar
+    })
+    const browserCookieStorage1 = new BrowserCookieStorage({
+      window: dom.window
+    })
+    browserCookieStorage1.save({data: givenCookie})
+    dom.reconfigure({url: `http://asubdomainof.${givenHost}/`})
+    const browserCookieStorage2 = new BrowserCookieStorage({
+      window: dom.window
+    })
+    const cookie2 = browserCookieStorage2.load()
+    expect(cookie2).to.equal(givenCookie)
+    expect(cookieJar.getCookiesSync(`http://${givenHost}/`)).to.have.lengthOf(1)
   })
 })


### PR DESCRIPTION
## Description
Nowadays the cookie was saved with the subdomain where boros is executed.

<img width="553" alt="Screenshot 2020-08-17 at 14 42 34" src="https://user-images.githubusercontent.com/45286922/90397406-14647480-e098-11ea-8e56-1b0fe2fa262a.png">

This PR fixes this subdomain issues.

## Solves ticket/s
https://jira.scmspain.com/browse/PSP-3470

## Expected behavior
The cookie must be saved with the main domain, and if an old cookie with subdomain is present it will be migrated automatically.
<img width="551" alt="Screenshot 2020-08-17 at 14 44 17" src="https://user-images.githubusercontent.com/45286922/90397567-52fa2f00-e098-11ea-94a6-c1b6053d4a3b.png">

## Review steps
Link this branch with tcf/ui component.

## Further considerations
If the consent is present with a subdomain, it will be deleted and replaced with a new cookie without subdomain

## Memetized description
![](https://media.giphy.com/media/5zsi2v0SD5wmo3fiQC/giphy.gif)