### PR TITLE
Feature/add decoded cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,23 +9,25 @@
 
 ## Table of Contents
 
-* [About](#about)
-* [Features](#features)
-* [Technical features](#technical-features)
-* [Configuration](#configuration)
-* [Usage](#usage)
-* [License](#license)
-
+- [About](#about)
+- [Features](#features)
+- [License](#license)
 
 ## About
+
+**Boros TCF** is a stand alone Consent Management Provider solution compliant with the "Transparency & Consent Framework version 2.0" standard established by the [IAB Europe](https://iabeurope.eu/tcf-2-0/).
 
 ## Features
 
 * Initialization with Stub, [see details here](https://github.com/scm-spain/boros-tcf-stub)
- 
-## Technical features
+* Extra cookie storage
 
-## Usage
+  A cookie named "borosTcf" is stored with the user consents stringified data.
+  The structure of that cookie is:
+  ```
+  {policyVersion: 2, cmpVersion: 12, purpose: {consents: {1: true, 2: true, 3: false, ....}}, specialFeatureOptions: {1: true}}
+  ```
 
 ## License
+
 Boros TCF is [MIT licensed](./LICENSE).

--- a/src/main/application/services/vendorconsent/SaveUserConsentUseCase.js
+++ b/src/main/application/services/vendorconsent/SaveUserConsentUseCase.js
@@ -28,7 +28,10 @@ class SaveUserConsentUseCase {
     const consent = await this._consentEncoderService.encode({
       consent: incomingConsent
     })
-    this._consentRepository.saveUserConsent({consent})
+    this._consentRepository.saveUserConsent({
+      encodedConsent: consent,
+      decodedConsent: incomingConsent
+    })
   }
 }
 

--- a/src/main/core/constants.js
+++ b/src/main/core/constants.js
@@ -48,3 +48,28 @@ export const VENDOR_LIST_ENDPOINT =
  * in which the publisher's business entity is established.
  */
 export const PUBLISHER_CC = 'ES'
+
+/**
+ * Encoded consent cookie name
+ */
+export const VENDOR_CONSENT_COOKIE_NAME = 'euconsent-v2'
+
+/**
+ * Decoded consent cookie name
+ */
+export const BOROS_CONSENT_COOKIE_NAME = 'borosTcf'
+
+/**
+ * Cookies max age
+ */
+export const VENDOR_CONSENT_COOKIE_MAX_AGE = 33696000
+
+/**
+ * Cookies default path
+ */
+export const VENDOR_CONSENT_COOKIE_DEFAULT_PATH = '/'
+
+/**
+ * Cookies same site local value
+ */
+export const VENDOR_CONSENT_COOKIE_SAME_SITE_LOCAL_VALUE = 'Lax'

--- a/src/main/domain/consent/Consent.js
+++ b/src/main/domain/consent/Consent.js
@@ -83,6 +83,14 @@ export class Consent {
     return this._valid
   }
 
+  get cmpVersion() {
+    return this._cmpVersion
+  }
+
+  get policyVersion() {
+    return this._policyVersion
+  }
+
   toJSON() {
     return {
       cmpId: this._cmpId,

--- a/src/main/domain/consent/ConsentRepository.js
+++ b/src/main/domain/consent/ConsentRepository.js
@@ -3,7 +3,7 @@
  */
 class ConsentRepository {
   loadUserConsent() {}
-  saveUserConsent({consent}) {}
+  saveUserConsent({encodedConsent, decodedConsent}) {}
 }
 
 export {ConsentRepository}

--- a/src/main/domain/consent/LoadConsentService.js
+++ b/src/main/domain/consent/LoadConsentService.js
@@ -71,7 +71,8 @@ export class LoadConsentService {
       consent: savedConsent
     })
     this._consentRepository.saveUserConsent({
-      consent: encodedConsent
+      encodedConsent: encodedConsent,
+      decodedConsent: savedConsent
     })
     const renewedEncodedConsent = this._consentRepository.loadUserConsent()
     const consent = this._consentDecoderService.decode({

--- a/src/main/infrastructure/bootstrap/TcfApiInitializer.js
+++ b/src/main/infrastructure/bootstrap/TcfApiInitializer.js
@@ -32,11 +32,10 @@ import {InMemoryStatusRepository} from '../../infrastructure/status/InMemoryStat
 import {TcfApiV2} from '../../application/TcfApiV2'
 import {ObservableFactory} from '../../domain/service/ObservableFactory'
 
-const VENDOR_CONSENT_COOKIE_NAME = 'euconsent-v2'
-const BOROS_CONSENT_COOKIE_NAME = 'borosTcf'
-const VENDOR_CONSENT_COOKIE_MAX_AGE = 33696000
-const VENDOR_CONSENT_COOKIE_DEFAULT_PATH = '/'
-const VENDOR_CONSENT_COOKIE_SAME_SITE_LOCAL_VALUE = 'Lax'
+import {
+  VENDOR_CONSENT_COOKIE_NAME,
+  BOROS_CONSENT_COOKIE_NAME
+} from '../../core/constants'
 
 class TcfApiInitializer {
   static init({language} = {}) {
@@ -74,10 +73,7 @@ class TcfApiInitializer {
             new BrowserCookieStorage({
               domain: window.location.hostname,
               window,
-              cookieName: VENDOR_CONSENT_COOKIE_NAME,
-              cookieDefaultPath: VENDOR_CONSENT_COOKIE_DEFAULT_PATH,
-              CookieMaxAge: VENDOR_CONSENT_COOKIE_MAX_AGE,
-              CookieSameSiteVlue: VENDOR_CONSENT_COOKIE_SAME_SITE_LOCAL_VALUE
+              cookieName: VENDOR_CONSENT_COOKIE_NAME
             })
         )
         singleton(
@@ -86,10 +82,7 @@ class TcfApiInitializer {
             new BrowserCookieStorage({
               domain: window.location.hostname,
               window,
-              cookieName: BOROS_CONSENT_COOKIE_NAME,
-              cookieDefaultPath: VENDOR_CONSENT_COOKIE_DEFAULT_PATH,
-              CookieMaxAge: VENDOR_CONSENT_COOKIE_MAX_AGE,
-              CookieSameSiteVlue: VENDOR_CONSENT_COOKIE_SAME_SITE_LOCAL_VALUE
+              cookieName: BOROS_CONSENT_COOKIE_NAME
             })
         )
         singleton(ConsentEncoderService, () => new IABConsentEncoderService())

--- a/src/main/infrastructure/bootstrap/TcfApiInitializer.js
+++ b/src/main/infrastructure/bootstrap/TcfApiInitializer.js
@@ -10,7 +10,6 @@ import {BorosTcf} from '../../application/BorosTcf'
 import {VendorListRepository} from '../../domain/vendorlist/VendorListRepository'
 import {ConsentRepository} from '../../domain/consent/ConsentRepository'
 import {CookieConsentRepository} from '../repository/CookieConsentRepository'
-import {CookieStorage} from '../repository/cookie/CookieStorage'
 import {BrowserCookieStorage} from '../repository/cookie/BrowserCookieStorage'
 import {ConsentEncoderService} from '../../domain/consent/ConsentEncoderService'
 import {IABConsentEncoderService} from '../service/IABConsentEncoderService'
@@ -32,6 +31,12 @@ import {InMemoryStatusRepository} from '../../infrastructure/status/InMemoryStat
 
 import {TcfApiV2} from '../../application/TcfApiV2'
 import {ObservableFactory} from '../../domain/service/ObservableFactory'
+
+const VENDOR_CONSENT_COOKIE_NAME = 'euconsent-v2'
+const BOROS_CONSENT_COOKIE_NAME = 'borosTcf'
+const VENDOR_CONSENT_COOKIE_MAX_AGE = 33696000
+const VENDOR_CONSENT_COOKIE_DEFAULT_PATH = '/'
+const VENDOR_CONSENT_COOKIE_SAME_SITE_LOCAL_VALUE = 'Lax'
 
 class TcfApiInitializer {
   static init({language} = {}) {
@@ -64,9 +69,28 @@ class TcfApiInitializer {
 
         singleton(ConsentRepository, () => new CookieConsentRepository())
         singleton(
-          CookieStorage,
+          'euconsentCookieStorage',
           () =>
-            new BrowserCookieStorage({domain: window.location.hostname, window})
+            new BrowserCookieStorage({
+              domain: window.location.hostname,
+              window,
+              cookieName: VENDOR_CONSENT_COOKIE_NAME,
+              cookieDefaultPath: VENDOR_CONSENT_COOKIE_DEFAULT_PATH,
+              CookieMaxAge: VENDOR_CONSENT_COOKIE_MAX_AGE,
+              CookieSameSiteVlue: VENDOR_CONSENT_COOKIE_SAME_SITE_LOCAL_VALUE
+            })
+        )
+        singleton(
+          'borosTcfCookieStorage',
+          () =>
+            new BrowserCookieStorage({
+              domain: window.location.hostname,
+              window,
+              cookieName: BOROS_CONSENT_COOKIE_NAME,
+              cookieDefaultPath: VENDOR_CONSENT_COOKIE_DEFAULT_PATH,
+              CookieMaxAge: VENDOR_CONSENT_COOKIE_MAX_AGE,
+              CookieSameSiteVlue: VENDOR_CONSENT_COOKIE_SAME_SITE_LOCAL_VALUE
+            })
         )
         singleton(ConsentEncoderService, () => new IABConsentEncoderService())
         singleton(ConsentDecoderService, () => new IABConsentDecoderService())

--- a/src/main/infrastructure/repository/CookieConsentRepository.js
+++ b/src/main/infrastructure/repository/CookieConsentRepository.js
@@ -1,19 +1,23 @@
 import {ConsentRepository} from '../../domain/consent/ConsentRepository'
 import {inject} from '../../core/ioc/ioc'
-import {CookieStorage} from './cookie/CookieStorage'
 
 class CookieConsentRepository extends ConsentRepository {
-  constructor(cookieStorage = inject(CookieStorage)) {
+  constructor(
+    euconsentCookieStorage = inject('euconsentCookieStorage'),
+    borosTcfCookieStorage = inject('borosTcfCookieStorage')
+  ) {
     super()
-    this._cookieStorage = cookieStorage
+    this._euconsentCookieStorage = euconsentCookieStorage
+    this._borosTcfCookieStorage = borosTcfCookieStorage
   }
 
   loadUserConsent() {
-    return this._cookieStorage.load() || ''
+    return this._euconsentCookieStorage.load() || ''
   }
 
-  saveUserConsent({consent}) {
-    this._cookieStorage.save({data: consent})
+  saveUserConsent({encodedConsent, decodedConsent}) {
+    this._euconsentCookieStorage.save({data: encodedConsent})
+    this._borosTcfCookieStorage.save({data: decodedConsent})
   }
 }
 

--- a/src/main/infrastructure/repository/cookie/BrowserCookieStorage.js
+++ b/src/main/infrastructure/repository/cookie/BrowserCookieStorage.js
@@ -1,19 +1,15 @@
 import {CookieStorage} from './CookieStorage'
+import {
+  VENDOR_CONSENT_COOKIE_DEFAULT_PATH,
+  VENDOR_CONSENT_COOKIE_MAX_AGE,
+  VENDOR_CONSENT_COOKIE_SAME_SITE_LOCAL_VALUE
+} from '../../../core/constants'
 
 export class BrowserCookieStorage extends CookieStorage {
-  constructor({
-    window,
-    cookieName,
-    cookieDefaultPath,
-    CookieMaxAge,
-    CookieSameSiteVlue
-  }) {
+  constructor({window, cookieName}) {
     super()
     this._window = window
     this._cookieName = cookieName
-    this._cookieDefaultPath = cookieDefaultPath
-    this._CookieMaxAge = CookieMaxAge
-    this._CookieSameSiteVlue = CookieSameSiteVlue
   }
 
   load() {
@@ -30,9 +26,9 @@ export class BrowserCookieStorage extends CookieStorage {
     const cookieValue = [
       `${this._cookieName}=${data}`,
       `domain=${domain}`,
-      `path=${this._cookieDefaultPath}`,
-      `max-age=${this._CookieMaxAge}`,
-      `SameSite=${this._CookieSameSiteVlue}`
+      `path=${VENDOR_CONSENT_COOKIE_DEFAULT_PATH}`,
+      `max-age=${VENDOR_CONSENT_COOKIE_MAX_AGE}`,
+      `SameSite=${VENDOR_CONSENT_COOKIE_SAME_SITE_LOCAL_VALUE}`
     ].join(';')
     this._window.document.cookie = cookieValue
   }
@@ -46,7 +42,7 @@ export class BrowserCookieStorage extends CookieStorage {
     const host = this._window.location.hostname || ''
     const cookieParts = [
       `${this._cookieName}=`,
-      `path=${this._cookieDefaultPath}`,
+      `path=${VENDOR_CONSENT_COOKIE_DEFAULT_PATH}`,
       `domain=${host}`,
       `expires= Thu, 01 Jan 1970 00:00:00 GMT`
     ]

--- a/src/main/infrastructure/repository/cookie/BrowserCookieStorage.js
+++ b/src/main/infrastructure/repository/cookie/BrowserCookieStorage.js
@@ -77,13 +77,13 @@ export class BrowserCookieStorage extends CookieStorage {
 
   _parseData({data}) {
     const {
-      tcfPolicyVersion,
+      policyVersion,
       cmpVersion,
       purpose: {consents},
       specialFeatureOptions
     } = data
     const usedData = {
-      tcfPolicyVersion,
+      policyVersion,
       cmpVersion,
       purpose: {consents},
       specialFeatureOptions

--- a/src/test/application/BorosTcfTest.js
+++ b/src/test/application/BorosTcfTest.js
@@ -9,7 +9,6 @@ import {
   VendorListValueSpanish
 } from '../fixtures/vendorlist/VendorListValue'
 import {TestableCookieStorageMock} from '../testable/infrastructure/repository/TestableCookieStorageMock'
-import {CookieStorage} from '../../main/infrastructure/repository/cookie/CookieStorage'
 import {
   BOROS_TCF_ID,
   BOROS_TCF_VERSION,
@@ -110,7 +109,7 @@ describe('BorosTcf', () => {
         cookie45WithoutVendorsConsentsAndIsValid
       )
       const borosTcf = TestableTcfApiInitializer.create()
-        .mock(CookieStorage, cookieStorageMock)
+        .mock('euconsentCookieStorage', cookieStorageMock)
         .mock(GVLFactory, mockGVLFactory)
         .init()
 
@@ -155,7 +154,7 @@ describe('BorosTcf', () => {
       })
 
       const borosTcfVersion = TestableTcfApiInitializer.create()
-        .mock(CookieStorage, cookieStorageMock)
+        .mock('euconsentCookieStorage', cookieStorageMock)
         .mock(GVLFactory, mockGVLFactory)
         .init()
 
@@ -202,7 +201,7 @@ describe('BorosTcf', () => {
 
       const cookieStorageMock = new TestableCookieStorageMock()
       const borosTcf = TestableTcfApiInitializer.create()
-        .mock(CookieStorage, cookieStorageMock)
+        .mock('euconsentCookieStorage', cookieStorageMock)
         .init()
 
       return borosTcf
@@ -267,7 +266,7 @@ describe('BorosTcf', () => {
 
     it('should load the saved user consent', () => {
       const borosTcf = TestableTcfApiInitializer.create()
-        .mock(CookieStorage, new TestableCookieStorageMock())
+        .mock('euconsentCookieStorage', new TestableCookieStorageMock())
         .init()
       return borosTcf
         .saveUserConsent({purpose: givenPurpose, vendor: givenVendor})
@@ -314,7 +313,7 @@ describe('BorosTcf', () => {
       }
 
       const borosTcfMocked = TestableTcfApiInitializer.create()
-        .mock(CookieStorage, new TestableCookieStorageMock())
+        .mock('euconsentCookieStorage', new TestableCookieStorageMock())
         .mock(VendorListRepository, vendorListRepositoryMock)
         .init()
 
@@ -360,7 +359,7 @@ describe('BorosTcf', () => {
       }
 
       const borosTcf = TestableTcfApiInitializer.create()
-        .mock(CookieStorage, new TestableCookieStorageMock())
+        .mock('euconsentCookieStorage', new TestableCookieStorageMock())
         .mock(VendorListRepository, vendorListRepository)
         .init()
 
@@ -400,7 +399,7 @@ describe('BorosTcf', () => {
       }
 
       const borosTcf = TestableTcfApiInitializer.create()
-        .mock(CookieStorage, new TestableCookieStorageMock())
+        .mock('euconsentCookieStorage', new TestableCookieStorageMock())
         .mock(VendorListRepository, vendorListRepository)
         .init()
 
@@ -443,7 +442,7 @@ describe('BorosTcf', () => {
         data: cookieVersion36
       })
       const borosTcf = TestableTcfApiInitializer.create()
-        .mock(CookieStorage, cookieStorageMock)
+        .mock('euconsentCookieStorage', cookieStorageMock)
         .mock(GVLFactory, mockGVLFactory)
         .mock(VendorListRepository, vendorListRepository)
         .init()
@@ -471,7 +470,7 @@ describe('BorosTcf', () => {
           'CO1wTaiO1wTaiCBADAENAkCAAAAAAAAAAAAAABEAAiAA.IF7NX2T5OI2vjq2ZdF7BEaYwfZxyigMgShhQIsS8NwIeFbBoGP2AgHBG4JCQAGBAkkACBAQIsHGBcCQABgIgRiRCMQEmMjzNKBJJAggkbM0FACDVmnsHS3ZCY70--u__bMAA'
       })
       const borosTcf = TestableTcfApiInitializer.create()
-        .mock(CookieStorage, cookieStorageMock)
+        .mock('euconsentCookieStorage', cookieStorageMock)
         .mock(VendorListRepository, vendorListRepository)
         .init()
 
@@ -507,7 +506,7 @@ describe('BorosTcf', () => {
         data: VendorList45.data
       })
       const borosTcf = TestableTcfApiInitializer.create()
-        .mock(CookieStorage, cookieStorageMock)
+        .mock('euconsentCookieStorage', cookieStorageMock)
         .mock(GVLFactory, mockGVLFactory)
         .init()
 
@@ -523,7 +522,7 @@ describe('BorosTcf', () => {
         }
       }
       const borosTcf = TestableTcfApiInitializer.create()
-        .mock(CookieStorage, throwableCookieStorage)
+        .mock('euconsentCookieStorage', throwableCookieStorage)
         .init()
 
       const consent = await borosTcf.loadUserConsent()

--- a/src/test/infrastructure/repository/cookie/BrowserCookieStorageTest.js
+++ b/src/test/infrastructure/repository/cookie/BrowserCookieStorageTest.js
@@ -93,7 +93,7 @@ describe('BrowserCookieStorage Should', () => {
       window
     })
     const givenData = {
-      tcfPolicyVersion: 2,
+      policyVersion: 2,
       cmpVersion: 12,
       purpose: {consents: {1: true, 2: true, 3: false}},
       specialFeatureOptions: {1: true}
@@ -121,14 +121,14 @@ describe('BrowserCookieStorage Should', () => {
     }
     const givenSpecialFeatureOptions = {1: true}
     const givenData = {
-      tcfPolicyVersion: givenTcfPolicyVersion,
+      policyVersion: givenTcfPolicyVersion,
       cmpVersion: givenCmpVersion,
       vendors: givenVendors,
       purpose: givenPurposes,
       specialFeatureOptions: givenSpecialFeatureOptions
     }
     const expectedCookieData = JSON.stringify({
-      tcfPolicyVersion: givenTcfPolicyVersion,
+      policyVersion: givenTcfPolicyVersion,
       cmpVersion: givenCmpVersion,
       purpose: {consents: givenPurposes.consents},
       specialFeatureOptions: givenSpecialFeatureOptions

--- a/src/test/infrastructure/repository/cookie/BrowserCookieStorageTest.js
+++ b/src/test/infrastructure/repository/cookie/BrowserCookieStorageTest.js
@@ -7,10 +7,7 @@ describe('BrowserCookieStorage Should', () => {
     new BrowserCookieStorage({
       domain: window.location.hostname,
       window,
-      cookieName,
-      cookieDefaultPath: '/',
-      CookieMaxAge: 33696000,
-      CookieSameSiteVlue: 'Lax'
+      cookieName
     })
 
   it('Write And read a cookie', () => {

--- a/src/test/infrastructure/repository/cookie/BrowserCookieStorageTest.js
+++ b/src/test/infrastructure/repository/cookie/BrowserCookieStorageTest.js
@@ -3,11 +3,22 @@ import {expect} from 'chai'
 import jsdom, {JSDOM} from 'jsdom'
 
 describe('BrowserCookieStorage Should', () => {
+  const buildCookieStorage = ({cookieName, window}) =>
+    new BrowserCookieStorage({
+      domain: window.location.hostname,
+      window,
+      cookieName,
+      cookieDefaultPath: '/',
+      CookieMaxAge: 33696000,
+      CookieSameSiteVlue: 'Lax'
+    })
+
   it('Write And read a cookie', () => {
     const window = new JSDOM('<!DOCTYPE html><body></body>', {
       url: 'http://example.com/'
     }).window
-    const browserCookieStorage = new BrowserCookieStorage({
+    const browserCookieStorage = buildCookieStorage({
+      cookieName: 'euconsent-v2',
       window
     })
 
@@ -19,7 +30,8 @@ describe('BrowserCookieStorage Should', () => {
     const window = new JSDOM('<!DOCTYPE html><body></body>', {
       url: 'http://example.com/'
     }).window
-    const browserCookieStorage = new BrowserCookieStorage({
+    const browserCookieStorage = buildCookieStorage({
+      cookieName: 'euconsent-v2',
       window
     })
 
@@ -32,15 +44,18 @@ describe('BrowserCookieStorage Should', () => {
     const dom1 = new JSDOM('<!DOCTYPE html><body></body>', {
       url: 'http://example1.com/'
     })
-    const browserCookieStorage1 = new BrowserCookieStorage({
+    const browserCookieStorage1 = buildCookieStorage({
+      cookieName: 'euconsent-v2',
       window: dom1.window
     })
     const dom2 = new JSDOM('<!DOCTYPE html><body></body>', {
       url: 'http://example2.com/'
     })
-    const browserCookieStorage2 = new BrowserCookieStorage({
+    const browserCookieStorage2 = buildCookieStorage({
+      cookieName: 'euconsent-v2',
       window: dom2.window
     })
+
     browserCookieStorage1.save({data: givenCookie})
     const cookie1 = browserCookieStorage1.load()
     const cookie2 = browserCookieStorage2.load()
@@ -55,16 +70,72 @@ describe('BrowserCookieStorage Should', () => {
       url: `http://www.${givenHost}/`,
       cookieJar
     })
-    const browserCookieStorage1 = new BrowserCookieStorage({
+    const browserCookieStorage1 = buildCookieStorage({
+      cookieName: 'euconsent-v2',
       window: dom.window
     })
     browserCookieStorage1.save({data: givenCookie})
     dom.reconfigure({url: `http://asubdomainof.${givenHost}/`})
-    const browserCookieStorage2 = new BrowserCookieStorage({
+    const browserCookieStorage2 = buildCookieStorage({
+      cookieName: 'euconsent-v2',
       window: dom.window
     })
     const cookie2 = browserCookieStorage2.load()
     expect(cookie2).to.equal(givenCookie)
     expect(cookieJar.getCookiesSync(`http://${givenHost}/`)).to.have.lengthOf(1)
+  })
+  it('Write and read a cookie with object as a data', () => {
+    const window = new JSDOM('<!DOCTYPE html><body></body>', {
+      url: 'http://example.com/'
+    }).window
+    const browserCookieStorage = buildCookieStorage({
+      cookieName: 'borosTcf',
+      window
+    })
+    const givenData = {
+      tcfPolicyVersion: 2,
+      cmpVersion: 12,
+      purpose: {consents: {1: true, 2: true, 3: false}},
+      specialFeatureOptions: {1: true}
+    }
+    const expectedCookieData = JSON.stringify(givenData)
+
+    browserCookieStorage.save({data: givenData})
+    const cookie = browserCookieStorage.load()
+    expect(cookie).equal(expectedCookieData)
+  })
+  it('Write and read a cookie with correct parsed data', () => {
+    const window = new JSDOM('<!DOCTYPE html><body></body>', {
+      url: 'http://example.com/'
+    }).window
+    const browserCookieStorage = buildCookieStorage({
+      cookieName: 'borosTcf',
+      window
+    })
+    const givenTcfPolicyVersion = 2
+    const givenCmpVersion = 12
+    const givenVendors = {1: true, 2: true, 3: false}
+    const givenPurposes = {
+      consents: {1: true, 2: true, 3: false},
+      legitimateInterests: {1: true, 2: true, 3: false}
+    }
+    const givenSpecialFeatureOptions = {1: true}
+    const givenData = {
+      tcfPolicyVersion: givenTcfPolicyVersion,
+      cmpVersion: givenCmpVersion,
+      vendors: givenVendors,
+      purpose: givenPurposes,
+      specialFeatureOptions: givenSpecialFeatureOptions
+    }
+    const expectedCookieData = JSON.stringify({
+      tcfPolicyVersion: givenTcfPolicyVersion,
+      cmpVersion: givenCmpVersion,
+      purpose: {consents: givenPurposes.consents},
+      specialFeatureOptions: givenSpecialFeatureOptions
+    })
+
+    browserCookieStorage.save({data: givenData})
+    const cookie = browserCookieStorage.load()
+    expect(cookie).equal(expectedCookieData)
   })
 })

--- a/src/test/tcfv2/AddEventListenerCommandTest.js
+++ b/src/test/tcfv2/AddEventListenerCommandTest.js
@@ -8,7 +8,6 @@ import {CookieConsentRepository} from '../../main/infrastructure/repository/Cook
 import {Status} from '../../main/domain/status/Status'
 import {StatusRepository} from '../../main/domain/status/StatusRepository'
 import {VendorListRepository} from '../../main/domain/vendorlist/VendorListRepository'
-import {CookieStorage} from '../../main/infrastructure/repository/cookie/CookieStorage'
 
 describe('AddEventListenerCommand Should', () => {
   const command = 'addEventListener'
@@ -147,7 +146,7 @@ describe('AddEventListenerCommand Should', () => {
     })
     TestableTcfApiInitializer.create()
       .mock(VendorListRepository, vendorListRepository)
-      .mock(CookieStorage, cookieStorageMock)
+      .mock('euconsentCookieStorage', cookieStorageMock)
       .init()
     window.__tcfapi(command, version, callback)
 
@@ -217,7 +216,7 @@ describe('AddEventListenerCommand Should', () => {
       const cookieStorageMock = new TestableCookieStorageMock()
       const borosTcf = TestableTcfApiInitializer.create()
         .mock(VendorListRepository, vendorListRepository)
-        .mock(CookieStorage, cookieStorageMock)
+        .mock('euconsentCookieStorage', cookieStorageMock)
         .init()
       window.__tcfapi(command, version, callback)
       borosTcf

--- a/src/test/tcfv2/GetTCDataCommandTest.js
+++ b/src/test/tcfv2/GetTCDataCommandTest.js
@@ -1,7 +1,6 @@
 import jsdom from 'jsdom-global'
 import {expect} from 'chai'
 import {TestableTcfApiInitializer} from '../testable/infrastructure/bootstrap/TestableTcfApiInitializer'
-import {CookieStorage} from '../../main/infrastructure/repository/cookie/CookieStorage'
 import {TestableCookieStorageMock} from '../testable/infrastructure/repository/TestableCookieStorageMock'
 import {Status} from '../../main/domain/status/Status'
 import {StatusRepository} from '../../main/domain/status/StatusRepository'
@@ -31,7 +30,7 @@ describe('getTCData', () => {
       getStatus: () => statusMock
     }
     const borosTcf = TestableTcfApiInitializer.create()
-      .mock(CookieStorage, cookieStorageMock)
+      .mock('euconsentCookieStorage', cookieStorageMock)
       .mock(StatusRepository, statusRepositoryMock)
       .init()
 

--- a/src/test/tcfv2/PingCommandTest.js
+++ b/src/test/tcfv2/PingCommandTest.js
@@ -1,7 +1,6 @@
 import 'jsdom-global/register'
 import {expect} from 'chai'
 import {TestableTcfApiInitializer} from '../testable/infrastructure/bootstrap/TestableTcfApiInitializer'
-import {CookieStorage} from '../../main/infrastructure/repository/cookie/CookieStorage'
 import {TestableCookieStorageMock} from '../testable/infrastructure/repository/TestableCookieStorageMock'
 
 describe('ping', () => {
@@ -60,7 +59,7 @@ describe('ping', () => {
     const givenVersion = 2
     const cookieStorageMock = new TestableCookieStorageMock()
     const borosTcf = TestableTcfApiInitializer.create()
-      .mock(CookieStorage, cookieStorageMock)
+      .mock('euconsentCookieStorage', cookieStorageMock)
       .init()
     await borosTcf.saveUserConsent({purpose: givenPurpose, vendor: givenVendor})
     await borosTcf.getVendorList()
@@ -87,7 +86,7 @@ describe('ping', () => {
   it('should return undefined gvlVersion if there is no consent', async () => {
     const cookieStorageMock = new TestableCookieStorageMock()
     TestableTcfApiInitializer.create()
-      .mock(CookieStorage, cookieStorageMock)
+      .mock('euconsentCookieStorage', cookieStorageMock)
       .init()
 
     const {pingReturn} = await new Promise(resolve =>


### PR DESCRIPTION
## Description
Add a new cookie with the stringified value of the user consents.

## Solves ticket/s
https://jira.scmspain.com/browse/PSP-3611

## Expected behavior
Every time that the euconsent cookie is saved or updated another cookie, "borosTcf" will be saved with the stringified data of user consents.

## Review steps
Build this package and run some web server linking tcf-ui & tcf-services packages with boros-tcf locally installed. 
Check if the borosTcf cookie is correctly stored.
![image](https://user-images.githubusercontent.com/26205284/95838161-becbe180-0d41-11eb-8dae-e45785d0029c.png)

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/EKUvB9uFnm2Xe/giphy.gif)