### PR TITLE
fix: check if callback is a function

### DIFF
--- a/src/main/application/TcfApiV2.js
+++ b/src/main/application/TcfApiV2.js
@@ -33,11 +33,13 @@ class TcfApiV2 {
   }
 
   getTCData(callback, vendorIds) {
-    callback(this._getTCDataUseCase.execute({vendorIds}), true)
+    typeof callback === 'function' &&
+      callback(this._getTCDataUseCase.execute({vendorIds}), true)
   }
 
   ping(callback) {
-    callback(this._pingUseCase.execute(), true)
+    typeof callback === 'function' &&
+      callback(this._pingUseCase.execute(), true)
   }
 
   addEventListener(callback) {
@@ -51,10 +53,13 @@ class TcfApiV2 {
   getVendorList(callback, vendorListVersion) {
     return this._getVendorListUseCase
       .execute({vendorListVersion})
-      .then(vendorList => callback(vendorList, true))
+      .then(
+        vendorList =>
+          typeof callback === 'function' && callback(vendorList, true)
+      )
       .catch(error => {
         console.log('Error obtaining the vendor list', error)
-        callback(null, false)
+        typeof callback === 'function' && callback(null, false)
       })
   }
 }

--- a/src/main/domain/service/EventStatusService.js
+++ b/src/main/domain/service/EventStatusService.js
@@ -72,7 +72,7 @@ export class EventStatusService {
     const tcData = this._getTCDataUseCase.execute()
     tcData.listenerId = reference
 
-    callback(tcData, true)
+    typeof callback === 'function' && callback(tcData, true)
   }
 
   removeEventListener({callback, listenerId}) {
@@ -80,7 +80,7 @@ export class EventStatusService {
       eventName: EVENT_STATUS,
       reference: listenerId
     })
-    callback(success)
+    typeof callback === 'function' && callback(success)
   }
 }
 

--- a/src/main/domain/service/EventStatusService.js
+++ b/src/main/domain/service/EventStatusService.js
@@ -65,7 +65,7 @@ export class EventStatusService {
         observer: callback
       })
     } catch (error) {
-      callback(null, false)
+      typeof callback === 'function' && callback(null, false)
       return
     }
 

--- a/src/main/infrastructure/controller/TcfApiController.js
+++ b/src/main/infrastructure/controller/TcfApiController.js
@@ -24,7 +24,7 @@ class TcfApiController {
 
   _reject(callback) {
     try {
-      callback(null, false)
+      typeof callback === 'function' && callback(null, false)
     } catch (ignored) {}
   }
 


### PR DESCRIPTION
## Description

Some implementers are using callback = false. This PR prevents undesired errors of 'callback is not a function'.

## Solves ticket/s
https://jira.scmspain.com/browse/PSP-3714

## Expected behavior
Do not throw an error if the callback is not provided.
