### PR TITLE
Fix/include polyfills

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   },
   "dependencies": {
     "@iabtcf/core": "^1.0.1",
-    "brusc": "1"
+    "brusc": "1",
+    "core-js": "3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "babel-preset-sui": "3",
     "chai": "4.2.0",
     "clean-webpack-plugin": "3.0.0",
-    "codecov": "3.6.5",
+    "codecov": "3.7.1",
     "html-webpack-plugin": "4.0.4",
     "jsdom": "16.4.0",
     "jsdom-global": "3.0.2",

--- a/src/main/application/services/tcdata/GetTCDataUseCase.js
+++ b/src/main/application/services/tcdata/GetTCDataUseCase.js
@@ -30,7 +30,7 @@ export class GetTCDataUseCase {
   execute({vendorIds} = {}) {
     if (
       Array.isArray(vendorIds) &&
-      vendorIds.some(vendorId => !this._isInteger(vendorId) || vendorId < 1)
+      vendorIds.some(vendorId => !Number.isInteger(vendorId) || vendorId < 1)
     ) {
       throw Error(
         'vendorIds parameter of getTCData has invalid data. It must be an array of positive integers, or undefined'
@@ -64,13 +64,5 @@ export class GetTCDataUseCase {
       eventStatus: eventStatus
     }).value()
     return tcData
-  }
-
-  _isInteger(value) {
-    return (
-      typeof value === 'number' &&
-      isFinite(value) &&
-      Math.floor(value) === value
-    )
   }
 }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,3 +1,7 @@
+import 'core-js/features/number/is-integer'
+import 'core-js/es/set'
+import 'core-js/features/string/repeat'
+import 'regenerator-runtime/runtime'
 import {TcfApiInitializer} from './infrastructure/bootstrap/TcfApiInitializer'
 
 export default TcfApiInitializer


### PR DESCRIPTION
## Description
Include iabtcf/core necessary polyfills for IE11. I obtain the polyfills by try and error with browserstack.

## Partially Solves ticket/s
https://jira.scmspain.com/browse/PSP-3520

## Expected behavior
Work in IE11

## Review steps
Link in tcf/ui of adevinta-spain-components
Up the FC web-app in ssr mode, but patch the package.json script dev:staticsas follows:
```
"dev:statics": "CDN=/ NODE_ENV=production sui-bundler build -C --link-package=../adevinta-spain-components/components/tcf/ui"
```

## Memetized description
![por Dios](https://media.giphy.com/media/SP58bfyWGP1pC/giphy-downsized.gif)