### PR TITLE
feat: update vendor endpoint to krakend Co-authored-by: Pablo Rey Sob…

### DIFF
--- a/src/main/core/constants.js
+++ b/src/main/core/constants.js
@@ -50,7 +50,7 @@ export const VENDOR_LIST_LATEST_VERSION = 'LATEST'
  * Base endpoint to get access to remote Vendor List resources
  */
 export const VENDOR_LIST_ENDPOINT =
-  'https://ms-adit--operations-gateway.spain.advgo.net/borostcf/v2/vendorlist'
+  'https://adit.spain.advgo.net/borostcf/v2/vendorlist'
 
 /**
  * Country code of the country that determines the legislation of

--- a/src/main/infrastructure/repository/iab/GVLFactory.js
+++ b/src/main/infrastructure/repository/iab/GVLFactory.js
@@ -36,8 +36,8 @@ export class GVLFactory {
   }
 
   _setStaticGVLParameters() {
-    GVL.languageFilename = `${VENDOR_LIST_LATEST_VERSION}?language=[LANG]`
-    GVL.latestFilename = `${VENDOR_LIST_LATEST_VERSION}?language=${this._language}`
-    GVL.versionedFilename = `[VERSION]?language=${this._language}`
+    GVL.languageFilename = `${VENDOR_LIST_LATEST_VERSION}/[LANG]`
+    GVL.latestFilename = `${VENDOR_LIST_LATEST_VERSION}/${this._language}`
+    GVL.versionedFilename = `[VERSION]/${this._language}`
   }
 }

--- a/src/test/testable/infrastructure/repository/iab/TestableGVLFactory.js
+++ b/src/test/testable/infrastructure/repository/iab/TestableGVLFactory.js
@@ -87,7 +87,7 @@ export class TestableGVLFactory extends GVLFactory {
 
   _nockKoResponse({version, language}) {
     nock('http://mock.borostcf.com/borostcf/v2/vendorlist')
-      .get(`/${version}?language=${language}`)
+      .get(`/${version}/${language}`)
       .replyWithError({
         message: 'Unavailable',
         code: 'WHATEVER_ERROR'
@@ -96,7 +96,7 @@ export class TestableGVLFactory extends GVLFactory {
 
   _nockOkResponse({version, language, vendorList}) {
     nock('http://mock.borostcf.com/borostcf/v2/vendorlist')
-      .get(`/${version}?language=${language}`)
+      .get(`/${version}/${language}`)
       .reply(200, vendorList, {
         'access-control-allow-origin': '*',
         'access-control-allow-credentials': 'true'


### PR DESCRIPTION
…ral <pabloreysobral@gmail.com>

Co-authored-by: Candy Montero <candymdeoleo@gmail.com>"

## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->
Changed endpoint from Zuul to KrakenD

## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->
https://jira.scmspain.com/browse/PSP-4608

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->
Should get VendorList from KrakenD instead of Zuul

## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->

- Revert back to commit https://github.com/SUI-Components/adevinta-spain-components/commit/177ef02c9037be52696399d099774049ebd6f706
- Changed npm version to 12.14.1
- Use npm run dev tcf/ui -- --link-package <whatever-root>/boros-tcf to link packages

Check Network on the browser to see if the url changed to 'https://adit.spain.advgo.net/borostcf/v2/vendorlist'

## Further considerations
<!--- If applies, add information of breaking changes, agreed deploy timings, ...  -->

This repository is now deprecated and won't be updated in the future. 

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/g96QRNjWUvdKw/giphy.gif)