### PR TITLE
fix multiple initializations

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "extends": "./node_modules/@s-ui/lint/stylelint.config.js"
   },
   "dependencies": {
-    "@iabtcf/core": "^1.0.1",
+    "@iabtcf/core": "1",
     "brusc": "1",
     "core-js": "3"
   }

--- a/src/main/domain/service/DomainEventBus.js
+++ b/src/main/domain/service/DomainEventBus.js
@@ -53,7 +53,7 @@ export class DomainEventBus {
         .then(() => {
           observer.observe({domainEvent: {eventName, payload}})
         })
-        .catch(error => console.log('Error' + error))
+        .catch(error => console.log('Error', error))
     })
   }
 }

--- a/src/main/infrastructure/bootstrap/TcfApiInitializer.js
+++ b/src/main/infrastructure/bootstrap/TcfApiInitializer.js
@@ -35,6 +35,9 @@ import {ObservableFactory} from '../../domain/service/ObservableFactory'
 
 class TcfApiInitializer {
   static init({language} = {}) {
+    if (typeof window !== 'undefined' && window.__tcfapi_boros) {
+      return window.__tcfapi_boros
+    }
     iocModule({
       module: IOC_MODULE,
       initializer: ({singleton}) => {
@@ -85,6 +88,9 @@ class TcfApiInitializer {
     borosTcf.ready()
 
     borosTcf.loadUserConsent({notify: true})
+    if (typeof window !== 'undefined') {
+      window.__tcfapi_boros = borosTcf
+    }
     return borosTcf
   }
 }

--- a/src/test/domain/service/DomainEventBusTest.js
+++ b/src/test/domain/service/DomainEventBusTest.js
@@ -15,11 +15,11 @@ describe('DomainEventBus Should', () => {
 
   describe('getNumberOfRegisteredEvents', () => {
     it('return zero for getNumberOfRegisteredEvents when is created', () => {
-      const domainEventBus = new DomainEventBus()
+      const domainEventBus = new DomainEventBus({observableFactory})
       expect(domainEventBus.getNumberOfRegisteredEvents).to.be.equal(0)
     })
     it('return two for getNumberOfRegisteredEvents when two different events are registered', () => {
-      const domainEventBus = new DomainEventBus()
+      const domainEventBus = new DomainEventBus({observableFactory})
 
       domainEventBus.register({
         eventName: firstEventName,
@@ -32,7 +32,7 @@ describe('DomainEventBus Should', () => {
       expect(domainEventBus.getNumberOfRegisteredEvents).to.be.equal(2)
     })
     it('return one for getNumberOfRegisteredEvents when the same  event is  registered twice', () => {
-      const domainEventBus = new DomainEventBus()
+      const domainEventBus = new DomainEventBus({observableFactory})
 
       domainEventBus.register({
         eventName: firstEventName,
@@ -47,7 +47,7 @@ describe('DomainEventBus Should', () => {
   })
   describe('getNumberOfObserversRegisteredForAnEvent and register', () => {
     it('return zero for getNumberOfObserversRegisteredForAnEvent when is created', () => {
-      const domainEventBus = new DomainEventBus()
+      const domainEventBus = new DomainEventBus({observableFactory})
       expect(
         domainEventBus.getNumberOfObserversRegisteredForAnEvent({
           eventName: firstEventName
@@ -55,7 +55,7 @@ describe('DomainEventBus Should', () => {
       ).to.be.equal(0)
     })
     it('return one for each event  when two different events are registered', () => {
-      const domainEventBus = new DomainEventBus()
+      const domainEventBus = new DomainEventBus({observableFactory})
 
       domainEventBus.register({
         eventName: firstEventName,
@@ -77,7 +77,7 @@ describe('DomainEventBus Should', () => {
       ).to.be.equal(1)
     })
     it('return two for an event  when two different observers are registered to the same event', () => {
-      const domainEventBus = new DomainEventBus()
+      const domainEventBus = new DomainEventBus({observableFactory})
 
       domainEventBus.register({
         eventName: firstEventName,
@@ -96,13 +96,13 @@ describe('DomainEventBus Should', () => {
   })
   describe('raise', () => {
     it('when we rise an event without observers, should not crash ', done => {
-      const domainEventBus = new DomainEventBus()
+      const domainEventBus = new DomainEventBus({observableFactory})
       Promise.resolve()
         .then(() => domainEventBus.raise({eventName: 'unexistingEvent'}))
         .then(() => done())
     })
     it('call all observers once when raise is called', () => {
-      const domainEventBus = new DomainEventBus()
+      const domainEventBus = new DomainEventBus({observableFactory})
       const spyFirstObserver = sinon.spy(firstObserver)
       const spySecondObserver = sinon.spy(secondObserver)
       domainEventBus.register({
@@ -121,7 +121,7 @@ describe('DomainEventBus Should', () => {
       })
     })
     it('call only the observers for the specific event when raise is called', done => {
-      const domainEventBus = new DomainEventBus()
+      const domainEventBus = new DomainEventBus({observableFactory})
       const spyFirstObserver = sinon.spy(firstObserver)
       const spySecondObserver = sinon.spy(secondObserver)
       domainEventBus.register({
@@ -150,12 +150,12 @@ describe('DomainEventBus Should', () => {
           })
       })
     })
-    it('if first observer throw an exception, second observer shOold be called when raise is called', () => {
+    it('if first observer throw an exception, second observer should be called when raise is called', () => {
       const firstObseverThrowException = () => {
         throw new Error('Error')
       }
 
-      const domainEventBus = new DomainEventBus()
+      const domainEventBus = new DomainEventBus({observableFactory})
       const spyFirstObserver = sinon.spy(firstObseverThrowException)
       const spySecondObserver = sinon.spy(secondObserver)
       domainEventBus.register({
@@ -176,7 +176,7 @@ describe('DomainEventBus Should', () => {
   })
   describe('getNumberOfRegisteredEvents and unregister', () => {
     it('after unregister getNumberOfRegisteredEvents should decrease', () => {
-      const domainEventBus = new DomainEventBus()
+      const domainEventBus = new DomainEventBus({observableFactory})
       const reference = domainEventBus.register({
         eventName: firstEventName,
         observer: firstObserver
@@ -188,7 +188,7 @@ describe('DomainEventBus Should', () => {
       expect(domainEventBus.getNumberOfRegisteredEvents).to.be.equal(0)
     })
     it('after unregister an event that has not been registered should  not crash', () => {
-      const domainEventBus = new DomainEventBus()
+      const domainEventBus = new DomainEventBus({observableFactory})
       domainEventBus.unregister({
         eventName: firstEventName,
         reference: null
@@ -198,7 +198,7 @@ describe('DomainEventBus Should', () => {
   })
   describe('getNumberOfObserversRegisteredForAnEvent and unregister', done => {
     it('after unregister getNumberOfObserversRegisteredForAnEvent should decrease', () => {
-      const domainEventBus = new DomainEventBus()
+      const domainEventBus = new DomainEventBus({observableFactory})
       const reference = domainEventBus.register({
         eventName: firstEventName,
         observer: firstObserver
@@ -222,7 +222,7 @@ describe('DomainEventBus Should', () => {
     it('call all observer except the unregistered one', done => {
       const spyFirstObserver = sinon.spy(firstObserver)
       const spySecondObserver = sinon.spy(secondObserver)
-      const domainEventBus = new DomainEventBus()
+      const domainEventBus = new DomainEventBus({observableFactory})
       const reference = domainEventBus.register({
         eventName: firstEventName,
         observer: spyFirstObserver
@@ -251,14 +251,14 @@ describe('DomainEventBus Should', () => {
   })
   describe('unregister', () => {
     it('when unregister and un existent event return false', () => {
-      const domainEventBus = new DomainEventBus()
+      const domainEventBus = new DomainEventBus({observableFactory})
       const success = domainEventBus.unregister({
         eventName: 'unexitingEvent'
       })
       expect(success).to.be.false
     })
     it('when unregister and an event that exists but reference is not found, then return false', () => {
-      const domainEventBus = new DomainEventBus()
+      const domainEventBus = new DomainEventBus({observableFactory})
       domainEventBus.register({
         eventName: firstEventName,
         observer: firstObserver
@@ -270,7 +270,7 @@ describe('DomainEventBus Should', () => {
       expect(success).to.be.false
     })
     it('when unregister and an event that  exists and reference is  found, then return true', () => {
-      const domainEventBus = new DomainEventBus()
+      const domainEventBus = new DomainEventBus({observableFactory})
       const reference = domainEventBus.register({
         eventName: firstEventName,
         observer: firstObserver
@@ -285,7 +285,7 @@ describe('DomainEventBus Should', () => {
   describe('register', () => {
     it('Should fail if observer is not a function', done => {
       try {
-        const domainEventBus = new DomainEventBus()
+        const domainEventBus = new DomainEventBus({observableFactory})
         domainEventBus.register({eventName: 'givenEvent', observer: {}})
         done(new Error('Should fail'))
       } catch (error) {

--- a/src/test/tcfv2/AddEventListenerCommandTest.js
+++ b/src/test/tcfv2/AddEventListenerCommandTest.js
@@ -24,9 +24,12 @@ describe('AddEventListenerCommand Should', () => {
       window.document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT'
     }
   }
-  beforeEach(function() {
+
+  beforeEach(() => {
+    window.__tcfapi_boros = undefined
     deleteAllCookies()
   })
+
   describe('General AddEventListenerCommand Scenarios', () => {
     it('when we create an event listener, then listener callback should be immediately called', done => {
       TestableTcfApiInitializer.create().init()

--- a/src/test/tcfv2/PingCommandTest.js
+++ b/src/test/tcfv2/PingCommandTest.js
@@ -7,6 +7,11 @@ import {TestableCookieStorageMock} from '../testable/infrastructure/repository/T
 describe('ping', () => {
   const command = 'ping'
   const version = 2
+
+  beforeEach(() => {
+    window.__tcfapi_boros = undefined
+  })
+
   it('should return a PingReturn object according to specs', done => {
     TestableTcfApiInitializer.create().init()
     window.__tcfapi(command, version, (pingReturn, success) => {


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

When integrated in Rect pages that cause re-renders of the component that is including BorosTcf, it's being initialized N times causing it to not work for TCData event listeners, because some listeners have been registered to an event bus that has been replaced for a new one in a further initializations.
To not deal with integrators about it, at least as a first hotfix approximation, we'll save the first initialized instance of BorosTcf at `window.__tcfapi__boros` and any further initialization will receive that instance instead of creating new instances for all.

We need this because as `window.__tcfapi` function must be treated as a singleton, and the first BorosTcf instance is connected to it, any next BorosTcf instantiation has no sense to exist.

The bug detected (with hardcoded log lines to detect the problem) can be visualized here:
<img width="1455" alt="Captura de pantalla 2020-10-07 a las 19 03 10" src="https://user-images.githubusercontent.com/20399660/95365826-ebf83a00-08d2-11eb-916e-10d4c1f910fd.png">

As seen in the image, the DomainEventBus is being initialized N times, so using the `window.__tcfapi('addEventListener', ...)` command has an unexpected behavior as when an user saves the consent, the `useractioncomplete` event is raised to another different event bus which has no registered event listeners and so, will never dispatch the `useractioncomplete` with a `TCData` to the `addEventListener` caller.

## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3607

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/V0IdVIIW1y5d6/giphy.gif)