### PR TITLE
Fix/base64 cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,44 @@
 * Initialization with Stub, [see details here](https://github.com/scm-spain/boros-tcf-stub)
 * Extra cookie storage
 
-  A cookie named "borosTcf" is stored with the user consents stringified data.
-  The structure of that cookie is:
+  A cookie named "borosTcf" is stored with the user consents stringified data, encoded in Base64.
+  
+  Sample `borosTcf` value: `eyJwb2xpY3lWZXJzaW9uIjoyLCJjbXBWZXJzaW9uIjoxLCJwdXJwb3NlIjp7ImNvbnNlbnRzIjp7IjEiOnRydWUsIjIiOnRydWUsIjMiOnRydWUsIjQiOnRydWUsIjUiOnRydWUsIjYiOnRydWUsIjciOnRydWUsIjgiOnRydWUsIjkiOnRydWUsIjEwIjp0cnVlfX0sInNwZWNpYWxGZWF0dXJlcyI6eyIxIjp0cnVlfX0=`
+  
+  The encoded data in this sample value, and the cookie encoded data structure is:
   ```
-  {policyVersion: 2, cmpVersion: 12, purpose: {consents: {1: true, 2: true, 3: false, ....}}, specialFeatureOptions: {1: true}}
+  {
+    "policyVersion": 2,
+    "cmpVersion": 1,
+    "purpose": {
+      "consents": {
+        "1": true,
+        "2": true,
+        "3": true,
+        "4": true,
+        "5": true,
+        "6": true,
+        "7": true,
+        "8": true,
+        "9": true,
+        "10": true
+      }
+    },
+    "specialFeatures": {
+      "1": true
+    }
+  }
+  ```
+  
+  To decode the cookie, p.ex.:
+  
+  ```
+  // Java
+  String decoded = new String(Base64.getDecoder().decode(cookieValue));
+  
+  // Node
+  const decoded = Buffer.from(cookieValue, 'base64').toString()
+  
   ```
 
 `npm i @adv-ui/boros-tcf`

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "extends": "./node_modules/@s-ui/lint/stylelint.config.js"
   },
   "dependencies": {
-    "@iabtcf/core": "1",
+    "@iabtcf/core": "1.0.1",
     "brusc": "1",
     "core-js": "3"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,3 @@
+import TcfApiInitializer from './main'
+
+export default TcfApiInitializer

--- a/src/main/core/constants.js
+++ b/src/main/core/constants.js
@@ -2,14 +2,18 @@
 /**
  * Package Name
  */
-export const PACKAGE_NAME = __PACKAGE_NAME__
+export const PACKAGE_NAME =
+  (typeof __PACKAGE_NAME__ !== 'undefined' && __PACKAGE_NAME__) || 'boros-tcf'
 
 /**
  * Boros TCF Version is the current version.
  * It'll be the minor version as once developed, the IAB's TCF defined API should not change,
  * so major versions are useless to define this information value required by the PingReturn object.
  */
-export const BOROS_TCF_VERSION = __PACKAGE_MINOR_VERSION__
+export const BOROS_TCF_VERSION =
+  (typeof __PACKAGE_MINOR_VERSION__ !== 'undefined' &&
+    __PACKAGE_MINOR_VERSION__) ||
+  1
 
 /**
  * Boros TCF IAB's registered ID

--- a/src/main/infrastructure/repository/CookieConsentRepository.js
+++ b/src/main/infrastructure/repository/CookieConsentRepository.js
@@ -17,7 +17,9 @@ class CookieConsentRepository extends ConsentRepository {
 
   saveUserConsent({encodedConsent, decodedConsent}) {
     this._euconsentCookieStorage.save({data: encodedConsent})
-    this._borosTcfCookieStorage.save({data: decodedConsent})
+    try {
+      this._borosTcfCookieStorage.save({data: decodedConsent})
+    } catch (ignored) {}
   }
 }
 

--- a/src/main/infrastructure/repository/cookie/BrowserCookieStorage.js
+++ b/src/main/infrastructure/repository/cookie/BrowserCookieStorage.js
@@ -76,15 +76,17 @@ export class BrowserCookieStorage extends CookieStorage {
       policyVersion,
       cmpVersion,
       purpose: {consents},
-      specialFeatureOptions
+      specialFeatures
     } = data
     const usedData = {
       policyVersion,
       cmpVersion,
       purpose: {consents},
-      specialFeatureOptions
+      specialFeatures
     }
-    return JSON.stringify(usedData)
+    const stringData = JSON.stringify(usedData)
+    const base64Data = this._window.btoa(stringData)
+    return base64Data
   }
 }
 

--- a/src/test/infrastructure/repository/cookie/BrowserCookieStorageTest.js
+++ b/src/test/infrastructure/repository/cookie/BrowserCookieStorageTest.js
@@ -93,13 +93,14 @@ describe('BrowserCookieStorage Should', () => {
       policyVersion: 2,
       cmpVersion: 12,
       purpose: {consents: {1: true, 2: true, 3: false}},
-      specialFeatureOptions: {1: true}
+      specialFeatures: {1: true}
     }
     const expectedCookieData = JSON.stringify(givenData)
 
     browserCookieStorage.save({data: givenData})
     const cookie = browserCookieStorage.load()
-    expect(cookie).equal(expectedCookieData)
+    const decodedCookie = Buffer.from(cookie, 'base64').toString()
+    expect(decodedCookie).equal(expectedCookieData)
   })
   it('Write and read a cookie with correct parsed data', () => {
     const window = new JSDOM('<!DOCTYPE html><body></body>', {
@@ -116,23 +117,24 @@ describe('BrowserCookieStorage Should', () => {
       consents: {1: true, 2: true, 3: false},
       legitimateInterests: {1: true, 2: true, 3: false}
     }
-    const givenSpecialFeatureOptions = {1: true}
+    const givenSpecialFeatures = {1: true}
     const givenData = {
       policyVersion: givenTcfPolicyVersion,
       cmpVersion: givenCmpVersion,
       vendors: givenVendors,
       purpose: givenPurposes,
-      specialFeatureOptions: givenSpecialFeatureOptions
+      specialFeatures: givenSpecialFeatures
     }
     const expectedCookieData = JSON.stringify({
       policyVersion: givenTcfPolicyVersion,
       cmpVersion: givenCmpVersion,
       purpose: {consents: givenPurposes.consents},
-      specialFeatureOptions: givenSpecialFeatureOptions
+      specialFeatures: givenSpecialFeatures
     })
 
     browserCookieStorage.save({data: givenData})
     const cookie = browserCookieStorage.load()
-    expect(cookie).equal(expectedCookieData)
+    const decodedCookie = Buffer.from(cookie, 'base64').toString()
+    expect(decodedCookie).equal(expectedCookieData)
   })
 })


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

This PR main objective is to:
- encode the `borosTcf` cookie value in Base64 because storing it as a stringified JSON makes it unusable to the servers, as according to [RFC cookie-spec](https://curl.haxx.se/rfc/cookie_spec.html) `This string is a sequence of characters excluding semi-colon, comma and white space. If there is a need to place such data in the name or value, some encoding method such as URL style %XX encoding is recommended, though no encoding is defined or required.`

There are 2 more changes:

- fix IAB's core dependency to `"@iabtcf/core": "1.0.1"`, because next versions changed the way to decode vendor consents and legitimate interests, as vendors in the GVL are defined to require consents or to request legitimate interest, never both, so actually `boros-tcf` tests will fail with upgraded dependency and also, our consent model's "valid" attribute would come to `false` when GVL vendors are compared to existing decoded cookie, so a tech-debt will be opened to upgrade the library with safety.

- created a `src/index.js` (not packaged for NPM) only for connecting local changes with the `--link-package` in the [Boros TCF UI component](https://github.com/SUI-Components/adevinta-spain-components/tree/master/components/tcf/ui) from Adevinta Components. 

## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3645

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

- `borosTcf` cookie is created/updated in sync with the `euconsent-v2` cookie, but now it's value is codified in Base64
![image](https://user-images.githubusercontent.com/20399660/97422647-65051300-190e-11eb-8356-d5b755b50553.png)

## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->

With the adevinta components demo: https://github.com/SUI-Components/adevinta-spain-components
`npm run dev tcf/ui -- --link-package=../boros-tcf`

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/3oKIPlCroSFHV8uoko/giphy.gif)