### PR TITLE
fix api sent to ready callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "clean-webpack-plugin": "3.0.0",
     "codecov": "3.6.5",
     "html-webpack-plugin": "4.0.4",
-    "jsdom": "16.2.2",
+    "jsdom": "16.4.0",
     "jsdom-global": "3.0.2",
     "mocha": "5.2.0",
     "mocha-param": "2.0.1",

--- a/src/main/application/BorosTcf.js
+++ b/src/main/application/BorosTcf.js
@@ -30,7 +30,11 @@ class BorosTcf {
     this._saveUserConsentUseCase = saveUserConsentUseCase
     this._getTCDataUseCase = getTCDataUseCase
     this._changeUiVisibleUseCase = changeUiVisibleUseCase
-    statusRepository.getStatus().cmpStatus = Status.CMPSTATUS_LOADED
+    this._statusRepository = statusRepository
+  }
+
+  ready() {
+    this._statusRepository.getStatus().cmpStatus = Status.CMPSTATUS_LOADED
   }
 
   /**

--- a/src/main/infrastructure/bootstrap/TcfApiInitializer.js
+++ b/src/main/infrastructure/bootstrap/TcfApiInitializer.js
@@ -79,9 +79,11 @@ class TcfApiInitializer {
     })
 
     const registryService = new TcfApiRegistryService()
-    registryService.register()
-
     const borosTcf = new BorosTcf()
+
+    registryService.register({borosTcf})
+    borosTcf.ready()
+
     borosTcf.loadUserConsent({notify: true})
     return borosTcf
   }

--- a/src/main/infrastructure/service/TcfApiRegistryService.js
+++ b/src/main/infrastructure/service/TcfApiRegistryService.js
@@ -6,7 +6,7 @@ class TcfApiRegistryService {
     this._tcfApiController = tcfApiController
   }
 
-  register() {
+  register({borosTcf}) {
     if (typeof window === 'undefined') return
     const onReady = this._getStubbed(ON_READY_COMMAND)
     const pending = this._getStubbed(PENDING_COMMAND)
@@ -14,7 +14,7 @@ class TcfApiRegistryService {
     window.__tcfapi = (command, version, callback, parameter) =>
       this._tcfApiController.process(command, version, callback, parameter)
 
-    this._run(() => onReady && onReady(this._tcfApiController.api))
+    this._run(() => onReady && onReady(borosTcf))
     this._run(
       () => pending && pending.forEach(pendingFunction => pendingFunction())
     )

--- a/src/test/infrastructure/bootstrap/TcfApiInitializerTest.js
+++ b/src/test/infrastructure/bootstrap/TcfApiInitializerTest.js
@@ -25,7 +25,7 @@ describe('TcfApiInitializer', () => {
   })
   it('should process the onReady callback', done => {
     const onReady = api => {
-      expect(api instanceof TcfApiV2).to.be.true
+      expect(api instanceof BorosTcf).to.be.true
       done()
     }
     window.__tcfapi = command => {

--- a/src/test/infrastructure/bootstrap/TcfApiInitializerTest.js
+++ b/src/test/infrastructure/bootstrap/TcfApiInitializerTest.js
@@ -2,7 +2,6 @@ import jsdom from 'jsdom-global'
 import {expect} from 'chai'
 import {TcfApiInitializer} from '../../../main/infrastructure/bootstrap/TcfApiInitializer'
 import {BorosTcf} from '../../../main/application/BorosTcf'
-import {TcfApiV2} from '../../../main/application/TcfApiV2'
 
 describe('TcfApiInitializer', () => {
   beforeEach(() => jsdom())


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

In order to allow custom commands (and giving them access to the `save` feature), the `onReady` callback should provide the BorosTcf API instead of the API with the base IAB commands.

## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3510

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

no changes

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/l3JDJ8hPoiNbAt6Uw/giphy.gif)